### PR TITLE
In extarctBests() and extractOne() use '>=' instead of '>'

### DIFF
--- a/fuzzywuzzy/process.py
+++ b/fuzzywuzzy/process.py
@@ -104,7 +104,7 @@ def extractBests(query, choices, processor=None, scorer=None, score_cutoff=0, li
 
     best_list = extract(query, choices, processor, scorer, limit)
     if len(best_list) > 0:
-        return list(itertools.takewhile(lambda x: x[1] > score_cutoff, best_list))
+        return list(itertools.takewhile(lambda x: x[1] >= score_cutoff, best_list))
     else:
         return []
 
@@ -127,7 +127,7 @@ def extractOne(query, choices, processor=None, scorer=None, score_cutoff=0):
     best_list = extract(query, choices, processor, scorer, limit=1)
     if len(best_list) > 0:
         best = best_list[0]
-        if best[1] > score_cutoff:
+        if best[1] >= score_cutoff:
             return best
         else:
             return None

--- a/test_fuzzywuzzy.py
+++ b/test_fuzzywuzzy.py
@@ -379,6 +379,21 @@ class ProcessTest(unittest.TestCase):
         #best = process.extractOne(query, choices)
         #self.assertIsNotNone(best)
 
+    def testWithCutoff2(self):
+        choices = [
+            "new york mets vs chicago cubs",
+            "chicago cubs at new york mets",
+            "atlanta braves vs pittsbugh pirates",
+            "new york yankees vs boston red sox"
+        ]
+
+        query = "new york mets vs chicago cubs"
+        # Only find 100-score cases
+        res = process.extractOne(query, choices, score_cutoff=100)
+        self.assertTrue(res is not None)
+        best_match, score = res
+        self.assertTrue(best_match is choices[0])
+
     def testEmptyStrings(self):
         choices = [
             "",


### PR DESCRIPTION
When you need to set `cutoff` to 100%, it doesn't work, because the operator used is `>`
I propose to use `>=` in order, first of all, to start using 100 as a `cutoff` argument, and then it is more adequate anyway.
What will you say?
