### PR TITLE
Remove explicit check for lists

### DIFF
--- a/fuzzywuzzy/process.py
+++ b/fuzzywuzzy/process.py
@@ -52,8 +52,14 @@ def extract(query, choices, processor=None, scorer=None, limit=5):
                        use utils.full_process()
 
     """
-    if choices is None or len(choices) == 0:
+    if choices is None:
         return []
+
+    try:
+        if len(choices) == 0:
+            return []
+    except TypeError:
+        pass
 
     # default, turn whatever the choice is into a workable string
     if processor is None:


### PR DESCRIPTION
The logic in `process.extract()` should support any Python sequence/iterable. The explicit check for lists is unnecessary and limiting (for example, it forces conversion of generators and other iterable classes to lists). 

This is more in the spirit of Python duck-typing -- if an object can't be iterated, an error will be raised at runtime. I think this is more clear than the current behavior, which returns an empty list if `choices` isn't a list and doesn't explain why.
