### PR TITLE
patched "name 'unicode' is not defined" python3

### DIFF
--- a/fuzzywuzzy/utils.py
+++ b/fuzzywuzzy/utils.py
@@ -17,6 +17,7 @@ def validate_string(s):
 bad_chars = str("").join([chr(i) for i in range(128, 256)])  # ascii dammit!
 if PY3:
     translation_table = dict((ord(c), None) for c in bad_chars)
+    unicode = str
 
 
 def asciionly(s):


### PR DESCRIPTION
see issue https://github.com/seatgeek/fuzzywuzzy/issues/80

```python
In [1]: import sys
        sys.version_info[0]
Out[1]: 3

In [2]: from fuzzywuzzy import fuzz
In [3]: fuzz.ratio('24','3434')
Out[3]: 33

In [4]: fuzz.ratio(24,'3434')
Out[4]: 33
```