### PR TITLE
make process.extract accept {dict, list}-like choices

### DIFF
--- a/fuzzywuzzy/process.py
+++ b/fuzzywuzzy/process.py
@@ -69,21 +69,20 @@ def extract(query, choices, processor=None, scorer=None, limit=5):
     if scorer is None:
         scorer = fuzz.WRatio
 
-    sl = list()
+    sl = []
 
-    if isinstance(choices, dict):
+    try:
+        # See if choices is a dictionary-like object.
         for key, choice in choices.items():
             processed = processor(choice)
             score = scorer(query, processed)
-            tuple = (choice, score, key)
-            sl.append(tuple)
-
-    else:
+            sl.append((choice, score, key))
+    except AttributeError:
+        # It's a list; just iterate over it.
         for choice in choices:
             processed = processor(choice)
             score = scorer(query, processed)
-            tuple = (choice, score)
-            sl.append(tuple)
+            sl.append((choice, score))
 
     sl.sort(key=lambda i: i[1], reverse=True)
     return sl[:limit]

--- a/test_fuzzywuzzy.py
+++ b/test_fuzzywuzzy.py
@@ -77,7 +77,6 @@ class UtilsTest(unittest.TestCase):
         for s in self.mixed_strings:
             utils.full_process(s, force_ascii=True)
 
-
 class RatioTest(unittest.TestCase):
 
     def setUp(self):
@@ -421,6 +420,32 @@ class ProcessTest(unittest.TestCase):
 
         best = process.extractOne(query, choices)
         self.assertEqual(best[0], choices[1])
+
+    def test_list_like_extract(self):
+        """We should be able to use a list-like object for choices."""
+        def generate_choices():
+            choices = ['a', 'Bb', 'CcC']
+            for choice in choices:
+                yield choice
+        search = 'aaa'
+        result = [(value, confidence) for value, confidence in
+                  process.extract(search, generate_choices())]
+        self.assertTrue(len(result) > 0)
+
+    def test_dict_like_extract(self):
+        """We should be able to use a dict-like object for choices, not only a
+        dict, and still get dict-like output.
+        """
+        try:
+            from UserDict import UserDict
+        except ImportError:
+            from collections import UserDict
+        choices = UserDict({'aa': 'bb', 'a1': None})
+        search = 'aaa'
+        result = process.extract(search, choices)
+        self.assertTrue(len(result) > 0)
+        for value, confidence, key in result:
+            self.assertTrue(value in choices.values())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously, process.extract expected lists or dictionaries, and tested
this with isinstance() calls. In keeping with the spirit of Python (duck
typing and all that), this change enables one to use extract() on any
dict-like object for dict-like results, or any list-like object for
list-like results.

So now we can (and, indeed, I've added tests for these uses) call
extract() on things like:

- a generator of strings ("any iterable")
- a UserDict
- custom user-made classes that "look like" dicts
  (or, really, anything with a .items() method that 
  behaves like a dict)
- plain old lists and dicts

The behavior is exactly the same for previous use cases of
lists-and-dicts.

This change goes along nicely with PR #68, since those docs suggest
dict-like behavior is valid, and this change makes that true.