### PR TITLE
FIX: 0.4.0 is released, no need to specify 0.3.1 in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Using PIP via PyPI
 
 .. code:: bash
 
-    pip install fuzzywuzzy==0.3.1
+    pip install fuzzywuzzy
 
 Using PIP via Github
 


### PR DESCRIPTION
Rather self-explanatory - unless 0.4.0 is still unstable/considered a dev branch.

I just installed using the usual `pip install fuzzywuzzy` and 0.4.0 comes down...