### PR TITLE
Fixed return value of _token_set when given an empty string

### DIFF
--- a/fuzzywuzzy/fuzz.py
+++ b/fuzzywuzzy/fuzz.py
@@ -128,6 +128,8 @@ def _token_set(s1,  s2, partial=True):
     if s1 is None: raise TypeError("s1 is None")
     if s2 is None: raise TypeError("s2 is None")
 
+    if not (validate_string(s1) and validate_string(s2)): return 0
+
     # pull tokens
     tokens1 = set(REG_TOKEN.findall(s1))
     tokens2 = set(REG_TOKEN.findall(s2))


### PR DESCRIPTION
fuzz._token_set now calls utils.validate_string to check if an empty string has been passed as one of the args. If so, it will return 0. 
