### PR TITLE
Levenshtein benchmarks

### DIFF
--- a/benchmarks.py
+++ b/benchmarks.py
@@ -2,8 +2,15 @@
 
 from timeit import timeit
 import math
+import csv
 
 iterations = 100000
+
+
+reader = csv.DictReader(open('data/titledata.csv'), delimiter='|')
+titles = [i['custom_title'] for i in reader]
+title_blob = '\n'.join(titles)
+
 
 cirque_strings = [
     "cirque du soleil - zarkana - las vegas",
@@ -79,3 +86,21 @@ for s in cirque_strings:
     print '-------------------------------'
     print_result_from_timeit('fuzz.WRatio(u\'cirque du soleil\', u\'%s\')' % s,
                              common_setup + basic_setup, number=iterations / 100)
+
+
+# let me show you something
+
+s = 'New York Yankees'
+
+test = 'import functools\n'
+test += 'title_blob = """%s"""\n' % title_blob
+test += 'title_blob = title_blob.strip()\n'
+test += 'titles = title_blob.split("\\n")\n'
+
+print 'Real world ratio(): "%s"' % s
+print '-------------------------------'
+test += 'prepared_ratio = functools.partial(fuzz.ratio, "%s")\n' % s
+test += 'titles.sort(key=prepared_ratio)\n'
+print_result_from_timeit(test,
+                         common_setup + basic_setup,
+                         number=100)

--- a/data/titledata.csv
+++ b/data/titledata.csv
@@ -1,0 +1,2765 @@
+id|custom_title|stubhub_title|vividseats_title
+701562|Toronto Blue Jays at Baltimore Orioles (Wednesday April 25, 2012)|Baltimore Orioles vs Toronto Blue Jays [4/25/2012] Tickets at StubHub!|Toronto Blue Jays at Baltimore Orioles
+701563|Texas Rangers at Baltimore Orioles (Tuesday May 8, 2012)|Baltimore Orioles vs Texas Rangers [5/8/2012] Tickets at StubHub!|Texas Rangers at Baltimore Orioles
+701564|Toronto Blue Jays at Baltimore Orioles (Tuesday April 24, 2012)|Baltimore Orioles vs Toronto Blue Jays [4/24/2012] Tickets at StubHub!|Toronto Blue Jays at Baltimore Orioles
+701565|Texas Rangers at Baltimore Orioles (Wednesday May 9, 2012)|Baltimore Orioles vs Texas Rangers [5/9/2012] Tickets at StubHub!|Texas Rangers at Baltimore Orioles
+701566|Oakland Athletics at Baltimore Orioles (Friday April 27, 2012)|Baltimore Orioles vs Oakland Athletics [4/27/2012] Tickets at StubHub!|Oakland Athletics at Baltimore Orioles
+701567|Toronto Blue Jays at Baltimore Orioles (Thursday April 26, 2012)|Baltimore Orioles vs Toronto Blue Jays [4/26/2012] Tickets at StubHub!|Toronto Blue Jays at Baltimore Orioles
+701568|Minnesota Twins at Baltimore Orioles (Saturday April 7, 2012)|Baltimore Orioles vs Minnesota Twins [4/7/2012] Tickets at StubHub!|Minnesota Twins at Baltimore Orioles
+701569|Oakland Athletics at Baltimore Orioles (Sunday April 29, 2012)|Baltimore Orioles vs Oakland Athletics [4/29/2012] Tickets at StubHub!|Oakland Athletics at Baltimore Orioles
+701570|Minnesota Twins at Baltimore Orioles (Friday April 6, 2012)|Baltimore Orioles vs Minnesota Twins [4/6/2012] Tickets at StubHub!|Minnesota Twins at Baltimore Orioles
+701571|Oakland Athletics at Baltimore Orioles (Saturday April 28, 2012)|Baltimore Orioles vs Oakland Athletics [4/28/2012] Tickets at StubHub!|Oakland Athletics at Baltimore Orioles
+701572|New York Yankees at Baltimore Orioles (Monday April 9, 2012)|Baltimore Orioles vs New York Yankees [4/9/2012] Tickets at StubHub!|New York Yankees at Baltimore Orioles
+701573|Minnesota Twins at Baltimore Orioles (Sunday April 8, 2012)|Baltimore Orioles vs Minnesota Twins [4/8/2012] Tickets at StubHub!|Minnesota Twins at Baltimore Orioles
+701574|New York Yankees at Baltimore Orioles (Wednesday April 11, 2012)|Baltimore Orioles vs New York Yankees [4/11/2012] Tickets at StubHub!|New York Yankees at Baltimore Orioles
+701575|New York Yankees at Baltimore Orioles (Tuesday April 10, 2012)|Baltimore Orioles vs New York Yankees [4/10/2012] Tickets at StubHub!|New York Yankees at Baltimore Orioles
+701576|Texas Rangers at Baltimore Orioles (Monday May 7, 2012)|Baltimore Orioles vs Texas Rangers [5/7/2012] Tickets at StubHub!|Texas Rangers at Baltimore Orioles
+701577|Texas Rangers at Baltimore Orioles (Thursday May 10, 2012)|Baltimore Orioles vs Texas Rangers [5/10/2012] Tickets at StubHub!|Texas Rangers at Baltimore Orioles
+701823|Philadelphia Phillies at Miami Marlins (Saturday September 29, 2012)|Miami Marlins vs Philadelphia Phillies [09/29/2012] Tickets at StubHub!|Philadelphia Phillies at Miami Marlins
+701824|New York Mets at Miami Marlins (Friday May 11, 2012)|Miami Marlins vs New York Mets [05/11/2012] Tickets at StubHub!|New York Mets at Miami Marlins
+701825|Washington Nationals at Miami Marlins (Wednesday August 29, 2012)|Miami Marlins vs Washington Nationals [08/29/2012] Tickets at StubHub!|Washington Nationals at Miami Marlins
+701826|New York Mets at Miami Marlins (Monday October 1, 2012)|Miami Marlins vs New York Mets [10/01/2012] Tickets at StubHub!|New York Mets at Miami Marlins
+701827|Houston Astros at Miami Marlins (Sunday April 15, 2012)|Miami Marlins vs Houston Astros [04/15/2012] Tickets at StubHub!|Houston Astros at Miami Marlins
+701828|Atlanta Braves at Miami Marlins (Wednesday September 19, 2012)|Miami Marlins vs Atlanta Braves [09/19/2012] Tickets at StubHub!|Atlanta Braves at Miami Marlins
+701829|Cincinnati Reds at Miami Marlins (Friday Spetember 14, 2012)|Miami Marlins vs Cincinnati Reds [09/14/2012] Tickets at StubHub!|Cincinnati Reds at Miami Marlins
+701830|New York Mets at Miami Marlins (Friday August 31, 2012)|Miami Marlins vs New York Mets [08/31/2012] Tickets at StubHub!|New York Mets at Miami Marlins
+701831|San Diego Padres at Miami Marlins (Friday July 27, 2012)|Miami Marlins vs San Diego Padres [07/27/2012] Tickets at StubHub!|San Diego Padres at Miami Marlins
+701832|Chicago Cubs at Miami Marlins (Tuesday April 17, 2012)|Miami Marlins vs Chicago Cubs [04/17/2012] Tickets at StubHub!|Chicago Cubs at Miami Marlins
+701833|Atlanta Braves at Miami Marlins (Monday September 17, 2012)|Miami Marlins vs Atlanta Braves [09/17/2012] Tickets at StubHub!|Atlanta Braves at Miami Marlins
+701834|Colorado Rockies at Miami Marlins (Wednesday May 23, 2012)|Miami Marlins vs Colorado Rockies [05/23/2012] Tickets at StubHub!|Colorado Rockies at Miami Marlins
+701835|Washington Nationals at Miami Marlins (Saturday July 14, 2012)|Miami Marlins vs Washington Nationals [07/14/2012] Tickets at StubHub!|Washington Nationals at Miami Marlins
+701836|Chicago Cubs at Miami Marlins (Thursday April 19, 2012)|Miami Marlins vs Chicago Cubs [04/19/2012] Tickets at StubHub!|Chicago Cubs at Miami Marlins
+701837|New York Mets at Miami Marlins (Sunday September 2, 2012)|Miami Marlins vs New York Mets [09/02/2012] Tickets at StubHub!|New York Mets at Miami Marlins
+701838|Colorado Rockies at Miami Marlins (Monday May 21, 2012)|Miami Marlins vs Colorado Rockies [05/21/2012] Tickets at StubHub!|Colorado Rockies at Miami Marlins
+701839|Los Angeles Dodgers at Miami Marlins (Sunday August 12, 2012)|Miami Marlins vs Los Angeles Dodgers [08/12/2012] Tickets at StubHub!|Los Angeles Dodgers at Miami Marlins
+701840|San Diego Padres at Miami Marlins (Sunday July 29, 2012)|Miami Marlins vs San Diego Padres [07/29/2012] Tickets at StubHub!|San Diego Padres at Miami Marlins
+701841|Toronto Blue Jays at Miami Marlins (Saturday June 23, 2012)|Miami Marlins vs Toronto Blue Jays [06/23/2012] Tickets at StubHub!|Toronto Blue Jays at Miami Marlins
+701842|Philadelphia Phillies at Miami Marlins (Tuesday August 14, 2012)|Miami Marlins vs Philadelphia Phillies [08/14/2012] Tickets at StubHub!|Philadelphia Phillies at Miami Marlins
+701843|Philadelphia Phillies at Miami Marlins (Friday June 29, 2012)|Miami Marlins vs Philadelphia Phillies [06/29/2012] Tickets at StubHub!|Philadelphia Phillies at Miami Marlins
+701844|Tampa Bay Rays at Miami Marlins (Sunday June 10, 2012)|Miami Marlins vs Tampa Bay Rays [06/10/2012] Tickets at StubHub!|Tampa Bay Rays at Miami Marlins
+701845|Atlanta Braves at Miami Marlins (Tuesday June 5, 2012)|Miami Marlins vs Atlanta Braves [06/05/2012] Tickets at StubHub!|Atlanta Braves at Miami Marlins
+701846|New York Mets at Miami Marlins (Tuesday October 2, 2012)|Miami Marlins vs New York Mets [10/02/2012] Tickets at StubHub!|New York Mets at Miami Marlins
+701847|Tampa Bay Rays at Miami Marlins (Friday June 8, 2012)|Miami Marlins vs Tampa Bay Rays [06/08/2012] Tickets at StubHub!|Tampa Bay Rays at Miami Marlins
+701848|Washington Nationals at Miami Marlins (Tuesday August 28, 2012)|Miami Marlins vs Washington Nationals [08/28/2012] Tickets at StubHub!|Washington Nationals at Miami Marlins
+701849|Los Angeles Dodgers at Miami Marlins (Friday August 10, 2012)|Miami Marlins vs Los Angeles Dodgers [08/10/2012] Tickets at StubHub!|Los Angeles Dodgers at Miami Marlins
+701850|Arizona Diamondback at Miami Marlins (Friday April 27, 2012)|Miami Marlins vs Arizona Diamondback [04/27/2012] Tickets at StubHub!|Arizona Diamondbacks at Miami Marlins
+701851|St Louis Cardinals at Miami Marlins (Wednesday April 4, 2012)|Miami Marlins vs St Louis Cardinals [04/04/2012] Tickets at StubHub!|St. Louis Cardinals at Miami Marlins
+701852|Washington National at Miami Marlins (Tuesday May 29, 2012)|Miami Marlins vs Washington National [05/29/2012] Tickets at StubHub!|Washington Nationals at Miami Marlins
+701853|Toronto Blue Jays at Miami Marlins (Friday June 22, 2012)|Miami Marlins vs Toronto Blue Jays [06/22/2012] Tickets at StubHub!|Toronto Blue Jays at Miami Marlins
+701854|Arizona Diamondback at Miami Marlins (Sunday April 29, 2012)|Miami Marlins vs Arizona Diamondback [04/29/2012] Tickets at StubHub!|Arizona Diamondbacks at Miami Marlins
+701855|Boston Red Sox at Miami Marlins (Tuesday June 12, 2012)|Miami Marlins vs Boston Red Sox [06/12/2012] Tickets at StubHub!|Boston Red Sox at Miami Marlins
+701856|San Francisco Giants at Miami Marlins (Sunday May 27, 2012)|Miami Marlins vs San Francisco Giants [05/27/2012] Tickets at StubHub!|San Francisco Giants at Miami Marlins
+701857|Pittsburgh Pirates at Miami Marlins (Monday May 14, 2012)|Miami Marlins vs Pittsburgh Pirates [05/14/2012] Tickets at StubHub!|Pittsburgh Pirates at Miami Marlins
+701858|Philadelphia Phillies at Miami Marlins (Sunday September 30, 2012)|Miami Marlins vs Philadelphia Phillies [09/30/2012] Tickets at StubHub!|Philadelphia Phillies at Miami Marlins
+701859|San Francisco Giants at Miami Marlins (Friday May 25, 2012)|Miami Marlins vs San Francisco Giants [05/25/2012] Tickets at StubHub!|San Francisco Giants at Miami Marlins
+701860|New York Mets at Miami Marlins (Saturday May 12, 2012)|Miami Marlins vs New York Mets [05/12/2012] Tickets at StubHub!|New York Mets at Miami Marlins
+701861|New York Mets at Miami Marlins (Wednesday October 3, 2012)|Miami Marlins vs New York Mets [10/03/2012] Tickets at StubHub!|New York Mets at Miami Marlins
+701862|Milwaukee Brewers at Miami Marlins (Thursday September 6, 2012)|Miami Marlins vs Milwaukee Brewers [09/06/2012] Tickets at StubHub!|Milwaukee Brewers at Miami Marlins
+701863|Philadelphia Phillies at Miami Marlins (Friday September 28, 2012)|Miami Marlins vs Philadelphia Phillies [09/28/2012] Tickets at StubHub!|Philadelphia Phillies at Miami Marlins
+701864|Atlanta Braves at Miami Marlins (Wednesday June 6, 2012)|Miami Marlins vs Atlanta Braves [06/06/2012] Tickets at StubHub!|Atlanta Braves at Miami Marlins
+701865|St Louis Cardinals at Miami Marlins (Wednesday June 27, 2012)|Miami Marlins vs St Louis Cardinals [06/27/2012] Tickets at StubHub!|St. Louis Cardinals at Miami Marlins
+701866|Philadelphia Phillies at Miami Marlins (Sunday July 1, 2012)|Miami Marlins vs Philadelphia Phillies [07/01/2012] Tickets at StubHub!|Philadelphia Phillies at Miami Marlins
+701867|Atlanta Braves at Miami Marlins (Tuesday July 24, 2012)|Miami Marlins vs Atlanta Braves [07/24/2012] Tickets at StubHub!|Atlanta Braves at Miami Marlins
+701868|Houston Astros at Miami Marlins (Saturday April 14, 2012)|Miami Marlins vs Houston Astros [04/14/2012] Tickets at StubHub!|Houston Astros at Miami Marlins
+701869|Cincinnati Reds at Miami Marlins (Sunday September 16, 2012)|Miami Marlins vs Cincinnati Reds [09/16/2012] Tickets at StubHub!|Cincinnati Reds at Miami Marlins
+701870|Cincinnati Reds at Miami Marlins (Saturday September 15, 2012)|Miami Marlins vs Cincinnati Reds [09/15/2012] Tickets at StubHub!|Cincinnati Reds at Miami Marlins
+701871|Colorado Rockies at Miami Marlins (Tuesday May 22, 2012)|Miami Marlins vs Colorado Rockies [05/22/2012] Tickets at StubHub!|Colorado Rockies at Miami Marlins
+701872|St Louis Cardinals at Miami Marlins (Tuesday June 26, 2012)|Miami Marlins vs St Louis Cardinals [06/26/2012] Tickets at StubHub!|St. Louis Cardinals at Miami Marlins
+701873|Atlanta Braves at Miami Marlins (Monday July 23, 2012)|Miami Marlins vs Atlanta Braves [07/23/2012] Tickets at StubHub!|Atlanta Braves at Miami Marlins
+701874|Atlanta Braves at Miami Marlins (Tuesday September 18, 2012)|Miami Marlins vs Atlanta Braves [09/18/2012] Tickets at StubHub!|Atlanta Braves at Miami Marlins
+701875|Washington Nationals at Miami Marlins (Monday July 16, 2012)|Miami Marlins vs Washington Nationals [07/16/2012] Tickets at StubHub!|Washington Nationals at Miami Marlins
+701876|Chicago Cubs at Miami Marlins (Wednesday April 18, 2012)|Miami Marlins vs Chicago Cubs [04/18/2012] Tickets at StubHub!|Chicago Cubs at Miami Marlins
+701877|Atlanta Braves at Miami Marlins (Wednesday July 25, 2012)|Miami Marlins vs Atlanta Braves [07/25/2012] Tickets at StubHub!|Atlanta Braves at Miami Marlins
+701878|Milwaukee Brewers at Miami Marlins (Monday September 3, 2012)|Miami Marlins vs Milwaukee Brewers [09/03/2012] Tickets at StubHub!|Milwaukee Brewers at Miami Marlins
+701879|San Diego Padres at Miami Marlins (Saturday July 28, 2012)|Miami Marlins vs San Diego Padres [07/28/2012] Tickets at StubHub!|San Diego Padres at Miami Marlins
+701880|Philadelphia Phillies at Miami Marlins (Wednesday August 15, 2012)|Miami Marlins vs Philadelphia Phillies [08/15/2012] Tickets at StubHub!|Philadelphia Phillies at Miami Marlins
+701881|Philadelphia Phillies at Miami Marlins (Saturday June 30, 2012)|Miami Marlins vs Philadelphia Phillies [06/30/2012] Tickets at StubHub!|Philadelphia Phillies at Miami Marlins
+701882|Boston Red Sox at Miami Marlins (Monday June 11, 2012)|Miami Marlins vs Boston Red Sox [06/11/2012] Tickets at StubHub!|Boston Red Sox at Miami Marlins
+701883|New York Mets at Miami Marlins (Saturday September 1, 2012)|Miami Marlins vs New York Mets [09/01/2012] Tickets at StubHub!|New York Mets at Miami Marlins
+701884|Milwaukee Brewers at Miami Marlins (Tuesday September 4, 2012)|Miami Marlins vs Milwaukee Brewers [09/04/2012] Tickets at StubHub!|Milwaukee Brewers at Miami Marlins
+701885|Tampa Bay Rays at Miami Marlins (Saturday June 9, 2012)|Miami Marlins vs Tampa Bay Rays [06/09/2012] Tickets at StubHub!|Tampa Bay Rays at Miami Marlins
+701887|Los Angeles Dodgers at Miami Marlins (Saturday August 11, 2012)|Miami Marlins vs Los Angeles Dodgers [08/11/2012] Tickets at StubHub!|Los Angeles Dodgers at Miami Marlins
+701889|Milwaukee Brewers at Miami Marlins (Wednesday September 5, 2012)|Miami Marlins vs Milwaukee Brewers [09/05/2012] Tickets at StubHub!|Milwaukee Brewers at Miami Marlins
+701890|Washington National at Miami Marlins (Monday May 28, 2012)|Miami Marlins vs Washington National [05/28/2012] Tickets at StubHub!|Washington Nationals at Miami Marlins
+701891|Washington Nationals at Miami Marlins (Friday July 13, 2012)|Miami Marlins vs Washington Nationals [07/13/2012] Tickets at StubHub!|Washington Nationals at Miami Marlins
+701892|Boston Red Sox at Miami Marlins (Wednesday June 13, 2012)|Miami Marlins vs Boston Red Sox [06/13/2012] Tickets at StubHub!|Boston Red Sox at Miami Marlins
+701893|San Francisco Giants at Miami Marlins (Saturday May 26, 2012)|Miami Marlins vs San Francisco Giants [05/26/2012] Tickets at StubHub!|San Francisco Giants at Miami Marlins
+701894|Washington Nationals at Miami Marlins (Sunday July 15, 2012)|Miami Marlins vs Washington Nationals [07/15/2012] Tickets at StubHub!|Washington Nationals at Miami Marlins
+701895|Arizona Diamondback at Miami Marlins (Saturday April 28, 2012)|Miami Marlins vs Arizona Diamondback [04/28/2012] Tickets at StubHub!|Arizona Diamondbacks at Miami Marlins
+701896|Philadelphia Phillies at Miami Marlins (Monday August 13, 2012)|Miami Marlins vs Philadelphia Phillies [08/13/2012] Tickets at StubHub!|Philadelphia Phillies at Miami Marlins
+701897|San Francisco Giants at Miami Marlins (Thursday May 24, 2012)|Miami Marlins vs San Francisco Giants [05/24/2012] Tickets at StubHub!|San Francisco Giants at Miami Marlins
+701898|Pittsburgh Pirates at Miami Marlins (Tuesday May 15, 2012)|Miami Marlins vs Pittsburgh Pirates [05/15/2012] Tickets at StubHub!|Pittsburgh Pirates at Miami Marlins
+701899|Arizona Diamondbacks at Miami Marlins (Monday April 30, 2012)|Miami Marlins vs Arizona Diamondbacks [04/30/2012] Tickets at StubHub!|Arizona Diamondbacks at Miami Marlins
+701900|Toronto Blue Jays at Miami Marlins (Sunday June 24, 2012)|Miami Marlins vs Toronto Blue Jays [06/24/2012] Tickets at StubHub!|Toronto Blue Jays at Miami Marlins
+701901|Atlanta Braves at Miami Marlins (Thursday June 7, 2012)|Miami Marlins vs Atlanta Braves [06/07/2012] Tickets at StubHub!|Atlanta Braves at Miami Marlins
+701902|New York Mets at Miami Marlins (Sunday May 13, 2012)|Miami Marlins vs New York Mets [05/13/2012] Tickets at StubHub!|New York Mets at Miami Marlins
+701903|Houston Astros at Miami Marlins (Friday April 13, 2012)|Miami Marlins vs Houston Astros [04/13/2012] Tickets at StubHub!|Houston Astros at Miami Marlins
+701911|Cincinnati Reds at Pittsburgh Pirates (Saturday September 29, 2012)|Pittsburgh Pirates vs Cincinnati Reds [09/29/2012] Tickets at StubHub!|Cincinnati Reds at Pittsburgh Pirates
+701912|Chicago Cubs at Pittsburgh Pirates (Saturday September 8, 2012)|Pittsburgh Pirates vs Chicago Cubs [09/08/2012] Tickets at StubHub!|Chicago Cubs at Pittsburgh Pirates
+701913|Houston Astros at Pittsburgh Pirates (Thursday July 5, 2012)|Pittsburgh Pirates vs Houston Astros [07/05/2012] Tickets at StubHub!|Houston Astros at Pittsburgh Pirates
+701914|St Louis Cardinals at Pittsburgh Pirates (Wednesday August 29, 2012)|Pittsburgh Pirates vs St Louis Cardinals [08/29/2012] Tickets at StubHub!|St. Louis Cardinals at Pittsburgh Pirates
+701915|Chicago Cubs at Pittsburgh Pirates (Saturday May 26, 2012)|Pittsburgh Pirates vs Chicago Cubs [05/26/2012] Tickets at StubHub!|Chicago Cubs at Pittsburgh Pirates
+701916|Milwaukee Brewers at Pittsburgh Pirates (Wednesday September 19, 2012)|Pittsburgh Pirates vs Milwaukee Brewers [09/19/2012] Tickets at StubHub!|Milwaukee Brewers at Pittsburgh Pirates
+701917|Washington Nationals at Pittsburgh Pirates (Wednesday May 9, 2012)|Pittsburgh Pirates vs Washington Nationals [05/09/2012] Tickets at StubHub!|Washington Nationals at Pittsburgh Pirates
+701918|Houston Astros at Pittsburgh Pirates (Friday May 11, 2012)|Pittsburgh Pirates vs Houston Astros [05/11/2012] Tickets at StubHub!|Houston Astros at Pittsburgh Pirates
+701919|New York Mets at Pittsburgh Pirates (Wednesday May 23, 2012)|Pittsburgh Pirates vs New York Mets [05/23/2012] Tickets at StubHub!|New York Mets at Pittsburgh Pirates
+701920|Milwaukee Brewers at Pittsburgh Pirates (Saturday August 25, 2012)|Pittsburgh Pirates vs Milwaukee Brewers [08/25/2012] Tickets at StubHub!|Milwaukee Brewers at Pittsburgh Pirates
+701921|Atlanta Braves at Pittsburgh Pirates (Monday October 1, 2012)|Pittsburgh Pirates vs Atlanta Braves [10/01/2012] Tickets at StubHub!|Atlanta Braves at Pittsburgh Pirates
+701922|New York Mets at Pittsburgh Pirates (Monday May 21, 2012)|Pittsburgh Pirates vs New York Mets [05/21/2012] Tickets at StubHub!|New York Mets at Pittsburgh Pirates
+701923|St Louis Cardinals at Pittsburgh Pirates (Monday August 27, 2012)|Pittsburgh Pirates vs St Louis Cardinals [08/27/2012] Tickets at StubHub!|St. Louis Cardinals at Pittsburgh Pirates
+701924|San Diego Padres at Pittsburgh Pirates (Sunday August 12, 2012)|Pittsburgh Pirates vs San Diego Padres [08/12/2012] Tickets at StubHub!|San Diego Padres at Pittsburgh Pirates
+701925|St Louis Cardinals at Pittsburgh Pirates (Saturday April 21, 2012)|Pittsburgh Pirates vs St Louis Cardinals [04/21/2012] Tickets at StubHub!|St. Louis Cardinals at Pittsburgh Pirates
+701926|Arizona Diamondbacks at Pittsburgh Pirates (Monday August 6, 2012)|Pittsburgh Pirates vs Arizona Diamondbacks [08/06/2012] Tickets at StubHub!|Arizona Diamondbacks at Pittsburgh Pirates
+701927|San Francisco Giants at Pittsburgh Pirates (Sunday July 8, 2012)|Pittsburgh Pirates vs San Francisco Giants [07/08/2012] Tickets at StubHub!|San Francisco Giants at Pittsburgh Pirates
+701928|Los Angeles Dodgers at Pittsburgh Pirates (Tuesday August 14, 2012)|Pittsburgh Pirates vs Los Angeles Dodgers [08/14/2012] Tickets at StubHub!|Los Angeles Dodgers at Pittsburgh Pirates
+701929|Colorado Rockies at Pittsburgh Pirates (Monday April 23, 2012)|Pittsburgh Pirates vs Colorado Rockies [04/23/2012] Tickets at StubHub!|Colorado Rockies at Pittsburgh Pirates
+701930|Kansas City Royals at Pittsburgh Pirates (Sunday June 10, 2012)|Pittsburgh Pirates vs Kansas City Royals [06/10/2012] Tickets at StubHub!|Kansas City Royals at Pittsburgh Pirates
+701931|San Francisco Giants at Pittsburgh Pirates (Friday July 6, 2012)|Pittsburgh Pirates vs San Francisco Giants [07/06/2012] Tickets at StubHub!|San Francisco Giants at Pittsburgh Pirates
+701932|Cincinnati Reds at Pittsburgh Pirates (Friday May 4, 2012)|Pittsburgh Pirates vs Cincinnati Reds [05/04/2012] Tickets at StubHub!|Cincinnati Reds at Pittsburgh Pirates
+701933|Atlanta Braves at Pittsburgh Pirates (Tuesday October 2, 2012)|Pittsburgh Pirates vs Atlanta Braves [10/02/2012] Tickets at StubHub!|Atlanta Braves at Pittsburgh Pirates
+701934|Minnesota Twins at Pittsburgh Pirates (Tuesday June 19, 2012)|Pittsburgh Pirates vs Minnesota Twins [06/19/2012] Tickets at StubHub!|Minnesota Twins at Pittsburgh Pirates
+701935|Kansas City Royals at Pittsburgh Pirates (Friday June 8, 2012)|Pittsburgh Pirates vs Kansas City Royals [06/08/2012] Tickets at StubHub!|Kansas City Royals at Pittsburgh Pirates
+701936|Houston Astros at Pittsburgh Pirates (Tuesday September 4, 2012)|Pittsburgh Pirates vs Houston Astros [09/04/2012] Tickets at StubHub!|Houston Astros at Pittsburgh Pirates
+701937|San Diego Padres at Pittsburgh Pirates (Friday August 10, 2012)|Pittsburgh Pirates vs San Diego Padres [08/10/2012] Tickets at StubHub!|San Diego Padres at Pittsburgh Pirates
+701938|Chicago Cubs at Pittsburgh Pirates (Wednesday July 25, 2012)|Pittsburgh Pirates vs Chicago Cubs [07/25/2012] Tickets at StubHub!|Chicago Cubs at Pittsburgh Pirates
+701939|Cincinnati Reds at Pittsburgh Pirates (Tuesday May 29, 2012)|Pittsburgh Pirates vs Cincinnati Reds [05/29/2012] Tickets at StubHub!|Cincinnati Reds at Pittsburgh Pirates
+701940|Chicago Cubs at Pittsburgh Pirates (Sunday May 27, 2012)|Pittsburgh Pirates vs Chicago Cubs [05/27/2012] Tickets at StubHub!|Chicago Cubs at Pittsburgh Pirates
+701941|Detroit Tigers at Pittsburgh Pirates (Saturday June 23, 2012)|Pittsburgh Pirates vs Detroit Tigers [06/23/2012] Tickets at StubHub!|Detroit Tigers at Pittsburgh Pirates
+701942|San Francisco Giants at Pittsburgh Pirates (Saturday July 7, 2012)|Pittsburgh Pirates vs San Francisco Giants [07/07/2012] Tickets at StubHub!|San Francisco Giants at Pittsburgh Pirates
+701943|Miami Marlins at Pittsburgh Pirates (Saturday July 21, 2012)|Pittsburgh Pirates vs Miami Marlins [07/21/2012] Tickets at StubHub!|Miami Marlins at Pittsburgh Pirates
+701944|Minnesota Twins at Pittsburgh Pirates (Thursday June 21, 2012)|Pittsburgh Pirates vs Minnesota Twins [06/21/2012] Tickets at StubHub!|Minnesota Twins at Pittsburgh Pirates
+701945|Philadelphia Phillies at Pittsburgh Pirates (Sunday April 8, 2012)|Pittsburgh Pirates vs Philadelphia Phillies [04/08/2012] Tickets at StubHub!|Philadelphia Phillies at Pittsburgh Pirates
+701946|Cincinnati Reds at Pittsburgh Pirates (Sunday September 30, 2012)|Pittsburgh Pirates vs Cincinnati Reds [09/30/2012] Tickets at StubHub!|Cincinnati Reds at Pittsburgh Pirates
+701947|Chicago Cubs at Pittsburgh Pirates (Monday July 23, 2012)|Pittsburgh Pirates vs Chicago Cubs [07/23/2012] Tickets at StubHub!|Chicago Cubs at Pittsburgh Pirates
+701948|Houston Astros at Pittsburgh Pirates (Monday July 2, 2012)|Pittsburgh Pirates vs Houston Astros [07/02/2012] Tickets at StubHub!|Houston Astros at Pittsburgh Pirates
+701949|Los Angeles Dodgers at Pittsburgh Pirates (Thursday August 16, 2012)|Pittsburgh Pirates vs Los Angeles Dodgers [08/16/2012] Tickets at StubHub!|Los Angeles Dodgers at Pittsburgh Pirates
+701950|Arizona Diamondbacks at Pittsburgh Pirates (Thursday August 9, 2012)|Pittsburgh Pirates vs Arizona Diamondbacks [08/09/2012] Tickets at StubHub!|Arizona Diamondbacks at Pittsburgh Pirates
+701951|Colorado Rockies at Pittsburgh Pirates (Wednesday April 25, 2012)|Pittsburgh Pirates vs Colorado Rockies [04/25/2012] Tickets at StubHub!|Colorado Rockies at Pittsburgh Pirates
+701952|Cincinnati Reds at Pittsburgh Pirates (Friday September 28, 2012)|Pittsburgh Pirates vs Cincinnati Reds [09/28/2012] Tickets at StubHub!|Cincinnati Reds at Pittsburgh Pirates
+701953|Washington Nationals at Pittsburgh Pirates (Thursday May 10, 2012)|Pittsburgh Pirates vs Washington Nationals [05/10/2012] Tickets at StubHub!|Washington Nationals at Pittsburgh Pirates
+701954|Arizona Diamondbacks at Pittsburgh Pirates (Tuesday August 7, 2012)|Pittsburgh Pirates vs Arizona Diamondbacks [08/07/2012] Tickets at StubHub!|Arizona Diamondbacks at Pittsburgh Pirates
+701955|Milwaukee Brewers at Pittsburgh Pirates (Tuesday September 18, 2012)|Pittsburgh Pirates vs Milwaukee Brewers [09/18/2012] Tickets at StubHub!|Milwaukee Brewers at Pittsburgh Pirates
+701956|Chicago Cubs at Pittsburgh Pirates (Sunday September 9, 2012)|Pittsburgh Pirates vs Chicago Cubs [09/09/2012] Tickets at StubHub!|Chicago Cubs at Pittsburgh Pirates
+701957|Washington Nationals at Pittsburgh Pirates (Tuesday May 8, 2012)|Pittsburgh Pirates vs Washington Nationals [05/08/2012] Tickets at StubHub!|Washington Nationals at Pittsburgh Pirates
+701958|St Louis Cardinals at Pittsburgh Pirates (Tuesday August 28, 2012)|Pittsburgh Pirates vs St Louis Cardinals [08/28/2012] Tickets at StubHub!|St. Louis Cardinals at Pittsburgh Pirates
+701959|New York Mets at Pittsburgh Pirates (Tuesday May 22, 2012)|Pittsburgh Pirates vs New York Mets [05/22/2012] Tickets at StubHub!|New York Mets at Pittsburgh Pirates
+701960|Arizona Diamondbacks at Pittsburgh Pirates (Wednesday August 8, 2012)|Pittsburgh Pirates vs Arizona Diamondbacks [08/08/2012] Tickets at StubHub!|Arizona Diamondbacks at Pittsburgh Pirates
+701961|Cincinnati Reds at Pittsburgh Pirates (Sunday May 6, 2012)|Pittsburgh Pirates vs Cincinnati Reds [05/06/2012] Tickets at StubHub!|Cincinnati Reds at Pittsburgh Pirates
+701962|Chicago Cubs at Pittsburgh Pirates (Friday May 25, 2012)|Pittsburgh Pirates vs Chicago Cubs [05/25/2012] Tickets at StubHub!|Chicago Cubs at Pittsburgh Pirates
+701963|Milwaukee Brewers at Pittsburgh Pirates (Friday August 24, 2012)|Pittsburgh Pirates vs Milwaukee Brewers [08/24/2012] Tickets at StubHub!|Milwaukee Brewers at Pittsburgh Pirates
+701964|Los Angeles Dodgers at Pittsburgh Pirates (Monday August 13, 2012)|Pittsburgh Pirates vs Los Angeles Dodgers [08/13/2012] Tickets at StubHub!|Los Angeles Dodgers at Pittsburgh Pirates
+701965|Detroit Tigers at Pittsburgh Pirates (Sunday June 24, 2012)|Pittsburgh Pirates vs Detroit Tigers [06/24/2012] Tickets at StubHub!|Detroit Tigers at Pittsburgh Pirates
+701966|Milwaukee Brewers at Pittsburgh Pirates (Thursday September 20, 2012)|Pittsburgh Pirates vs Milwaukee Brewers [09/20/2012] Tickets at StubHub!|Milwaukee Brewers at Pittsburgh Pirates
+701967|Houston Astros at Pittsburgh Pirates (Monday September 3, 2012)|Pittsburgh Pirates vs Houston Astros [09/03/2012] Tickets at StubHub!|Houston Astros at Pittsburgh Pirates
+701968|Houston Astros at Pittsburgh Pirates (Saturday May 12, 2012)|Pittsburgh Pirates vs Houston Astros [05/12/2012] Tickets at StubHub!|Houston Astros at Pittsburgh Pirates
+701969|Milwaukee Brewers at Pittsburgh Pirates (Sunday August 26, 2012)|Pittsburgh Pirates vs Milwaukee Brewers [08/26/2012] Tickets at StubHub!|Milwaukee Brewers at Pittsburgh Pirates
+701970|Los Angeles Dodgers at Pittsburgh Pirates (Wednesday August 15, 2012)|Pittsburgh Pirates vs Los Angeles Dodgers [08/15/2012] Tickets at StubHub!|Los Angeles Dodgers at Pittsburgh Pirates
+701971|St Louis Cardinals at Pittsburgh Pirates (Friday April 20, 2012)|Pittsburgh Pirates vs St Louis Cardinals [04/20/2012] Tickets at StubHub!|St. Louis Cardinals at Pittsburgh Pirates
+701972|Atlanta Braves at Pittsburgh Pirates (Wednesday October 3, 2012)|Pittsburgh Pirates vs Atlanta Braves [10/03/2012] Tickets at StubHub!|Atlanta Braves at Pittsburgh Pirates
+701973|St Louis Cardinals at Pittsburgh Pirates (Sunday April 22, 2012)|Pittsburgh Pirates vs St Louis Cardinals [04/22/2012] Tickets at StubHub!|St. Louis Cardinals at Pittsburgh Pirates
+701974|Kansas City Royals at Pittsburgh Pirates (Saturday June 9, 2012)|Pittsburgh Pirates vs Kansas City Royals [06/09/2012] Tickets at StubHub!|Kansas City Royals at Pittsburgh Pirates
+701975|Chicago Cubs at Pittsburgh Pirates (Friday September 7, 2012)|Pittsburgh Pirates vs Chicago Cubs [09/07/2012] Tickets at StubHub!|Chicago Cubs at Pittsburgh Pirates
+701976|Cincinnati Reds at Pittsburgh Pirates (Wednesday May 30, 2012)|Pittsburgh Pirates vs Cincinnati Reds [05/30/2012] Tickets at StubHub!|Cincinnati Reds at Pittsburgh Pirates
+701977|Cincinnati Reds at Pittsburgh Pirates (Saturday May 5, 2012)|Pittsburgh Pirates vs Cincinnati Reds [05/05/2012] Tickets at StubHub!|Cincinnati Reds at Pittsburgh Pirates
+701978|San Diego Padres at Pittsburgh Pirates (Saturday August 11, 2012)|Pittsburgh Pirates vs San Diego Padres [08/11/2012] Tickets at StubHub!|San Diego Padres at Pittsburgh Pirates
+701979|Colorado Rockies at Pittsburgh Pirates (Tuesday April 24, 2012)|Pittsburgh Pirates vs Colorado Rockies [04/24/2012] Tickets at StubHub!|Colorado Rockies at Pittsburgh Pirates
+701980|Philadelphia Phillies at Pittsburgh Pirates (Thursday April 5, 2012)|Pittsburgh Pirates vs Philadelphia Phillies [04/05/2012] Tickets at StubHub!|Philadelphia Phillies at Pittsburgh Pirates
+701981|Houston Astros at Pittsburgh Pirates (Wednesday September 5, 2012)|Pittsburgh Pirates vs Houston Astros [09/05/2012] Tickets at StubHub!|Houston Astros at Pittsburgh Pirates
+701982|Houston Astros at Pittsburgh Pirates (Sunday May 13, 2012)|Pittsburgh Pirates vs Houston Astros [05/13/2012] Tickets at StubHub!|Houston Astros at Pittsburgh Pirates
+701983|Philadelphia Phillies at Pittsburgh Pirates (Saturday April 7, 2012)|Pittsburgh Pirates vs Philadelphia Phillies [04/07/2012] Tickets at StubHub!|Philadelphia Phillies at Pittsburgh Pirates
+701984|Miami Marlins at Pittsburgh Pirates (Friday July 20, 2012)|Pittsburgh Pirates vs Miami Marlins [07/20/2012] Tickets at StubHub!|Miami Marlins at Pittsburgh Pirates
+701985|Detroit Tigers at Pittsburgh Pirates (Friday June 22, 2012)|Pittsburgh Pirates vs Detroit Tigers [06/22/2012] Tickets at StubHub!|Detroit Tigers at Pittsburgh Pirates
+701986|Miami Marlins at Pittsburgh Pirates (Sunday July 22, 2012)|Pittsburgh Pirates vs Miami Marlins [07/22/2012] Tickets at StubHub!|Miami Marlins at Pittsburgh Pirates
+701987|Cincinnati Reds at Pittsburgh Pirates (Monday May 28, 2012)|Pittsburgh Pirates vs Cincinnati Reds [05/28/2012] Tickets at StubHub!|Cincinnati Reds at Pittsburgh Pirates
+701988|Minnesota Twins at Pittsburgh Pirates (Wednesday June 20, 2012)|Pittsburgh Pirates vs Minnesota Twins [06/20/2012] Tickets at StubHub!|Minnesota Twins at Pittsburgh Pirates
+701989|Chicago Cubs at Pittsburgh Pirates (Tuesday July 24, 2012)|Pittsburgh Pirates vs Chicago Cubs [07/24/2012] Tickets at StubHub!|Chicago Cubs at Pittsburgh Pirates
+701990|Houston Astros at Pittsburgh Pirates (Wednesday July 4, 2012)|Pittsburgh Pirates vs Houston Astros [07/04/2012] Tickets at StubHub!|Houston Astros at Pittsburgh Pirates
+701991|Houston Astros at Pittsburgh Pirates (Tuesday July 3, 2012)|Pittsburgh Pirates vs Houston Astros [07/03/2012] Tickets at StubHub!|Houston Astros at Pittsburgh Pirates
+702746|New York Mets at Philadelphia Phillies (Wednesday May 9, 2012)|Philadelphia Phillies vs New York Mets [05/09/2012] Tickets at StubHub!|New York Mets at Philadelphia Phillies
+702747|Pittsburgh Pirates at Philadelphia Phillies (Wednesday June 27, 2012)|Philadelphia Phillies vs Pittsburgh Pirates [06/27/2012] Tickets at StubHub!|Pittsburgh Pirates at Philadelphia Phillies
+702748|Miami Marlins at Philadelphia Phillies (Wednesday September 12, 2012)|Philadelphia Phillies vs Miami Marlins [09/12/2012] Tickets at StubHub!|Miami Marlins at Philadelphia Phillies
+702749|Washington Nationals at Philadelphia Phillies (Saturday August 25, 2012)|Philadelphia Phillies vs Washington Nationals [08/25/2012] Tickets at StubHub!|Washington Nationals at Philadelphia Phillies
+702750|Atlanta Braves at Philadelphia Phillies (Sunday September 23, 2012)|Philadelphia Phillies vs Atlanta Braves [09/23/2012] Tickets at StubHub!|Atlanta Braves at Philadelphia Phillies
+702751|Atlanta Braves at Philadelphia Phillies (Wednesday August 8, 2012)|Philadelphia Phillies vs Atlanta Braves [08/08/2012] Tickets at StubHub!|Atlanta Braves at Philadelphia Phillies
+702752|Colorado Rockies at Philadelphia Phillies (Tuesday June 19, 2012)|Philadelphia Phillies vs Colorado Rockies [06/19/2012] Tickets at StubHub!|Colorado Rockies at Philadelphia Phillies
+702753|Chicago Cubs at Philadelphia Phillies (Friday April 27, 2012)|Philadelphia Phillies vs Chicago Cubs [04/27/2012] Tickets at StubHub!|Chicago Cubs at Philadelphia Phillies
+702754|San Francisco Giants at Philadelphia Phillies (Saturday July 21, 2012)|Philadelphia Phillies vs San Francisco Giants [07/21/2012] Tickets at StubHub!|San Francisco Giants at Philadelphia Phillies
+702755|Houston Astros at Philadelphia Phillies (Monday May 14, 2012)|Philadelphia Phillies vs Houston Astros [05/14/2012] Tickets at StubHub!|Houston Astros at Philadelphia Phillies
+702756|Miami Marlins at Philadelphia Phillies (Saturday June 2, 2012)|Philadelphia Phillies vs Miami Marlins [06/02/2012] Tickets at StubHub!|Miami Marlins at Philadelphia Phillies
+702757|Atlanta Braves at Philadelphia Phillies (Friday July 6, 2012)|Philadelphia Phillies vs Atlanta Braves [07/06/2012] Tickets at StubHub!|Atlanta Braves at Philadelphia Phillies
+702758|Washington Nationals at Philadelphia Phillies (Tuesday May 22, 2012)|Philadelphia Phillies vs Washington Nationals [05/22/2012] Tickets at StubHub!|Washington Nationals at Philadelphia Phillies
+702759|Arizona Diamondbacks at Philadelphia Phillies (Friday August 3, 2012)|Philadelphia Phillies vs Arizona Diamondbacks [08/03/2012] Tickets at StubHub!|Arizona Diamondbacks at Philadelphia Phillies
+702760|Pittsburgh Pirates at Philadelphia Phillies (Tuesday June 26, 2012)|Philadelphia Phillies vs Pittsburgh Pirates [06/26/2012] Tickets at StubHub!|Pittsburgh Pirates at Philadelphia Phillies
+702761|Washington Nationals at Philadelphia Phillies (Friday August 24, 2012)|Philadelphia Phillies vs Washington Nationals [08/24/2012] Tickets at StubHub!|Washington Nationals at Philadelphia Phillies
+702762|New York Mets at Philadelphia Phillies (Monday May 7, 2012)|Philadelphia Phillies vs New York Mets [05/07/2012] Tickets at StubHub!|New York Mets at Philadelphia Phillies
+702763|St Louis Cardinals at Philadelphia Phillies (Saturday Agust 11, 2012)|Philadelphia Phillies vs St Louis Cardinals [08/11/2012] Tickets at StubHub!|St. Louis Cardinals at Philadelphia Phillies
+702764|San Francisco Giants at Philadelphia Phillies (Sunday July 22, 2012)|Philadelphia Phillies vs San Francisco Giants [07/22/2012] Tickets at StubHub!|San Francisco Giants at Philadelphia Phillies
+702765|Houston Astros at Philadelphia Phillies (Tuesday May 15, 2012)|Philadelphia Phillies vs Houston Astros [05/15/2012] Tickets at StubHub!|Houston Astros at Philadelphia Phillies
+702766|Miami Marlins at Philadelphia Phillies (Friday June 1, 2012)|Philadelphia Phillies vs Miami Marlins [06/01/2012] Tickets at StubHub!|Miami Marlins at Philadelphia Phillies
+702767|Miami Marlins at Philadelphia Phillies (Monday September 10, 2012)|Philadelphia Phillies vs Miami Marlins [09/10/2012] Tickets at StubHub!|Miami Marlins at Philadelphia Phillies
+702768|New York Mets at Philadelphia Phillies (Friday April 13, 2012)|Philadelphia Phillies vs New York Mets [04/13/2012] Tickets at StubHub!|New York Mets at Philadelphia Phillies
+702769|Atlanta Braves at Philadelphia Phillies (Saturday July 7, 2012)|Philadelphia Phillies vs Atlanta Braves [07/07/2012] Tickets at StubHub!|Atlanta Braves at Philadelphia Phillies
+702770|Washington Nationals at Philadelphia Phillies (Wednesday May 23, 2012)|Philadelphia Phillies vs Washington Nationals [05/23/2012] Tickets at StubHub!|Washington Nationals at Philadelphia Phillies
+702771|Pittsburgh Pirates at Philadelphia Phillies (Monday June 25, 2012)|Philadelphia Phillies vs Phillies vs Pirates [06/25/2012] Tickets at StubHub!|Pittsburgh Pirates at Philadelphia Phillies
+702772|Atlanta Braves at Philadelphia Phillies (Friday September 21, 2012)|Philadelphia Phillies vs Atlanta Braves [09/21/2012] Tickets at StubHub!|Atlanta Braves at Philadelphia Phillies
+702773|Atlanta Braves at Philadelphia Phillies (Sunday July 8, 2012)|Philadelphia Phillies vs Atlanta Braves [07/08/2012] Tickets at StubHub!|Atlanta Braves at Philadelphia Phillies
+702774|St Louis Cardinals at Philadelphia Phillies (Friday August 10, 2012)|Philadelphia Phillies vs St Louis Cardinals [08/10/2012] Tickets at StubHub!|St. Louis Cardinals at Philadelphia Phillies
+702775|Washington Nationals at Philadelphia Phillies (Wednesday September 26, 2012)|Philadelphia Phillies vs Washington Nationals [09/26/2012] Tickets at StubHub!|Washington Nationals at Philadelphia Phillies
+702776|Chicago Cubs at Philadelphia Phillies (Sunday April 29, 2012)|Philadelphia Phillies vs Chicago Cubs [04/29/2012] Tickets at StubHub!|Chicago Cubs at Philadelphia Phillies
+702777|Milwaukee Brewers at Philadelphia Phillies (Monday July 23, 2012)|Philadelphia Phillies vs Milwaukee Brewers [07/23/2012] Tickets at StubHub!|Milwaukee Brewers at Philadelphia Phillies
+702778|San Diego Padres at Philadelphia Phillies (Saturday May 12, 2012)|Philadelphia Phillies vs San Diego Padres [05/12/2012] Tickets at StubHub!|San Diego Padres at Philadelphia Phillies
+702779|Arizona Diamondbacks at Philadelphia Phillies (Sunday August 5, 2012)|Philadelphia Phillies vs Arizona Diamondbacks [08/05/2012] Tickets at StubHub!|Arizona Diamondbacks at Philadelphia Phillies
+702780|Miami Marlins at Philadelphia Phillies (Tuesday September 11, 2012)|Philadelphia Phillies vs Miami Marlins [09/11/2012] Tickets at StubHub!|Miami Marlins at Philadelphia Phillies
+702781|Miami Marlins at Philadelphia Phillies (Thursday April 12, 2012)|Philadelphia Phillies vs Miami Marlins [04/12/2012] Tickets at StubHub!|Miami Marlins at Philadelphia Phillies
+702782|Milwaukee Brewers at Philadelphia Phillies (Tuesday July 24, 2012)|Philadelphia Phillies vs Milwaukee Brewers [07/24/2012] Tickets at StubHub!|Milwaukee Brewers at Philadelphia Phillies
+702783|Boston Red Sox at Philadelphia Phillies (Sunday May 20, 2012)|Philadelphia Phillies vs Boston Red Sox [05/20/2012] Tickets at StubHub!|Boston Red Sox at Philadelphia Phillies
+702784|Tampa Bay Rays at Philadelphia Phillies (Sunday June 24, 2012)|Philadelphia Phillies vs Tampa Bay Rays [06/24/2012] Tickets at StubHub!|Tampa Bay Rays at Philadelphia Phillies
+702785|Washington Nationals at Philadelphia Phillies (Sunday August 26, 2012)|Philadelphia Phillies vs Washington Nationals [08/26/2012] Tickets at StubHub!|Washington Nationals at Philadelphia Phillies
+702786|Cincinnati Reds at Philadelphia Phillies (Tuesday August 21, 2012)|Philadelphia Phillies vs Cincinnati Reds [08/21/2012] Tickets at StubHub!|Cincinnati Reds at Philadelphia Phillies
+702787|Washington Nationals at Philadelphia Phillies (Thursday September 27, 2012)|Philadelphia Phillies vs Washington Nationals [09/27/2012] Tickets at StubHub!|Washington Nationals at Philadelphia Phillies
+702788|Chicago Cubs at Philadelphia Phillies (Saturday April 28, 2012)|Philadelphia Phillies vs Chicago Cubs [04/28/2012] Tickets at StubHub!|Chicago Cubs at Philadelphia Phillies
+702789|San Diego Padres at Philadelphia Phillies (Sunday May 13, 2012)|Philadelphia Phillies vs San Diego Padres [05/13/2012] Tickets at StubHub!|San Diego Padres at Philadelphia Phillies
+702790|Arizona Diamondbacks at Philadelphia Phillies (Saturday August 4, 2012)|Philadelphia Phillies vs Arizona Diamondbacks [08/04/2012] Tickets at StubHub!|Arizona Diamondbacks at Philadelphia Phillies
+702791|Los Angeles Dodgers at Philadelphia Phillies (Thursday June 7, 2012)|Philadelphia Phillies vs Los Angeles Dodgers [06/07/2012] Tickets at StubHub!|Los Angeles Dodgers at Philadelphia Phillies
+702792|Colorado Rockies at Philadelphia Phillies (Saturday September 8, 2012)|Philadelphia Phillies vs Colorado Rockies [09/08/2012] Tickets at StubHub!|Colorado Rockies at Philadelphia Phillies
+702793|New York Mets at Philadelphia Phillies (Wednesday August 29, 2012)|Philadelphia Phillies vs New York Mets [08/29/2012] Tickets at StubHub!|New York Mets at Philadelphia Phillies
+702794|New York Mets at Philadelphia Phillies (Sunday April 15, 2012)|Philadelphia Phillies vs New York Mets [04/15/2012] Tickets at StubHub!|New York Mets at Philadelphia Phillies
+702795|Milwaukee Brewers at Philadelphia Phillies (Wednesday July 25, 2012)|Philadelphia Phillies vs Milwaukee Brewers [07/25/2012] Tickets at StubHub!|Milwaukee Brewers at Philadelphia Phillies
+702796|Washington Nationals at Philadelphia Phillies (Monday May 21, 2012)|Philadelphia Phillies vs Washington Nationals [05/21/2012] Tickets at StubHub!|Washington Nationals at Philadelphia Phillies
+702797|St Louis Cardinals at Philadelphia Phillies (Sunday August 12, 2012)|Philadelphia Phillies vs St Louis Cardinals [08/12/2012] Tickets at StubHub!|St. Louis Cardinals at Philadelphia Phillies
+702798|Cincinnati Reds at Philadelphia Phillies (Monday August 20, 2012)|Philadelphia Phillies vs Cincinnati Reds [08/20/2012] Tickets at StubHub!|Cincinnati Reds at Philadelphia Phillies
+702799|Tampa Bay Rays at Philadelphia Phillies (Saturday June 23, 2012)|Philadelphia Phillies vs Tampa Bay Rays [06/23/2012] Tickets at StubHub!|Tampa Bay Rays at Philadelphia Phillies
+702800|Atlanta Braves at Philadelphia Phillies (Tuesday August 7, 2012)|Philadelphia Phillies vs Atlanta Braves [08/07/2012] Tickets at StubHub!|Atlanta Braves at Philadelphia Phillies
+702801|Los Angeles Dodgers at Philadelphia Phillies (Wednesday June 6, 2012)|Philadelphia Phillies vs Los Angeles Dodgers [06/06/2012] Tickets at StubHub!|Los Angeles Dodgers at Philadelphia Phillies
+702802|Colorado Rockies at Philadelphia Phillies (Sunday September 9, 2012)|Philadelphia Phillies vs Colorado Rockies [09/09/2012] Tickets at StubHub!|Colorado Rockies at Philadelphia Phillies
+702803|New York Mets at Philadelphia Phillies (Tuesday August 28, 2012)|Philadelphia Phillies vs New York Mets [08/28/2012] Tickets at StubHub!|New York Mets at Philadelphia Phillies
+702804|New York Mets at Philadelphia Phillies (Saturday April 14, 2012)|Philadelphia Phillies vs New York Mets [04/14/2012] Tickets at StubHub!|New York Mets at Philadelphia Phillies
+702805|Boston Red Sox at Philadelphia Phillies (Friday May 18, 2012)|Philadelphia Phillies vs Boston Red Sox [05/18/2012] Tickets at StubHub!|Boston Red Sox at Philadelphia Phillies
+702806|Cincinnati Reds at Philadelphia Phillies (Thursday August 23, 2012)|Philadelphia Phillies vs Cincinnati Reds [08/23/2012] Tickets at StubHub!|Cincinnati Reds at Philadelphia Phillies
+702807|Tampa Bay Rays at Philadelphia Phillies (Friday June 22, 2012)|Philadelphia Phillies vs Tampa Bay Rays [06/22/2012] Tickets at StubHub!|Tampa Bay Rays at Philadelphia Phillies
+702808|Miami Marlins at Philadelphia Phillies (Monday April 9, 2012)|Philadelphia Phillies vs Miami Marlins [04/09/2012] Tickets at StubHub!|Miami Marlins at Philadelphia Phillies
+702809|Washington Nationals at Philadelphia Phillies (Tuesday September 25, 2012)|Philadelphia Phillies vs Washington Nationals [09/25/2012] Tickets at StubHub!|Washington Nationals at Philadelphia Phillies
+702810|Chicago Cubs at Philadelphia Phillies (Monday April 30, 2012)|Philadelphia Phillies vs Chicago Cubs [04/30/2012] Tickets at StubHub!|Chicago Cubs at Philadelphia Phillies
+702811|San Diego Padres at Philadelphia Phillies (Friday May 11, 2012)|Philadelphia Phillies vs San Diego Padres [05/11/2012] Tickets at StubHub!|San Diego Padres at Philadelphia Phillies
+702812|Atlanta Braves at Philadelphia Phillies (Monday August 6, 2012)|Philadelphia Phillies vs Atlanta Braves [08/06/2012] Tickets at StubHub!|Atlanta Braves at Philadelphia Phillies
+702813|Los Angeles Dodgers at Philadelphia Phillies (Tuesday June 5, 2012)|Philadelphia Phillies vs Los Angeles Dodgers [06/05/2012] Tickets at StubHub!|Los Angeles Dodgers at Philadelphia Phillies
+702814|Boston Red Sox at Philadelphia Phillies (Saturday May 19, 2012)|Philadelphia Phillies vs Boston Red Sox [05/19/2012] Tickets at StubHub!|Boston Red Sox at Philadelphia Phillies
+702815|Cincinnati Reds at Philadelphia Phillies (Wednesday August 22, 2012)|Philadelphia Phillies vs Cincinnati Reds [08/22/2012] Tickets at StubHub!|Cincinnati Reds at Philadelphia Phillies
+702816|Colorado Rockies at Philadelphia Phillies (Thursday June 21, 2012)|Philadelphia Phillies vs Colorado Rockies [06/21/2012] Tickets at StubHub!|Colorado Rockies at Philadelphia Phillies
+702817|New York Mets at Philadelphia Phillies (Tuesday May 8, 2012)|Philadelphia Phillies vs New York Mets [05/08/2012] Tickets at StubHub!|New York Mets at Philadelphia Phillies
+702818|Los Angeles Dodgers at Philadelphia Phillies (Monday June 4, 2012)|Philadelphia Phillies vs Los Angeles Dodgers [06/04/2012] Tickets at StubHub!|Los Angeles Dodgers at Philadelphia Phillies
+702819|New York Mets at Philadelphia Phillies (Thursday August 30, 2012)|Philadelphia Phillies vs New York Mets [08/30/2012] Tickets at StubHub!|New York Mets at Philadelphia Phillies
+702820|Atlanta Braves at Philadelphia Phillies (Saturday September 22, 2012)|Philadelphia Phillies vs Atlanta Braves [09/22/2012] Tickets at StubHub!|Atlanta Braves at Philadelphia Phillies
+702821|Pittsburgh Pirates at Philadelphia Phillies (Thursday June 28, 2012)|Philadelphia Phillies vs Pittsburgh Pirates [06/28/2012] Tickets at StubHub!|Pittsburgh Pirates at Philadelphia Phillies
+702822|Colorado Rockies at Philadelphia Phillies (Friday September 7, 2012)|Philadelphia Phillies vs Colorado Rockies [09/07/2012] Tickets at StubHub!|Colorado Rockies at Philadelphia Phillies
+702823|San Francisco Giants at Philadelphia Phillies (Friday July 20, 2012)|Philadelphia Phillies vs San Francisco Giants [07/20/2012] Tickets at StubHub!|San Francisco Giants at Philadelphia Phillies
+702824|Miami Marlins at Philadelphia Phillies (Sunday June 3, 2012)|Philadelphia Phillies vs Miami Marlins [06/03/2012] Tickets at StubHub!|Miami Marlins at Philadelphia Phillies
+702825|Colorado Rockies at Philadelphia Phillies (Wednesday June 20, 2012)|Philadelphia Phillies vs Colorado Rockies [06/20/2012] Tickets at StubHub!|Colorado Rockies at Philadelphia Phillies
+702826|Miami Marlins at Philadelphia Phillies (Wednesday April 11, 2012)|Philadelphia Phillies vs Miami Marlins [04/11/2012] Tickets at StubHub!|Miami Marlins at Philadelphia Phillies
+703065|Seattle Mariners at New York Yankees (Friday May 11, 2012)|New York Yankees vs Seattle Mariners [5/11/2012] Tickets at StubHub!|Seattle Mariners at New York Yankees
+703066|Toronto Blue Jays at New York Yankees (Wednesday August 29, 2012)|New York Yankees vs Toronto Blue Jays [8/29/2012] Tickets at StubHub!|Toronto Blue Jays at New York Yankees
+703067|Tampa Bay Rays at New York Yankees (Tuesday June 5, 2012)|New York Yankees vs Tampa Bay Rays [6/5/2012] Tickets at StubHub!|Tampa Bay Rays at New York Yankees
+703068|Tampa Bay Rays at New York Yankees (Wednesday May 9, 2012)|New York Yankees vs Tampa Bay Rays [5/9/2012] Tickets at StubHub!|Tampa Bay Rays at New York Yankees
+703069|Baltimore Orioles at New York Yankees (Friday August 31, 2012)|New York Yankees vs Baltimore Orioles [8/31/2012] Tickets at StubHub!|Baltimore Orioles at New York Yankees
+703070|Minnesota Twins at New York Yankees (Tuesday April 17, 2012)|New York Yankees vs Minnesota Twins [4/17/2012] Tickets at StubHub!|Minnesota Twins at New York Yankees
+703071|Kansas City Royals at New York Yankees (Wednesday May 23, 2012)|New York Yankees vs Kansas City Royals [5/23/2012] Tickets at StubHub!|Kansas City Royals at New York Yankees
+703072|Minnesota Twins at New York Yankees (Thursday April 19, 2012)|New York Yankees vs Minnesota Twins [4/19/2012] Tickets at StubHub!|Minnesota Twins at New York Yankees
+703073|Kansas City Royals at New York Yankees (Monday May 21, 2012)|New York Yankees vs Kansas City Royals [5/21/2012] Tickets at StubHub!|Kansas City Royals at New York Yankees
+703074|Toronto Blue Jays at New York Yankees (Monday August 27, 2012)|New York Yankees vs Toronto Blue Jays [8/27/2012] Tickets at StubHub!|Toronto Blue Jays at New York Yankees
+703075|Cincinnati Reds at New York Yankees (Saturday May 19, 2012)|New York Yankees vs Cincinnati Reds [5/19/2012] Tickets at StubHub!|Cincinnati Reds at New York Yankees
+703076|Texas Rangers at New York Yankees (Tuesday August 14, 2012)|New York Yankees vs Texas Rangers [8/14/2012] Tickets at StubHub!|Texas Rangers at New York Yankees
+703077|Chicago White Sox at New York Yankees (Friday June 29, 2012)|New York Yankees vs Chicago White Sox [6/29/2012] Tickets at StubHub!|Chicago White Sox at New York Yankees
+703078|New York Mets at New York Yankees (Sunday June 10, 2012)|New York Yankees vs New York Mets [6/10/2012] Tickets at StubHub!|New York Mets at New York Yankees
+703079|Los Angeles Angels at New York Yankees (Sunday April 15, 2012)|New York Yankees vs Los Angeles Angels [4/15/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at New York Yankees
+703080|Baltimore Orioles at New York Yankees (Tuesday July 31, 2012)|New York Yankees vs Baltimore Orioles [7/31/2012] Tickets at StubHub!|Baltimore Orioles at New York Yankees
+703081|Baltimore Orioles at New York Yankees (Tuesday May 1, 2012)|New York Yankees vs Baltimore Orioles [5/1/2012] Tickets at StubHub!|Baltimore Orioles at New York Yankees
+703082|Atlanta Braves at New York Yankees (Tuesday June 19, 2012)|New York Yankees vs Atlanta Braves [6/19/2012] Tickets at StubHub!|Atlanta Braves at New York Yankees
+703083|New York Mets at New York Yankees (Friday June 8, 2012)|New York Yankees vs New York Mets [6/8/2012] Tickets at StubHub!|New York Mets at New York Yankees
+703084|Toronto Blue Jays at New York Yankees (Tuesday July 17, 2012)|New York Yankees vs Toronto Blue Jays [7/17/2012] Tickets at StubHub!|Toronto Blue Jays at New York Yankees
+703085|Baltimore Orioles at New York Yankees (Wednesday May 2, 2012)|New York Yankees vs Baltimore Orioles [5/2/2012] Tickets at StubHub!|Baltimore Orioles at New York Yankees
+703086|Detroit Tigers at New York Yankees (Friday April 27, 2012)|New York Yankees vs Detroit Tigers [4/27/2012] Tickets at StubHub!|Detroit Tigers at New York Yankees
+703087|Los Angeles Angels at New York Yankees (Saturday July 14, 2012)|New York Yankees vs Los Angeles Angels [7/14/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at New York Yankees
+703088|Detroit Tigers at New York Yankees (Sunday April 29, 2012)|New York Yankees vs Detroit Tigers [4/29/2012] Tickets at StubHub!|Detroit Tigers at New York Yankees
+703089|Seattle Mariners at New York Yankees (Saturday May 12, 2012)|New York Yankees vs Seattle Mariners [5/12/2012] Tickets at StubHub!|Seattle Mariners at New York Yankees
+703090|Texas Rangers at New York Yankees (Thursday August 16, 2012)|New York Yankees vs Texas Rangers [8/16/2012] Tickets at StubHub!|Texas Rangers at New York Yankees
+703091|Seattle Mariners at New York Yankees (Sunday August 5, 2012)|New York Yankees vs Seattle Mariners [8/5/2012] Tickets at StubHub!|Seattle Mariners at New York Yankees
+703092|Tampa Bay Rays at New York Yankees (Thursday May 10, 2012)|New York Yankees vs Tampa Bay Rays [5/10/2012] Tickets at StubHub!|Tampa Bay Rays at New York Yankees
+703093|Boston Red Sox at New York Yankees (Saturday August 18, 2012)|New York Yankees vs Boston Red Sox [8/18/2012] Tickets at StubHub!|Boston Red Sox at New York Yankees
+703094|Tampa Bay Rays at New York Yankees (Wednesday June 6, 2012)|New York Yankees vs Tampa Bay Rays [6/6/2012] Tickets at StubHub!|Tampa Bay Rays at New York Yankees
+703095|Cleveland Indians at New York Yankees (Wednesday June 27, 2012)|New York Yankees vs Cleveland Indians [6/27/2012] Tickets at StubHub!|Cleveland Indians at New York Yankees
+703096|Tampa Bay Rays at New York Yankees (Tuesday May 8, 2012)|New York Yankees vs Tampa Bay Rays [5/8/2012] Tickets at StubHub!|Tampa Bay Rays at New York Yankees
+703097|Toronto Blue Jays at New York Yankees (Tuesday August 28, 2012)|New York Yankees vs Toronto Blue Jays [8/28/2012] Tickets at StubHub!|Toronto Blue Jays at New York Yankees
+703098|Baltimore Orioles at New York Yankees (Wednesday August 1, 2012)|New York Yankees vs Baltimore Orioles [8/1/2012] Tickets at StubHub!|Baltimore Orioles at New York Yankees
+703099|Los Angeles Angels at New York Yankees (Saturday April 14, 2012)|New York Yankees vs Los Angeles Angels [4/14/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at New York Yankees
+703100|Kansas City Royals at New York Yankees (Tuesday May 22, 2012)|New York Yankees vs Kansas City Royals [5/22/2012] Tickets at StubHub!|Kansas City Royals at New York Yankees
+703101|Seattle Mariners at New York Yankees (Friday August 3, 2012)|New York Yankees vs Seattle Mariners [8/3/2012] Tickets at StubHub!|Seattle Mariners at New York Yankees
+703102|Minnesota Twins at New York Yankees (Monday April 16, 2012)|New York Yankees vs Minnesota Twins [4/16/2012] Tickets at StubHub!|Minnesota Twins at New York Yankees
+703103|Cincinnati Reds at New York Yankees (Sunday May 20, 2012)|New York Yankees vs Cincinnati Reds [5/20/2012] Tickets at StubHub!|Cincinnati Reds at New York Yankees
+703104|Texas Rangers at New York Yankees (Monday August 13, 2012)|New York Yankees vs Texas Rangers [8/13/2012] Tickets at StubHub!|Texas Rangers at New York Yankees
+703105|Minnesota Twins at New York Yankees (Wednesday April 18, 2012)|New York Yankees vs Minnesota Twins [4/18/2012] Tickets at StubHub!|Minnesota Twins at New York Yankees
+703106|Cleveland Indians at New York Yankees (Tuesday June 26, 2012)|New York Yankees vs Cleveland Indians [6/26/2012] Tickets at StubHub!|Cleveland Indians at New York Yankees
+703107|Cincinnati Reds at New York Yankees (Friday May 18, 2012)|New York Yankees vs Cincinnati Reds [5/18/2012] Tickets at StubHub!|Cincinnati Reds at New York Yankees
+703108|Texas Rangers at New York Yankees (Wednesday August 15, 2012)|New York Yankees vs Texas Rangers [8/15/2012] Tickets at StubHub!|Texas Rangers at New York Yankees
+703109|Chicago White Sox at New York Yankees (Saturday June 30, 2012)|New York Yankees vs Chicago White Sox [6/30/2012] Tickets at StubHub!|Chicago White Sox at New York Yankees
+703110|Baltimore Orioles at New York Yankees (Saturday September 1, 2012)|New York Yankees vs Baltimore Orioles [9/1/2012] Tickets at StubHub!|Baltimore Orioles at New York Yankees
+703111|Baltimore Orioles at New York Yankees (Monday July 30, 2012)|New York Yankees vs Baltimore Orioles [7/30/2012] Tickets at StubHub!|Baltimore Orioles at New York Yankees
+703112|Chicago White Sox at New York Yankees (Thursday June 28, 2012)|New York Yankees vs Chicago White Sox [6/28/2012] Tickets at StubHub!|Chicago White Sox at New York Yankees
+703113|New York Mets at New York Yankees (Saturday June 9, 2012)|New York Yankees vs New York Mets [6/9/2012] Tickets at StubHub!|New York Mets at New York Yankees
+703114|Boston Red Sox at New York Yankees (Sunday July 29, 2012)|New York Yankees vs Boston Red Sox [7/29/2012] Tickets at StubHub!|Boston Red Sox at New York Yankees
+703115|Toronto Blue Jays at New York Yankees (Monday July 16, 2012)|New York Yankees vs Toronto Blue Jays [7/16/2012] Tickets at StubHub!|Toronto Blue Jays at New York Yankees
+703116|Atlanta Braves at New York Yankees (Wednesday June 20, 2012)|New York Yankees vs Atlanta Braves [6/20/2012] Tickets at StubHub!|Atlanta Braves at New York Yankees
+703117|Atlanta Braves at New York Yankees (Monday June 18, 2012)|New York Yankees vs Atlanta Braves [6/18/2012] Tickets at StubHub!|Atlanta Braves at New York Yankees
+703118|Cleveland Indians at New York Yankees (Monday June 25, 2012)|New York Yankees vs Cleveland Indians [6/25/2012] Tickets at StubHub!|Cleveland Indians at New York Yankees
+703119|Boston Red Sox at New York Yankees (Saturday July 28, 2012)|New York Yankees vs Boston Red Sox [7/28/2012] Tickets at StubHub!|Boston Red Sox at New York Yankees
+703120|Toronto Blue Jays at New York Yankees (Wednesday July 18, 2012)|New York Yankees vs Toronto Blue Jays [7/18/2012] Tickets at StubHub!|Toronto Blue Jays at New York Yankees
+703121|Los Angeles Angels at New York Yankees (Friday July 13, 2012)|New York Yankees vs Los Angeles Angels [7/13/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at New York Yankees
+703122|Los Angeles Angels at New York Yankees (Sunday July 15, 2012)|New York Yankees vs Los Angeles Angels [7/15/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at New York Yankees
+703123|Detroit Tigers at New York Yankees (Saturday April 28, 2012)|New York Yankees vs Detroit Tigers [4/28/2012] Tickets at StubHub!|Detroit Tigers at New York Yankees
+703124|Chicago White Sox at New York Yankees (Sunday July 1, 2012)|New York Yankees vs Chicago White Sox [7/1/2012] Tickets at StubHub!|Chicago White Sox at New York Yankees
+703125|Boston Red Sox at New York Yankees (Friday August 17, 2012)|New York Yankees vs Boston Red Sox [8/17/2012] Tickets at StubHub!|Boston Red Sox at New York Yankees
+703126|Baltimore Orioles at New York Yankees (Monday April 30, 2012)|New York Yankees vs Baltimore Orioles [4/30/2012] Tickets at StubHub!|Baltimore Orioles at New York Yankees
+703127|Boston Red Sox at New York Yankees (Friday July 27, 2012)|New York Yankees vs Boston Red Sox [7/27/2012] Tickets at StubHub!|Boston Red Sox at New York Yankees
+703128|Los Angeles Angels at New York Yankees (Friday April 13, 2012)|New York Yankees vs Los Angeles Angels [4/13/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at New York Yankees
+703129|Seattle Mariners at New York Yankees (Sunday May 13, 2012)|New York Yankees vs Seattle Mariners [5/13/2012] Tickets at StubHub!|Seattle Mariners at New York Yankees
+703130|Boston Red Sox at New York Yankees (Sunday August 19, 2012)|New York Yankees vs Boston Red Sox [8/19/2012] Tickets at StubHub!|Boston Red Sox at New York Yankees
+703131|Seattle Mariners at New York Yankees (Saturday August 4, 2012)|New York Yankees vs Seattle Mariners [8/4/2012] Tickets at StubHub!|Seattle Mariners at New York Yankees
+703132|Tampa Bay Rays at New York Yankees (Thursday June 7, 2012)|New York Yankees vs Tampa Bay Rays [6/7/2012] Tickets at StubHub!|Tampa Bay Rays at New York Yankees
+703986|Boston Red Sox at Baltimore Orioles (Saturday September 29, 2012)|Baltimore Orioles vs Boston Red Sox [9/29/2012] Tickets at StubHub!|Boston Red Sox at Baltimore Orioles
+703987|New York Yankees at Baltimore Orioles (Saturday September 8, 2012)|Baltimore Orioles vs New York Yankees [9/8/2012] Tickets at StubHub!|New York Yankees at Baltimore Orioles
+703988|Tampa Bay Rays at Baltimore Orioles (Friday May 11, 2012)|Baltimore Orioles vs Tampa Bay Rays [5/11/2012] Tickets at StubHub!|Tampa Bay Rays at Baltimore Orioles
+703989|Chicago White Sox at Baltimore Orioles (Wednesday August 29, 2012)|Baltimore Orioles vs Chicago White Sox [8/29/2012] Tickets at StubHub!|Chicago White Sox at Baltimore Orioles
+703990|Seattle Mariners at Baltimore Orioles (Monday August 6, 2012)|Baltimore Orioles vs Seattle Mariners [8/6/2012] Tickets at StubHub!|Seattle Mariners at Baltimore Orioles
+703992|Tampa Bay Rays at Baltimore Orioles (Wednesday September 12, 2012)|Baltimore Orioles vs Tampa Bay Rays [9/12/2012] Tickets at StubHub!|Tampa Bay Rays at Baltimore Orioles
+703993|Boston Red Sox at Baltimore Orioles (Wednesday May 23, 2012)|Baltimore Orioles vs Boston Red Sox [5/23/2012] Tickets at StubHub!|Boston Red Sox at Baltimore Orioles
+703994|Toronto Blue Jays at Baltimore Orioles (Saturday August 25, 2012)|Baltimore Orioles vs Toronto Blue Jays [8/25/2012] Tickets at StubHub!|Toronto Blue Jays at Baltimore Orioles
+703995|Boston Red Sox at Baltimore Orioles (Monday May 21, 2012)|Baltimore Orioles vs Boston Red Sox [5/21/2012] Tickets at StubHub!|Boston Red Sox at Baltimore Orioles
+703996|Chicago White Sox at Baltimore Orioles (Monday August 27, 2012)|Baltimore Orioles vs Chicago White Sox [8/27/2012] Tickets at StubHub!|Chicago White Sox at Baltimore Orioles
+703997|Kansas City Royals at Baltimore Orioles (Sunday August 12, 2012)|Baltimore Orioles vs Kansas City Royals [8/12/2012] Tickets at StubHub!|Kansas City Royals at Baltimore Orioles
+703998|Oakland Athletics at Baltimore Orioles (Sunday July 29, 2012)|Baltimore Orioles vs Oakland Athletics [7/29/2012] Tickets at StubHub!|Oakland Athletics at Baltimore Orioles
+703999|Boston Red Sox at Baltimore Orioles (Tuesday August 14, 2012)|Baltimore Orioles vs Boston Red Sox [8/14/2012] Tickets at StubHub!|Boston Red Sox at Baltimore Orioles
+704000|Cleveland Indians at Baltimore Orioles (Friday June 29, 2012)|Baltimore Orioles vs Cleveland Indians [6/29/2012] Tickets at StubHub!|Cleveland Indians at Baltimore Orioles
+704001|Philadelphia Phillies at Baltimore Orioles (Sunday June 10, 2012)|Baltimore Orioles vs Philadelphia Phillies [6/10/2012] Tickets at StubHub!|Philadelphia Phillies at Baltimore Orioles
+704002|New York Yankees at Baltimore Orioles (Thursday September 6, 2012)|Baltimore Orioles vs New York Yankees [9/6/2012] Tickets at StubHub!|New York Yankees at Baltimore Orioles
+704003|Seattle Mariners at Baltimore Orioles (Wednesday August 8, 2012)|Baltimore Orioles vs Seattle Mariners [8/8/2012] Tickets at StubHub!|Seattle Mariners at Baltimore Orioles
+704004|Philadelphia Phillies at Baltimore Orioles (Friday June 8, 2012)|Baltimore Orioles vs Philadelphia Phillies [6/8/2012] Tickets at StubHub!|Philadelphia Phillies at Baltimore Orioles
+704005|Kansas City Royals at Baltimore Orioles (Friday August 10, 2012)|Baltimore Orioles vs Kansas City Royals [8/10/2012] Tickets at StubHub!|Kansas City Royals at Baltimore Orioles
+704006|Pittsburgh Pirates at Baltimore Orioles (Thursday June 14, 2012)|Baltimore Orioles vs Pittsburgh Pirates [6/14/2012] Tickets at StubHub!|Pittsburgh Pirates at Baltimore Orioles
+704007|Toronto Blue Jays at Baltimore Orioles (Wednesday September 26, 2012)|Baltimore Orioles vs Toronto Blue Jays [9/26/2012] Tickets at StubHub!|Toronto Blue Jays at Baltimore Orioles
+704008|Detroit Tigers at Baltimore Orioles (Saturday July 14, 2012)|Baltimore Orioles vs Detroit Tigers [7/14/2012] Tickets at StubHub!|Detroit Tigers at Baltimore Orioles
+704009|Washington Nationals at Baltimore Orioles (Saturday June 23, 2012)|Baltimore Orioles vs Washington Nationals [6/23/2012] Tickets at StubHub!|Washington Nationals at Baltimore Orioles
+704010|Pittsburgh Pirates at Baltimore Orioles (Tuesday June 12, 2012)|Baltimore Orioles vs Pittsburgh Pirates [6/12/2012] Tickets at StubHub!|Pittsburgh Pirates at Baltimore Orioles
+704011|Toronto Blue Jays at Baltimore Orioles (Monday September 24, 2012)|Baltimore Orioles vs Toronto Blue Jays [9/24/2012] Tickets at StubHub!|Toronto Blue Jays at Baltimore Orioles
+704012|Kansas City Royals at Baltimore Orioles (Sunday May 27, 2012)|Baltimore Orioles vs Kansas City Royals [5/27/2012] Tickets at StubHub!|Kansas City Royals at Baltimore Orioles
+704013|New York Yankees at Baltimore Orioles (Monday May 14, 2012)|Baltimore Orioles vs New York Yankees [5/14/2012] Tickets at StubHub!|New York Yankees at Baltimore Orioles
+704014|Boston Red Sox at Baltimore Orioles (Sunday September 30, 2012)|Baltimore Orioles vs Boston Red Sox [9/30/2012] Tickets at StubHub!|Boston Red Sox at Baltimore Orioles
+704015|Kansas City Royals at Baltimore Orioles (Friday May 25, 2012)|Baltimore Orioles vs Kansas City Royals [5/25/2012] Tickets at StubHub!|Kansas City Royals at Baltimore Orioles
+704016|Tampa Bay Rays at Baltimore Orioles (Saturday May 12, 2012)|Baltimore Orioles vs Tampa Bay Rays [5/12/2012] Tickets at StubHub!|Tampa Bay Rays at Baltimore Orioles
+704017|Boston Red Sox at Baltimore Orioles (Thursday August 16, 2012)|Baltimore Orioles vs Boston Red Sox [8/16/2012] Tickets at StubHub!|Boston Red Sox at Baltimore Orioles
+704018|Boston Red Sox at Baltimore Orioles (Friday September 28, 2012)|Baltimore Orioles vs Boston Red Sox [9/28/2012] Tickets at StubHub!|Boston Red Sox at Baltimore Orioles
+704019|Tampa Bay Rays at Baltimore Orioles (Tuesday September 11, 2012)|Baltimore Orioles vs Tampa Bay Rays [9/11/2012] Tickets at StubHub!|Tampa Bay Rays at Baltimore Orioles
+704020|Seattle Mariners at Baltimore Orioles (Tuesday August 7, 2012)|Baltimore Orioles vs Seattle Mariners [8/7/2012] Tickets at StubHub!|Seattle Mariners at Baltimore Orioles
+704021|Tampa Bay Rays at Baltimore Orioles (Tuesday July 24, 2012)|Baltimore Orioles vs Tampa Bay Rays [7/24/2012] Tickets at StubHub!|Tampa Bay Rays at Baltimore Orioles
+704022|New York Yankees at Baltimore Orioles (Sunday September 9, 2012)|Baltimore Orioles vs New York Yankees [9/9/2012] Tickets at StubHub!|New York Yankees at Baltimore Orioles
+704023|Cleveland Indians at Baltimore Orioles (Sunday July 1, 2012)|Baltimore Orioles vs Cleveland Indians [7/1/2012] Tickets at StubHub!|Cleveland Indians at Baltimore Orioles
+704024|Chicago White Sox at Baltimore Orioles (Tuesday August 28, 2012)|Baltimore Orioles vs Chicago White Sox [8/28/2012] Tickets at StubHub!|Chicago White Sox at Baltimore Orioles
+704025|Boston Red Sox at Baltimore Orioles (Tuesday May 22, 2012)|Baltimore Orioles vs Boston Red Sox [5/22/2012] Tickets at StubHub!|Boston Red Sox at Baltimore Orioles
+704026|Chicago White Sox at Baltimore Orioles (Thursday August 30, 2012)|Baltimore Orioles vs Chicago White Sox [8/30/2012] Tickets at StubHub!|Chicago White Sox at Baltimore Orioles
+704028|Tampa Bay Rays at Baltimore Orioles (Thursday September 13, 2012)|Baltimore Orioles vs Tampa Bay Rays [9/13/2012] Tickets at StubHub!|Tampa Bay Rays at Baltimore Orioles
+704029|Tampa Bay Rays at Baltimore Orioles (Thursday July 26, 2012)|Baltimore Orioles vs Tampa Bay Rays [7/26/2012] Tickets at StubHub!|Tampa Bay Rays at Baltimore Orioles
+704030|Toronto Blue Jays at Baltimore Orioles (Friday August 24, 2012)|Baltimore Orioles vs Toronto Blue Jays [8/24/2012] Tickets at StubHub!|Toronto Blue Jays at Baltimore Orioles
+704031|Washington Nationals at Baltimore Orioles (Sunday June 24, 2012)|Baltimore Orioles vs Washington Nationals [6/24/2012] Tickets at StubHub!|Washington Nationals at Baltimore Orioles
+704032|Tampa Bay Rays at Baltimore Orioles (Wednesday July 25, 2012)|Baltimore Orioles vs Tampa Bay Rays [7/25/2012] Tickets at StubHub!|Tampa Bay Rays at Baltimore Orioles
+704033|Oakland Athletics at Baltimore Orioles (Saturday July 28, 2012)|Baltimore Orioles vs Oakland Athletics [7/28/2012] Tickets at StubHub!|Oakland Athletics at Baltimore Orioles
+704034|Toronto Blue Jays at Baltimore Orioles (Sunday August 26, 2012)|Baltimore Orioles vs Toronto Blue Jays [8/26/2012] Tickets at StubHub!|Toronto Blue Jays at Baltimore Orioles
+704035|Boston Red Sox at Baltimore Orioles (Wednesday August 15, 2012)|Baltimore Orioles vs Boston Red Sox [8/15/2012] Tickets at StubHub!|Boston Red Sox at Baltimore Orioles
+704036|Cleveland Indians at Baltimore Orioles (Saturday June 30, 2012)|Baltimore Orioles vs Cleveland Indians [6/30/2012] Tickets at StubHub!|Cleveland Indians at Baltimore Orioles
+704037|Kansas City Royals at Baltimore Orioles (Thursday August 9, 2012)|Baltimore Orioles vs Kansas City Royals [8/9/2012] Tickets at StubHub!|Kansas City Royals at Baltimore Orioles
+704038|Cleveland Indians at Baltimore Orioles (Thursday June 28, 2012)|Baltimore Orioles vs Cleveland Indians [6/28/2012] Tickets at StubHub!|Cleveland Indians at Baltimore Orioles
+704039|Philadelphia Phillies at Baltimore Orioles (Saturday June 9, 2012)|Baltimore Orioles vs Philadelphia Phillies [6/9/2012] Tickets at StubHub!|Philadelphia Phillies at Baltimore Orioles
+704040|New York Yankees at Baltimore Orioles (Friday September 7, 2012)|Baltimore Orioles vs New York Yankees [9/7/2012] Tickets at StubHub!|New York Yankees at Baltimore Orioles
+704041|Kansas City Royals at Baltimore Orioles (Saturday August 11, 2012)|Baltimore Orioles vs Kansas City Royals [8/11/2012] Tickets at StubHub!|Kansas City Royals at Baltimore Orioles
+704042|Detroit Tigers at Baltimore Orioles (Friday July 13, 2012)|Baltimore Orioles vs Detroit Tigers [7/13/2012] Tickets at StubHub!|Detroit Tigers at Baltimore Orioles
+704043|Pittsburgh Pirates at Baltimore Orioles (Wednesday June 13, 2012)|Baltimore Orioles vs Pittsburgh Pirates [6/13/2012] Tickets at StubHub!|Pittsburgh Pirates at Baltimore Orioles
+704044|Kansas City Royals at Baltimore Orioles (Saturday May 26, 2012)|Baltimore Orioles vs Kansas City Royals [5/26/2012] Tickets at StubHub!|Kansas City Royals at Baltimore Orioles
+704045|Detroit Tigers at Baltimore Orioles (Sunday July 15, 2012)|Baltimore Orioles vs Detroit Tigers [7/15/2012] Tickets at StubHub!|Detroit Tigers at Baltimore Orioles
+704046|Washington Nationals at Baltimore Orioles (Friday June 22, 2012)|Baltimore Orioles vs Washington Nationals [6/22/2012] Tickets at StubHub!|Washington Nationals at Baltimore Orioles
+704047|Toronto Blue Jays at Baltimore Orioles (Tuesday September 25, 2012)|Baltimore Orioles vs Toronto Blue Jays [9/25/2012] Tickets at StubHub!|Toronto Blue Jays at Baltimore Orioles
+704048|New York Yankees at Baltimore Orioles (Tuesday May 15, 2012)|Baltimore Orioles vs New York Yankees [5/15/2012] Tickets at StubHub!|New York Yankees at Baltimore Orioles
+704049|Oakland Athletics at Baltimore Orioles (Friday July 27, 2012)|Baltimore Orioles vs Oakland Athletics [7/27/2012] Tickets at StubHub!|Oakland Athletics at Baltimore Orioles
+704050|Tampa Bay Rays at Baltimore Orioles (Sunday May 13, 2012)|Baltimore Orioles vs Tampa Bay Rays [5/13/2012] Tickets at StubHub!|Tampa Bay Rays at Baltimore Orioles
+704088|Miami Marlins at Washington Nationals (Sat. 9/8/12)|Washington Nationals vs Miami Marlins [9/8/2012] Tickets at StubHub!|Miami Marlins at Washington Nationals
+704089|San Francisco Giants at Washington Nationals (Thu. 7/5/12)|Washington Nationals vs San Francisco Giants [7/5/2012] Tickets at StubHub!|San Francisco Giants at Washington Nationals
+704090|Colorado Rockies at Washington Nationals (Sun. 7/8/12)|Washington Nationals vs Colorado Rockies [7/8/2012] Tickets at StubHub!|Colorado Rockies at Washington Nationals
+704091|Cincinnati Reds at Washington Nationals (Sun. 4/15/12)|Washington Nationals vs Cincinnati Reds [4/15/2012] Tickets at StubHub!|Cincinnati Reds at Washington Nationals
+704092|Los Angeles Dodgers at Washington Nationals (Wed. 9/19/12)|Washington Nationals vs Los Angeles Dodgers [9/19/2012] Tickets at StubHub!|Los Angeles Dodgers at Washington Nationals
+704093|Colorado Rockies at Washington Nationals (Sat. 7/7/12)|Washington Nationals vs Colorado Rockies [7/7/2012] Tickets at StubHub!|Colorado Rockies at Washington Nationals
+704094|St Louis Cardinals at Washington Nationals (Fri. 8/31/12)|Washington Nationals vs St Louis Cardinals [8/31/2012] Tickets at StubHub!|St. Louis Cardinals at Washington Nationals
+704095|Houston Astros at Washington Nationals (Tue. 4/17/12)|Washington Nationals vs Houston Astros [4/17/2012] Tickets at StubHub!|Houston Astros at Washington Nationals
+704096|New York Mets at Washington Nationals (Wed. 6/6/12)|Washington Nationals vs New York Mets [6/6/2012] Tickets at StubHub!|New York Mets at Washington Nationals
+704097|Philadelphia Phillies at Washington Nationals (Thu. 8/2/12)|Washington Nationals vs Philadelphia Phillies [8/2/2012] Tickets at StubHub!|Philadelphia Phillies at Washington Nationals
+704098|Houston Astros at Washington Nationals (Thu. 4/19/12)|Washington Nationals vs Houston Astros [4/19/2012] Tickets at StubHub!|Houston Astros at Washington Nationals
+704099|Milwaukee Brewers at Washington Nationals (Sun. 9/23/12)|Washington Nationals vs Milwaukee Brewers [9/23/2012] Tickets at StubHub!|Milwaukee Brewers at Washington Nationals
+704100|St Louis Cardinals at Washington Nationals (Sun. 9/2/12)|Washington Nationals vs St Louis Cardinals [9/2/2012] Tickets at StubHub!|St. Louis Cardinals at Washington Nationals
+704101|Miami Marlins at Washington Nationals (Sat. 4/21/12)|Washington Nationals vs Miami Marlins [4/21/2012] Tickets at StubHub!|Miami Marlins at Washington Nationals
+704102|Milwaukee Brewers at Washington Nationals (Fri. 9/21/12)|Washington Nationals vs Milwaukee Brewers [9/21/2012] Tickets at StubHub!|Milwaukee Brewers at Washington Nationals
+704103|Baltimore Orioles at Washington Nationals (Sat. 5/19/12)|Washington Nationals vs Baltimore Orioles [5/19/2012] Tickets at StubHub!|Baltimore Orioles at Washington Nationals
+704104|Philadelphia Phillies at Washington Nationals (Sun. 5/6/12)|Washington Nationals vs Philadelphia Phillies [5/6/2012] Tickets at StubHub!|Philadelphia Phillies at Washington Nationals
+704105|New York Mets at Washington Nationals (Tue. 6/5/12)|Washington Nationals vs New York Mets [6/5/2012] Tickets at StubHub!|New York Mets at Washington Nationals
+704106|Pittsburgh Pirates at Washington Nationals (Thu. 5/17/12)|Washington Nationals vs Pittsburgh Pirates [5/17/2012] Tickets at StubHub!|Pittsburgh Pirates at Washington Nationals
+704107|Philadelphia Phillies at Washington Nationals (Fri. 5/4/12)|Washington Nationals vs Philadelphia Phillies [5/4/2012] Tickets at StubHub!|Philadelphia Phillies at Washington Nationals
+704108|Tampa Bay Rays at Washington Nationals (Tue. 6/19/12)|Washington Nationals vs Tampa Bay Rays [6/19/2012] Tickets at StubHub!|Tampa Bay Rays at Washington Nationals
+704109|Chicago Cubs at Washington Nationals (Tue. 9/4/12)|Washington Nationals vs Chicago Cubs [9/4/2012] Tickets at StubHub!|Chicago Cubs at Washington Nationals
+704110|New York Mets at Washington Nationals (Tue. 7/17/12)|Washington Nationals vs New York Mets [7/17/2012] Tickets at StubHub!|New York Mets at Washington Nationals
+704111|Arizona Diamondbacks at Washington Nationals (Wed. 5/2/12)|Washington Nationals vs Arizona Diamondbacks [5/2/2012] Tickets at StubHub!|Arizona Diamondbacks at Washington Nationals
+704112|New York Yankees at Washington Nationals (Sun. 6/17/12)|Washington Nationals vs New York Yankees [6/17/2012] Tickets at StubHub!|New York Yankees at Washington Nationals
+704113|New York Mets at Washington Nationals (Thu. 7/19/12)|Washington Nationals vs New York Mets [7/19/2012] Tickets at StubHub!|New York Mets at Washington Nationals
+704114|Atlanta Braves at Washington Nationals (Mon. 8/20/12)|Washington Nationals vs Atlanta Braves [8/20/2012] Tickets at StubHub!|Atlanta Braves at Washington Nationals
+704115|Milwaukee Brewers at Washington Nationals (Mon. 9/24/12)|Washington Nationals vs Milwaukee Brewers [9/24/2012] Tickets at StubHub!|Milwaukee Brewers at Washington Nationals
+704116|Atlanta Braves at Washington Nationals (Sat. 7/21/12)|Washington Nationals vs Atlanta Braves [7/21/2012] Tickets at StubHub!|Atlanta Braves at Washington Nationals
+704117|San Diego Padres at Washington Nationals (Mon. 5/14/12)|Washington Nationals vs San Diego Padres [5/14/2012] Tickets at StubHub!|San Diego Padres at Washington Nationals
+704118|Atlanta Braves at Washington Nationals (Wed. 8/22/12)|Washington Nationals vs Atlanta Braves [8/22/2012] Tickets at StubHub!|Atlanta Braves at Washington Nationals
+704119|Tampa Bay Rays at Washington Nationals (Thu. 6/21/12)|Washington Nationals vs Tampa Bay Rays [6/21/2012] Tickets at StubHub!|Tampa Bay Rays at Washington Nationals
+704120|Atlanta Braves at Washington Nationals (Sat. 6/2/12)|Washington Nationals vs Atlanta Braves [6/2/2012] Tickets at StubHub!|Atlanta Braves at Washington Nationals
+704121|Chicago Cubs at Washington Nationals (Thu. 9/6/12)|Washington Nationals vs Chicago Cubs [9/6/2012] Tickets at StubHub!|Chicago Cubs at Washington Nationals
+704122|Miami Marlins at Washington Nationals (Sun. 8/5/12)|Washington Nationals vs Miami Marlins [8/5/2012] Tickets at StubHub!|Miami Marlins at Washington Nationals
+704123|San Francisco Giants at Washington Nationals (Wed. 7/4/12)|Washington Nationals vs San Francisco Giants [7/4/2012] Tickets at StubHub!|San Francisco Giants at Washington Nationals
+704124|New York Mets at Washington Nationals (Sat. 8/18/12)|Washington Nationals vs New York Mets [8/18/2012] Tickets at StubHub!|New York Mets at Washington Nationals
+704125|Philadelphia Phillies at Washington Nationals (Tue. 7/31/12)|Washington Nationals vs Philadelphia Phillies [7/31/2012] Tickets at StubHub!|Philadelphia Phillies at Washington Nationals
+704126|Cincinnati Reds at Washington Nationals (Thu. 4/12/12)|Washington Nationals vs Cincinnati Reds [4/12/2012] Tickets at StubHub!|Cincinnati Reds at Washington Nationals
+704127|Los Angeles Dodgers at Washington Nationals (Tue. 9/18/12)|Washington Nationals vs Los Angeles Dodgers [9/18/2012] Tickets at StubHub!|Los Angeles Dodgers at Washington Nationals
+704128|Miami Marlins at Washington Nationals (Sun. 9/9/12)|Washington Nationals vs Miami Marlins [9/9/2012] Tickets at StubHub!|Miami Marlins at Washington Nationals
+704129|Colorado Rockies at Washington Nationals (Fri. 7/6/12)|Washington Nationals vs Colorado Rockies [7/6/2012] Tickets at StubHub!|Colorado Rockies at Washington Nationals
+704130|Philadelphia Phillies at Washington Nationals (Wed. 8/1/12)|Washington Nationals vs Philadelphia Phillies [8/1/2012] Tickets at StubHub!|Philadelphia Phillies at Washington Nationals
+704131|Cincinnati Reds at Washington Nationals (Sat. 4/14/12)|Washington Nationals vs Cincinnati Reds [4/14/2012] Tickets at StubHub!|Cincinnati Reds at Washington Nationals
+704132|St Louis Cardinals at Washington Nationals (Thu. 8/30/12)|Washington Nationals vs St Louis Cardinals [8/30/2012] Tickets at StubHub!|St. Louis Cardinals at Washington Nationals
+704133|Miami Marlins at Washington Nationals (Fri. 8/3/12)|Washington Nationals vs Miami Marlins [8/3/2012] Tickets at StubHub!|Miami Marlins at Washington Nationals
+704134|Houston Astros at Washington Nationals (Mon. 4/16/12)|Washington Nationals vs Houston Astros [4/16/2012] Tickets at StubHub!|Houston Astros at Washington Nationals
+704135|Milwaukee Brewers at Washington Nationals (Sat. 9/22/12)|Washington Nationals vs Milwaukee Brewers [9/22/2012] Tickets at StubHub!|Milwaukee Brewers at Washington Nationals
+704136|Baltimore Orioles at Washington Nationals (Sun. 5/20/12)|Washington Nationals vs Baltimore Orioles [5/20/2012] Tickets at StubHub!|Baltimore Orioles at Washington Nationals
+704137|Houston Astros at Washington Nationals (Wed. 4/18/12)|Washington Nationals vs Houston Astros [4/18/2012] Tickets at StubHub!|Houston Astros at Washington Nationals
+704138|Los Angeles Dodgers at Washington Nationals (Thu. 9/20/12)|Washington Nationals vs Los Angeles Dodgers [9/20/2012] Tickets at StubHub!|Los Angeles Dodgers at Washington Nationals
+704139|Chicago Cubs at Washington Nationals (Mon. 9/3/12)|Washington Nationals vs Chicago Cubs [9/3/2012] Tickets at StubHub!|Chicago Cubs at Washington Nationals
+704140|Baltimore Orioles at Washington Nationals (Fri. 5/18/12)|Washington Nationals vs Baltimore Orioles [5/18/2012] Tickets at StubHub!|Baltimore Orioles at Washington Nationals
+704141|Miami Marlins at Washington Nationals (Fri. 4/20/12)|Washington Nationals vs Miami Marlins [4/20/2012] Tickets at StubHub!|Miami Marlins at Washington Nationals
+704142|St Louis Cardinals at Washington Nationals (Sat. 9/1/12)|Washington Nationals vs St Louis Cardinals [9/1/2012] Tickets at StubHub!|St. Louis Cardinals at Washington Nationals
+704143|Pittsburgh Pirates at Washington Nationals (Wed. 5/16/12)|Washington Nationals vs Pittsburgh Pirates [5/16/2012] Tickets at StubHub!|Pittsburgh Pirates at Washington Nationals
+704144|Miami Marlins at Washington Nationals (Sun. 4/22/12)|Washington Nationals vs Miami Marlins [4/22/2012] Tickets at StubHub!|Miami Marlins at Washington Nationals
+704145|Miami Marlins at Washington Nationals (Fri. 9/7/12)|Washington Nationals vs Miami Marlins [9/7/2012] Tickets at StubHub!|Miami Marlins at Washington Nationals
+704146|Philadelphia Phillies at Washington Nationals (Sat. 5/5/12)|Washington Nationals vs Philadelphia Phillies [5/5/2012] Tickets at StubHub!|Philadelphia Phillies at Washington Nationals
+704147|New York Yankees at Washington Nationals (Fri. 6/15/12)|Washington Nationals vs New York Yankees [6/15/2012] Tickets at StubHub!|New York Yankees at Washington Nationals
+704148|Chicago Cubs at Washington Nationals (Wed. 9/5/12)|Washington Nationals vs Chicago Cubs [9/5/2012] Tickets at StubHub!|Chicago Cubs at Washington Nationals
+704149|New York Mets at Washington Nationals (Wed. 7/18/12)|Washington Nationals vs New York Mets [7/18/2012] Tickets at StubHub!|New York Mets at Washington Nationals
+704150|Arizona Diamondbacks at Washington Nationals (Thu. 5/3/12)|Washington Nationals vs Arizona Diamondbacks [5/3/2012] Tickets at StubHub!|Arizona Diamondbacks at Washington Nationals
+704151|Atlanta Braves at Washington Nationals (Tue. 8/21/12)|Washington Nationals vs Atlanta Braves [8/21/2012] Tickets at StubHub!|Atlanta Braves at Washington Nationals
+704152|New York Yankees at Washington Nationals (Sat. 6/16/12)|Washington Nationals vs New York Yankees [6/16/2012] Tickets at StubHub!|New York Yankees at Washington Nationals
+704153|Atlanta Braves at Washington Nationals (Fri. 7/20/12)|Washington Nationals vs Atlanta Braves [7/20/2012] Tickets at StubHub!|Atlanta Braves at Washington Nationals
+704154|Arizona Diamondbacks at Washington Nationals (Tue. 5/1/12)|Washington Nationals vs Arizona Diamondbacks [5/1/2012] Tickets at StubHub!|Arizona Diamondbacks at Washington Nationals
+704155|Atlanta Braves at Washington Nationals (Sun. 6/3/12)|Washington Nationals vs Atlanta Braves [6/3/2012] Tickets at StubHub!|Atlanta Braves at Washington Nationals
+704156|Atlanta Braves at Washington Nationals (Sun. 7/22/12)|Washington Nationals vs Atlanta Braves [7/22/2012] Tickets at StubHub!|Atlanta Braves at Washington Nationals
+704157|San Diego Padres at Washington Nationals (Tue. 5/15/12)|Washington Nationals vs San Diego Padres [5/15/2012] Tickets at StubHub!|San Diego Padres at Washington Nationals
+704158|New York Mets at Washington Nationals (Fri. 8/17/12)|Washington Nationals vs New York Mets [8/17/2012] Tickets at StubHub!|New York Mets at Washington Nationals
+704159|Tampa Bay Rays at Washington Nationals (Wed. 6/20/12)|Washington Nationals vs Tampa Bay Rays [6/20/2012] Tickets at StubHub!|Tampa Bay Rays at Washington Nationals
+704160|Atlanta Braves at Washington Nationals (Fri. 6/1/12)|Washington Nationals vs Atlanta Braves [6/1/2012] Tickets at StubHub!|Atlanta Braves at Washington Nationals
+704161|New York Mets at Washington Nationals (Thu. 6/7/12)|Washington Nationals vs New York Mets [6/7/2012] Tickets at StubHub!|New York Mets at Washington Nationals
+704162|San Francisco Giants at Washington Nationals (Tue. 7/3/12)|Washington Nationals vs San Francisco Giants [7/3/2012] Tickets at StubHub!|San Francisco Giants at Washington Nationals
+704163|New York Mets at Washington Nationals (Sun. 8/19/12)|Washington Nationals vs New York Mets [8/19/2012] Tickets at StubHub!|New York Mets at Washington Nationals
+704164|Miami Marlins at Washington Nationals (Sat. 8/4/12)|Washington Nationals vs Miami Marlins [8/4/2012] Tickets at StubHub!|Miami Marlins at Washington Nationals
+704165|Cincinnati Reds at Washington Nationals (Fri. 4/13/12)|Washington Nationals vs Cincinnati Reds [4/13/2012] Tickets at StubHub!|Cincinnati Reds at Washington Nationals
+704177|Toronto Blue Jays at Boston Red Sox (Saturday September 8, 2012)|Boston Red Sox vs Toronto Blue Jays [9/8/2012] Tickets at StubHub!|Toronto Blue Jays at Boston Red Sox
+704178|Cleveland Indians at Boston Red Sox (Friday May 11, 2012)|Boston Red Sox vs Cleveland Indians [5/11/2012] Tickets at StubHub!|Cleveland Indians at Boston Red Sox
+704179|Texas Rangers at Boston Red Sox (Monday August 6, 2012)|Boston Red Sox vs Texas Rangers [8/6/2012] Tickets at StubHub!|Texas Rangers at Boston Red Sox
+704180|Tampa Bay Rays at Boston Red Sox (Sunday Aprile 15, 2012)|Boston Red Sox vs Tampa Bay Rays [4/15/2012] Tickets at StubHub!|Tampa Bay Rays at Boston Red Sox
+704181|New York Yankees at Boston Red Sox (Saturday July 7, 2012)|Boston Red Sox vs New York Yankees [7/7/2012] Tickets at StubHub!|New York Yankees at Boston Red Sox
+704182|Chicago White Sox at Boston Red Sox (Thursday July 19, 2012)|Boston Red Sox vs Chicago White Sox [7/19/2012] Tickets at StubHub!|Chicago White Sox at Boston Red Sox
+704183|Toronto Blue Jays at Boston Red Sox (Wednesday June 27, 2012)|Boston Red Sox vs Toronto Blue Jays [6/27/2012] Tickets at StubHub!|Toronto Blue Jays at Boston Red Sox
+704184|New York Yankees at Boston Red Sox (Wednesday September 12, 2012)|Boston Red Sox vs New York Yankees [9/12/2012] Tickets at StubHub!|New York Yankees at Boston Red Sox
+704185|Kansas City Royals at Boston Red Sox (Saturday August 25, 2012)|Boston Red Sox vs Kansas City Royals [8/25/2012] Tickets at StubHub!|Kansas City Royals at Boston Red Sox
+704186|Minnesota Twins at Boston Red Sox (Thursday August 2, 2012)|Boston Red Sox vs Minnesota Twins [8/2/2012] Tickets at StubHub!|Minnesota Twins at Boston Red Sox
+704187|Toronto Blue Jays at Boston Red Sox (Monday June 25, 2012)|Boston Red Sox vs Toronto Blue Jays [6/25/2012] Tickets at StubHub!|Toronto Blue Jays at Boston Red Sox
+704188|Baltimore Orioles at Boston Red Sox (Sunday September 23, 2012)|Boston Red Sox vs Baltimore Orioles [9/23/2012] Tickets at StubHub!|Baltimore Orioles at Boston Red Sox
+704189|Kansas City Royals at Boston Red Sox (Monday August 27, 2012)|Boston Red Sox vs Kansas City Royals [8/27/2012] Tickets at StubHub!|Kansas City Royals at Boston Red Sox
+704190|Baltimore Orioles at Boston Red Sox (Sunday May 6, 2012)|Boston Red Sox vs Baltimore Orioles [5/6/2012] Tickets at StubHub!|Baltimore Orioles at Boston Red Sox
+704191|New York Yankees at Boston Red Sox (Saturday April 21, 2012)|Boston Red Sox vs New York Yankees [4/21/2012] Tickets at StubHub!|New York Yankees at Boston Red Sox
+704192|Baltimore Orioles at Boston Red Sox (Friday September 21, 2012)|Boston Red Sox vs Baltimore Orioles [9/21/2012] Tickets at StubHub!|Baltimore Orioles at Boston Red Sox
+704193|Tampa Bay Rays at Boston Red Sox (Saturday may 26, 2012)|Boston Red Sox vs Tampa Bay Rays [5/26/2012] Tickets at StubHub!|Tampa Bay Rays at Boston Red Sox
+704194|Washington Nationals at Boston Red Sox (Sunday June 10, 2012)|Boston Red Sox vs Washington Nationals [6/10/2012] Tickets at StubHub!|Washington Nationals at Boston Red Sox
+704195|Baltimore Orioles at Boston Red Sox (Tuesday June 5, 2012)|Boston Red Sox vs Baltimore Orioles [6/5/2012] Tickets at StubHub!|Baltimore Orioles at Boston Red Sox
+704196|Detroit Tigers at Boston Red Sox (Tuesday July 31, 2012)|Boston Red Sox vs Detroit Tigers [7/31/2012] Tickets at StubHub!|Detroit Tigers at Boston Red Sox
+704197|Baltimore Orioles at Boston Red Sox (Friday May 4, 2012)|Boston Red Sox vs Baltimore Orioles [5/4/2012] Tickets at StubHub!|Baltimore Orioles at Boston Red Sox
+704198|Texas Rangers at Boston Red Sox (Wednesday August 8, 2012)|Boston Red Sox vs Texas Rangers [8/8/2012] Tickets at StubHub!|Texas Rangers at Boston Red Sox
+704199|New York Yankees at Boston Red Sox (Sunday July 8, 2012)|Boston Red Sox vs New York Yankees [7/8/2012] Tickets at StubHub!|New York Yankees at Boston Red Sox
+704200|Washington Nationals at Boston Red Sox (Friday June 8, 2012)|Boston Red Sox vs Washington Nationals [6/8/2012] Tickets at StubHub!|Washington Nationals at Boston Red Sox
+704201|Detroit Tigers at Boston Red Sox (Thursday May 31, 2012)|Boston Red Sox vs Detroit Tigers [5/31/2012] Tickets at StubHub!|Detroit Tigers at Boston Red Sox
+704202|Oakland Athletics at Boston Red Sox (Wednesday May 2, 2012)|Boston Red Sox vs Oakland Athletics [5/2/2012] Tickets at StubHub!|Oakland Athletics at Boston Red Sox
+704203|Chicago White Sox at Boston Red Sox (Monday July 16, 2012)|Boston Red Sox vs Chicago White Sox [7/16/2012] Tickets at StubHub!|Chicago White Sox at Boston Red Sox
+704204|Tampa Bay Rays at Boston Red Sox (Wednesday September 26, 2012)|Boston Red Sox vs Tampa Bay Rays [9/26/2012] Tickets at StubHub!|Tampa Bay Rays at Boston Red Sox
+704205|Detroit Tigers at Boston Red Sox (Tuesday May 29, 2012)|Boston Red Sox vs Detroit Tigers [5/29/2012] Tickets at StubHub!|Detroit Tigers at Boston Red Sox
+704206|Tampa Bay Rays at Boston Red Sox (Sunday May 27, 2012)|Boston Red Sox vs Tampa Bay Rays [5/27/2012] Tickets at StubHub!|Tampa Bay Rays at Boston Red Sox
+704207|Atlanta Braves at Boston Red Sox (Saturday June 23, 2012)|Boston Red Sox vs Atlanta Braves [6/23/2012] Tickets at StubHub!|Atlanta Braves at Boston Red Sox
+704208|Toronto Blue Jays at Boston Red Sox (Saturday July 21, 2012)|Boston Red Sox vs Toronto Blue Jays [7/21/2012] Tickets at StubHub!|Toronto Blue Jays at Boston Red Sox
+704209|Seattle Mariners at Boston Red Sox (Monday May 14, 2012)|Boston Red Sox vs Seattle Mariners [5/14/2012] Tickets at StubHub!|Seattle Mariners at Boston Red Sox
+704211|Miami Marlins at Boston Red Sox (Thursday June 21, 2012)|Boston Red Sox vs Miami Marlins [6/21/2012] Tickets at StubHub!|Miami Marlins at Boston Red Sox
+704212|Tampa Bay Rays at Boston Red Sox (Friday May 25, 2012)|Boston Red Sox vs Tampa Bay Rays [5/25/2012] Tickets at StubHub!|Tampa Bay Rays at Boston Red Sox
+704213|Cleveland Indians at Boston Red Sox (Saturday May 12, 2012)|Boston Red Sox vs Cleveland Indians [5/12/2012] Tickets at StubHub!|Cleveland Indians at Boston Red Sox
+704214|Minnesota Twins at Boston Red Sox (Sunday August 5, 2012)|Boston Red Sox vs Minnesota Twins [8/5/2012] Tickets at StubHub!|Minnesota Twins at Boston Red Sox
+704215|New York Yankees at Boston Red Sox (Tuesday September 11, 2012)|Boston Red Sox vs New York Yankees [9/11/2012] Tickets at StubHub!|New York Yankees at Boston Red Sox
+704216|Cleveland Indians at Boston Red Sox (Thursday May 10, 2012)|Boston Red Sox vs Cleveland Indians [5/10/2012] Tickets at StubHub!|Cleveland Indians at Boston Red Sox
+704217|Texas Rangers at Boston Red Sox (Tuesday August 7, 2012)|Boston Red Sox vs Texas Rangers [8/7/2012] Tickets at StubHub!|Texas Rangers at Boston Red Sox
+704218|Baltimore Orioles at Boston Red Sox (Wednesday June 6, 2012)|Boston Red Sox vs Baltimore Orioles [6/6/2012] Tickets at StubHub!|Baltimore Orioles at Boston Red Sox
+704219|Texas Rangers at Boston Red Sox (Tuesday April 17, 2012)|Boston Red Sox vs Texas Rangers [4/17/2012] Tickets at StubHub!|Texas Rangers at Boston Red Sox
+704220|Toronto Blue Jays at Boston Red Sox (Sunday September 9, 2012)|Boston Red Sox vs Toronto Blue Jays [9/9/2012] Tickets at StubHub!|Toronto Blue Jays at Boston Red Sox
+704221|New York Yankees at Boston Red Sox (Friday July 6, 2012)|Boston Red Sox vs New York Yankees [7/6/2012] Tickets at StubHub!|New York Yankees at Boston Red Sox
+704222|Detroit Tigers at Boston Red Sox (Wednesday August 1, 2012)|Boston Red Sox vs Detroit Tigers [8/1/2012] Tickets at StubHub!|Detroit Tigers at Boston Red Sox
+704223|Tampa Bay Rays at Boston Red Sox (Saturday April 14, 2012)|Boston Red Sox vs Tampa Bay Rays [4/14/2012] Tickets at StubHub!|Tampa Bay Rays at Boston Red Sox
+704224|Minnesota Twins at Boston Red Sox (Friday August 3, 2012)|Boston Red Sox vs Minnesota Twins [8/3/2012] Tickets at StubHub!|Minnesota Twins at Boston Red Sox
+704225|Toronto Blue Jays at Boston Red Sox (Tuesday June 26, 2012)|Boston Red Sox vs Toronto Blue Jays [6/26/2012] Tickets at StubHub!|Toronto Blue Jays at Boston Red Sox
+704226|Baltimore Orioles at Boston Red Sox (Saturday September 22, 2012)|Boston Red Sox vs Baltimore Orioles [9/22/2012] Tickets at StubHub!|Baltimore Orioles at Boston Red Sox
+704227|New York Yankees at Boston Red Sox (Thursday September 13, 2012)|Boston Red Sox vs New York Yankees [9/13/2012] Tickets at StubHub!|New York Yankees at Boston Red Sox
+704228|Miami Marlins at Boston Red Sox (Wednesday June 20, 2012)|Boston Red Sox vs Miami Marlins [6/20/2012] Tickets at StubHub!|Miami Marlins at Boston Red Sox
+704229|Kansas City Royals at Boston Red Sox (Friday August 24, 2012)|Boston Red Sox vs Kansas City Royals [8/24/2012] Tickets at StubHub!|Kansas City Royals at Boston Red Sox
+704230|Miami Marlins at Boston Red Sox (Tuesday June 19, 2012)|Boston Red Sox vs Miami Marlins [6/19/2012] Tickets at StubHub!|Miami Marlins at Boston Red Sox
+704231|Texas Rangers at Boston Red Sox (Wednesday April 18, 2012)|Boston Red Sox vs Texas Rangers [4/18/2012] Tickets at StubHub!|Texas Rangers at Boston Red Sox
+704232|Tampa Bay Rays at Boston Red Sox (Monday April 16, 2012)|Boston Red Sox vs Tampa Bay Rays [4/16/2012] Tickets at StubHub!|Tampa Bay Rays at Boston Red Sox
+704233|Kansas City Royals at Boston Red Sox (Sunday August 26, 2012)|Boston Red Sox vs Kansas City Royals [8/26/2012] Tickets at StubHub!|Kansas City Royals at Boston Red Sox
+704234|New York Yankees at Boston Red Sox (Friday April 20, 2012)|Boston Red Sox vs New York Yankees [4/20/2012] Tickets at StubHub!|New York Yankees at Boston Red Sox
+704235|Detroit Tigers at Boston Red Sox (Monday July 30, 2012)|Boston Red Sox vs Detroit Tigers [7/30/2012] Tickets at StubHub!|Detroit Tigers at Boston Red Sox
+704236|New York Yankees at Boston Red Sox (Sunday April 22, 2012)|Boston Red Sox vs New York Yankees [4/22/2012] Tickets at StubHub!|New York Yankees at Boston Red Sox
+704237|Washington Nationals at Boston Red Sox (Saturday June 9, 2012)|Boston Red Sox vs Washington Nationals [6/9/2012] Tickets at StubHub!|Washington Nationals at Boston Red Sox
+704238|Toronto Blue Jays at Boston Red Sox (Friday September 7, 2012)|Boston Red Sox vs Toronto Blue Jays [9/7/2012] Tickets at StubHub!|Toronto Blue Jays at Boston Red Sox
+704239|Detroit Tigers at Boston Red Sox (Wednesday May 30, 2012)|Boston Red Sox vs Detroit Tigers [5/30/2012] Tickets at StubHub!|Detroit Tigers at Boston Red Sox
+704240|Baltimore Orioles at Boston Red Sox (Saturday May 5, 2012)|Boston Red Sox vs Baltimore Orioles [5/5/2012] Tickets at StubHub!|Baltimore Orioles at Boston Red Sox
+704241|Chicago White Sox at Boston Red Sox (Tuesday July 17, 2012)|Boston Red Sox vs Chicago White Sox [7/17/2012] Tickets at StubHub!|Chicago White Sox at Boston Red Sox
+704242|Detroit Tigers at Boston Red Sox (Monday May 28, 2012)|Boston Red Sox vs Detroit Tigers [5/28/2012] Tickets at StubHub!|Detroit Tigers at Boston Red Sox
+704244|Toronto Blue Jays at Boston Red Sox (Friday July 20, 2012)|Boston Red Sox vs Toronto Blue Jays [7/20/2012] Tickets at StubHub!|Toronto Blue Jays at Boston Red Sox
+704245|Oakland Athletics at Boston Red Sox (Tuesday May 1, 2012)|Boston Red Sox vs Oakland Athletics [5/1/2012] Tickets at StubHub!|Oakland Athletics at Boston Red Sox
+704247|Atlanta Braves at Boston Red Sox (Friday June 22, 2012)|Boston Red Sox vs Atlanta Braves [6/22/2012] Tickets at StubHub!|Atlanta Braves at Boston Red Sox
+704248|Tampa Bay Rays at Boston Red Sox (Tuesday September 25, 2012)|Boston Red Sox vs Tampa Bay Rays [9/25/2012] Tickets at StubHub!|Tampa Bay Rays at Boston Red Sox
+704249|Toronto Blue Jays at Boston Red Sox (Sunday July 22, 2012)|Boston Red Sox vs Toronto Blue Jays [7/22/2012] Tickets at StubHub!|Toronto Blue Jays at Boston Red Sox
+704250|Seattle Mariners at Boston Red Sox (Tuesday may 15, 2012)|Boston Red Sox vs Seattle Mariners [5/15/2012] Tickets at StubHub!|Seattle Mariners at Boston Red Sox
+704251|Chicago White Sox at Boston Red Sox (Wednesday July 18, 2012)|Boston Red Sox vs Chicago White Sox [7/18/2012] Tickets at StubHub!|Chicago White Sox at Boston Red Sox
+704252|Oakland Athletics at Boston Red Sox (Monday April 30, 2012)|Boston Red Sox vs Oakland Athletics [4/30/2012] Tickets at StubHub!|Oakland Athletics at Boston Red Sox
+704253|Atlanta Braves at Boston Red Sox (Sunday June 24, 2012)|Boston Red Sox vs Atlanta Braves [6/24/2012] Tickets at StubHub!|Atlanta Braves at Boston Red Sox
+704254|Baltimore Orioles at Boston Red Sox (Thursday June 7, 2012)|Boston Red Sox vs Baltimore Orioles [6/7/2012] Tickets at StubHub!|Baltimore Orioles at Boston Red Sox
+704255|Cleveland Indians at Boston Red Sox (Sunday May 13, 2012)|Boston Red Sox vs Cleveland Indians [5/13/2012] Tickets at StubHub!|Cleveland Indians at Boston Red Sox
+704256|Minnesota Twins at Boston Red Sox (Saturday August 4, 2012)|Boston Red Sox vs Minnesota Twins [8/4/2012] Tickets at StubHub!|Minnesota Twins at Boston Red Sox
+704257|Tampa Bay Rays at Boston Red Sox (Friday April 13, 2012)|Boston Red Sox vs Tampa Bay Rays [4/13/2012] Tickets at StubHub!|Tampa Bay Rays at Boston Red Sox
+704980|Philadelphia Phillies at Washington Nationals (Tue. 10/2/12)|Washington Nationals vs Philadelphia Phillies [10/2/2012] Tickets at StubHub!|Philadelphia Phillies at Washington Nationals
+704981|Philadelphia Phillies at Washington Nationals (Wed. 10/3/12)|Washington Nationals vs Philadelphia Phillies [10/3/2012] Tickets at StubHub!|Philadelphia Phillies at Washington Nationals
+704982|Philadelphia Phillies at Washington Nationals (Mon. 10/1/12)|Washington Nationals vs Philadelphia Phillies [10/1/2012] Tickets at StubHub!|Philadelphia Phillies at Washington Nationals
+704986|Boston Red Sox at New York Yankees (Tuesday October 2, 2012)|New York Yankees vs Boston Red Sox [10/2/2012] Tickets at StubHub!|Boston Red Sox at New York Yankees
+704987|Toronto Blue Jays at New York Yankees (Tuesday September 18, 2012)|New York Yankees vs Toronto Blue Jays [9/18/2012] Tickets at StubHub!|Toronto Blue Jays at New York Yankees
+704988|Boston Red Sox at New York Yankees (Monday October 1, 2012)|New York Yankees vs Boston Red Sox [10/1/2012] Tickets at StubHub!|Boston Red Sox at New York Yankees
+704989|Toronto Blue Jays at New York Yankees (Wednesday September 19, 2012)|New York Yankees vs Toronto Blue Jays [9/19/2012] Tickets at StubHub!|Toronto Blue Jays at New York Yankees
+704990|Tampa Bay Rays at New York Yankees (Friday September 14, 2012)|New York Yankees vs Tampa Bay Rays [9/14/2012] Tickets at StubHub!|Tampa Bay Rays at New York Yankees
+704991|Tampa Bay Rays at New York Yankees (Sunday September 16, 2012)|New York Yankees vs Tampa Bay Rays [9/16/2012] Tickets at StubHub!|Tampa Bay Rays at New York Yankees
+704992|Tampa Bay Rays at New York Yankees (Saturday September 15, 2012)|New York Yankees vs Tampa Bay Rays [9/15/2012] Tickets at StubHub!|Tampa Bay Rays at New York Yankees
+704993|Oakland Athletics at New York Yankees (Saturday September 22, 2012)|New York Yankees vs Oakland Athletics [9/22/2012] Tickets at StubHub!|Oakland Athletics at New York Yankees
+704994|Oakland Athletics at New York Yankees (Sunday September 23, 2012)|New York Yankees vs Oakland Athletics [9/23/2012] Tickets at StubHub!|Oakland Athletics at New York Yankees
+704995|Baltimore Orioles at New York Yankees (Sunday September 2, 2012)|New York Yankees vs Baltimore Orioles [9/2/2012] Tickets at StubHub!|Baltimore Orioles at New York Yankees
+704996|Toronto Blue Jays at New York Yankees (Thursday September 20, 2012)|New York Yankees vs Toronto Blue Jays [9/20/2012] Tickets at StubHub!|Toronto Blue Jays at New York Yankees
+704997|Oakland Athletics at New York Yankees (Friday September 21, 2012)|New York Yankees vs Oakland Athletics [9/21/2012] Tickets at StubHub!|Oakland Athletics at New York Yankees
+704998|Boston Red Sox at New York Yankees (Wednesday October 3, 2012)|New York Yankees vs Boston Red Sox [10/3/2012] Tickets at StubHub!|Boston Red Sox at New York Yankees
+705784|Baltimore Orioles at Minnesota Twins (Wednesday July 18, 2012)|Minnesota Twins vs Baltimore Orioles [7/18/2012] Tickets at StubHub!|Baltimore Orioles at Minnesota Twins
+705785|Toronto Blue Jays at Minnesota Twins (Friday May 11, 2012)|Minnesota Twins vs Toronto Blue Jays [5/11/2012] Tickets at StubHub!|Toronto Blue Jays at Minnesota Twins
+705786|Seattle Mariners at Minnesota Twins (Wednesday August 29, 2012)|Minnesota Twins vs Seattle Mariners [8/29/2012] Tickets at StubHub!|Seattle Mariners at Minnesota Twins
+705787|Texas Rangers at Minnesota Twins (Sunday April 15, 2012)|Minnesota Twins vs Texas Rangers [4/15/2012] Tickets at StubHub!|Texas Rangers at Minnesota Twins
+705788|Cleveland Indians at Minnesota Twins (Saturday September 8, 2012)|Minnesota Twins vs Cleveland Indians [9/8/2012] Tickets at StubHub!|Cleveland Indians at Minnesota Twins
+705789|Los Angeles Angels at Minnesota Twins (Wednesday May 9, 2012)|Minnesota Twins vs Los Angeles Angels [5/9/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Minnesota Twins
+705790|Baltimore Orioles at Minnesota Twins (Thursday July 19, 2012)|Minnesota Twins vs Baltimore Orioles [7/19/2012] Tickets at StubHub!|Baltimore Orioles at Minnesota Twins
+705791|Chicago White Sox at Minnesota Twins (Wednesday June 27, 2012)|Minnesota Twins vs Chicago White Sox [6/27/2012] Tickets at StubHub!|Chicago White Sox at Minnesota Twins
+705792|Kansas City Royals at Minnesota Twins (Wednesday September 12, 2012)|Minnesota Twins vs Kansas City Royals [9/12/2012] Tickets at StubHub!|Kansas City Royals at Minnesota Twins
+705793|Chicago White Sox at Minnesota Twins (Monday June 25, 2012)|Minnesota Twins vs Chicago White Sox [6/25/2012] Tickets at StubHub!|Chicago White Sox at Minnesota Twins
+705794|Cleveland Indians at Minnesota Twins (Friday July 27, 2012)|Minnesota Twins vs Cleveland Indians [7/27/2012] Tickets at StubHub!|Cleveland Indians at Minnesota Twins
+705795|Seattle Mariners at Minnesota Twins (Monday August 27, 2012)|Minnesota Twins vs Seattle Mariners [8/27/2012] Tickets at StubHub!|Seattle Mariners at Minnesota Twins
+705796|Tampa Bay Rays at Minnesota Twins (Sunday August 12, 2012)|Minnesota Twins vs Tampa Bay Rays [8/12/2012] Tickets at StubHub!|Tampa Bay Rays at Minnesota Twins
+705797|Kansas City Royals at Minnesota Twins (Friday June 29, 2012)|Minnesota Twins vs Kansas City Royals [6/29/2012] Tickets at StubHub!|Kansas City Royals at Minnesota Twins
+705798|Cleveland Indians at Minnesota Twins (Sunday July 29, 2012)|Minnesota Twins vs Cleveland Indians [7/29/2012] Tickets at StubHub!|Cleveland Indians at Minnesota Twins
+705799|Detroit Tigers at Minnesota Twins (Tuesday August 14, 2012)|Minnesota Twins vs Detroit Tigers [8/14/2012] Tickets at StubHub!|Detroit Tigers at Minnesota Twins
+705800|Boston Red Sox at Minnesota Twins (Monday April 23, 2012)|Minnesota Twins vs Boston Red Sox [4/23/2012] Tickets at StubHub!|Boston Red Sox at Minnesota Twins
+705801|Chicago Cubs at Minnesota Twins (Sunday June 10, 2012)|Minnesota Twins vs Chicago Cubs [6/10/2012] Tickets at StubHub!|Chicago Cubs at Minnesota Twins
+705802|Chicago White Sox at Minnesota Twins (Tuesday July 31, 2012)|Minnesota Twins vs Chicago White Sox [7/31/2012] Tickets at StubHub!|Chicago White Sox at Minnesota Twins
+705803|Boston Red Sox at Minnesota Twins (Wednesday April 25, 2012)|Minnesota Twins vs Boston Red Sox [4/25/2012] Tickets at StubHub!|Boston Red Sox at Minnesota Twins
+705804|Chicago Cubs at Minnesota Twins (Friday June 8, 2012)|Minnesota Twins vs Chicago Cubs [6/8/2012] Tickets at StubHub!|Chicago Cubs at Minnesota Twins
+705805|Baltimore Orioles at Minnesota Twins (Tuesday July 17, 2012)|Minnesota Twins vs Baltimore Orioles [7/17/2012] Tickets at StubHub!|Baltimore Orioles at Minnesota Twins
+705806|Tampa Bay Rays at Minnesota Twins (Friday August 10, 2012)|Minnesota Twins vs Tampa Bay Rays [8/10/2012] Tickets at StubHub!|Tampa Bay Rays at Minnesota Twins
+705807|Kansas City Royals at Minnesota Twins (Friday April 27, 2012)|Minnesota Twins vs Kansas City Royals [4/27/2012] Tickets at StubHub!|Kansas City Royals at Minnesota Twins
+705808|Philadelphia Phillies at Minnesota Twins (Thursday June 14, 2012)|Minnesota Twins vs Philadelphia Phillies [6/14/2012] Tickets at StubHub!|Philadelphia Phillies at Minnesota Twins
+705809|Chicago White Sox at Minnesota Twins (Friday September 14, 2012)|Minnesota Twins vs Chicago White Sox [9/14/2012] Tickets at StubHub!|Chicago White Sox at Minnesota Twins
+705810|Oakland Athletics at Minnesota Twins (Tuesday May 29, 2012)|Minnesota Twins vs Oakland Athletics [5/29/2012] Tickets at StubHub!|Oakland Athletics at Minnesota Twins
+705811|Oakland Athletics at Minnesota Twins (Saturday July 14, 2012)|Minnesota Twins vs Oakland Athletics [7/14/2012] Tickets at StubHub!|Oakland Athletics at Minnesota Twins
+705812|Kansas City Royals at Minnesota Twins (Sunday April 29, 2012)|Minnesota Twins vs Kansas City Royals [4/29/2012] Tickets at StubHub!|Kansas City Royals at Minnesota Twins
+705813|Philadelphia Phillies at Minnesota Twins (Tuesday June 12, 2012)|Minnesota Twins vs Philadelphia Phillies [6/12/2012] Tickets at StubHub!|Philadelphia Phillies at Minnesota Twins
+705814|Detroit Tigers at Minnesota Twins (Sunday May 27, 2012)|Minnesota Twins vs Detroit Tigers [5/27/2012] Tickets at StubHub!|Detroit Tigers at Minnesota Twins
+705815|Cleveland Indians at Minnesota Twins (Monday May 14, 2012)|Minnesota Twins vs Cleveland Indians [5/14/2012] Tickets at StubHub!|Cleveland Indians at Minnesota Twins
+705816|Detroit Tigers at Minnesota Twins (Monday August 13, 2012)|Minnesota Twins vs Detroit Tigers [8/13/2012] Tickets at StubHub!|Detroit Tigers at Minnesota Twins
+705817|Detroit Tigers at Minnesota Twins (Friday May 25, 2012)|Minnesota Twins vs Detroit Tigers [5/25/2012] Tickets at StubHub!|Detroit Tigers at Minnesota Twins
+705818|Toronto Blue Jays at Minnesota Twins (Saturday May 12, 2012)|Minnesota Twins vs Toronto Blue Jays [5/12/2012] Tickets at StubHub!|Toronto Blue Jays at Minnesota Twins
+705819|Kansas City Royals at Minnesota Twins (Tuesday September 11, 2012)|Minnesota Twins vs Kansas City Royals [9/11/2012] Tickets at StubHub!|Kansas City Royals at Minnesota Twins
+705820|Toronto Blue Jays at Minnesota Twins (Thursday May 10, 2012)|Minnesota Twins vs Toronto Blue Jays [5/10/2012] Tickets at StubHub!|Toronto Blue Jays at Minnesota Twins
+705821|Los Angeles Angels at Minnesota Twins (Thursday April 12, 2012)|Minnesota Twins vs Los Angeles Angels [4/12/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Minnesota Twins
+705822|Cleveland Indians at Minnesota Twins (Sunday September 9, 2012)|Minnesota Twins vs Cleveland Indians [9/9/2012] Tickets at StubHub!|Cleveland Indians at Minnesota Twins
+705823|Los Angeles Angels at Minnesota Twins (Tuesday May 8, 2012)|Minnesota Twins vs Los Angeles Angels [5/8/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Minnesota Twins
+705824|Seattle Mariners at Minnesota Twins (Tuesday August 28, 2012)|Minnesota Twins vs Seattle Mariners [8/28/2012] Tickets at StubHub!|Seattle Mariners at Minnesota Twins
+705825|Chicago White Sox at Minnesota Twins (Wednesday August 1, 2012)|Minnesota Twins vs Chicago White Sox [8/1/2012] Tickets at StubHub!|Chicago White Sox at Minnesota Twins
+705826|Texas Rangers at Minnesota Twins (Saturday April 14, 2012)|Minnesota Twins vs Texas Rangers [4/14/2012] Tickets at StubHub!|Texas Rangers at Minnesota Twins
+705827|Chicago White Sox at Minnesota Twins (Sunday September 16, 2012)|Minnesota Twins vs Chicago White Sox [9/16/2012] Tickets at StubHub!|Chicago White Sox at Minnesota Twins
+705828|Chicago White Sox at Minnesota Twins (Saturday September 15, 2012)|Minnesota Twins vs Chicago White Sox [9/15/2012] Tickets at StubHub!|Chicago White Sox at Minnesota Twins
+705829|Seattle Mariners at Minnesota Twins (Thursday August 30, 2012)|Minnesota Twins vs Seattle Mariners [8/30/2012] Tickets at StubHub!|Seattle Mariners at Minnesota Twins
+705830|Chicago White Sox at Minnesota Twins (Tuesday June 26, 2012)|Minnesota Twins vs Chicago White Sox [6/26/2012] Tickets at StubHub!|Chicago White Sox at Minnesota Twins
+705831|Kansas City Royals at Minnesota Twins (Thursday September 13, 2012)|Minnesota Twins vs Kansas City Royals [9/13/2012] Tickets at StubHub!|Kansas City Royals at Minnesota Twins
+705832|Kansas City Royals at Minnesota Twins (Sunday July 1, 2012)|Minnesota Twins vs Kansas City Royals [7/1/2012] Tickets at StubHub!|Kansas City Royals at Minnesota Twins
+705833|Baltimore Orioles at Minnesota Twins (Monday July 16, 2012)|Minnesota Twins vs Baltimore Orioles [7/16/2012] Tickets at StubHub!|Baltimore Orioles at Minnesota Twins
+705834|Cleveland Indians at Minnesota Twins (Saturday July 28, 2012)|Minnesota Twins vs Cleveland Indians [7/28/2012] Tickets at StubHub!|Cleveland Indians at Minnesota Twins
+705835|Detroit Tigers at Minnesota Twins (Wednesday August 15, 2012)|Minnesota Twins vs Detroit Tigers [8/15/2012] Tickets at StubHub!|Detroit Tigers at Minnesota Twins
+705836|Kansas City Royals at Minnesota Twins (Saturday June 30, 2012)|Minnesota Twins vs Kansas City Royals [6/30/2012] Tickets at StubHub!|Kansas City Royals at Minnesota Twins
+705837|Chicago White Sox at Minnesota Twins (Monday July 30, 2012)|Minnesota Twins vs Chicago White Sox [7/30/2012] Tickets at StubHub!|Chicago White Sox at Minnesota Twins
+705838|Los Angeles Angels at Minnesota Twins (Monday May 7, 2012)|Minnesota Twins vs Los Angeles Angels [5/7/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Minnesota Twins
+705839|Chicago Cubs at Minnesota Twins (Saturday June 9, 2012)|Minnesota Twins vs Chicago Cubs [6/9/2012] Tickets at StubHub!|Chicago Cubs at Minnesota Twins
+705840|Cleveland Indians at Minnesota Twins (Friday September 7, 2012)|Minnesota Twins vs Cleveland Indians [9/7/2012] Tickets at StubHub!|Cleveland Indians at Minnesota Twins
+705841|Oakland Athletics at Minnesota Twins (Wednesday May 30, 2012)|Minnesota Twins vs Oakland Athletics [5/30/2012] Tickets at StubHub!|Oakland Athletics at Minnesota Twins
+705842|Tampa Bay Rays at Minnesota Twins (Saturday August 11, 2012)|Minnesota Twins vs Tampa Bay Rays [8/11/2012] Tickets at StubHub!|Tampa Bay Rays at Minnesota Twins
+705843|Boston Red Sox at Minnesota Twins (Tuesday April 24, 2012)|Minnesota Twins vs Boston Red Sox [4/24/2012] Tickets at StubHub!|Boston Red Sox at Minnesota Twins
+705844|Milwaukee Brewers at Minnesota Twins (Friday June 15, 2012)|Minnesota Twins vs Milwaukee Brewers [6/15/2012] Tickets at StubHub!|Milwaukee Brewers at Minnesota Twins
+705845|Oakland Athletics at Minnesota Twins (Monday May 28, 2012)|Minnesota Twins vs Oakland Athletics [5/28/2012] Tickets at StubHub!|Oakland Athletics at Minnesota Twins
+705846|Oakland Athletics at Minnesota Twins (Friday July 13, 2012)|Minnesota Twins vs Oakland Athletics [7/13/2012] Tickets at StubHub!|Oakland Athletics at Minnesota Twins
+705847|Milwaukee Brewers at Minnesota Twins (Saturday June 16, 2012)|Minnesota Twins vs Milwaukee Brewers [6/16/2012] Tickets at StubHub!|Milwaukee Brewers at Minnesota Twins
+705848|Philadelphia Phillies at Minnesota Twins (Wednesday June 13, 2012)|Minnesota Twins vs Philadelphia Phillies [6/13/2012] Tickets at StubHub!|Philadelphia Phillies at Minnesota Twins
+705849|Detroit Tigers at Minnesota Twins (Saturday May 26, 2012)|Minnesota Twins vs Detroit Tigers [5/26/2012] Tickets at StubHub!|Detroit Tigers at Minnesota Twins
+705850|Oakland Athletics at Minnesota Twins (Sunday July 15, 2012)|Minnesota Twins vs Oakland Athletics [7/15/2012] Tickets at StubHub!|Oakland Athletics at Minnesota Twins
+705851|Kansas City Royals at Minnesota Twins (Saturday April 28, 2012)|Minnesota Twins vs Kansas City Royals [4/28/2012] Tickets at StubHub!|Kansas City Royals at Minnesota Twins
+705852|Los Angeles Angels at Minnesota Twins (Monday April 9, 2012)|Minnesota Twins vs Los Angeles Angels [4/9/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Minnesota Twins
+705853|Cleveland Indians at Minnesota Twins (Tuesday May 15, 2012)|Minnesota Twins vs Cleveland Indians [5/15/2012] Tickets at StubHub!|Cleveland Indians at Minnesota Twins
+705854|Milwaukee Brewers at Minnesota Twins (Sunday June 17, 2012)|Minnesota Twins vs Milwaukee Brewers [6/17/2012] Tickets at StubHub!|Milwaukee Brewers at Minnesota Twins
+705855|Los Angeles Angels at Minnesota Twins (Wednesday April 11, 2012)|Minnesota Twins vs Los Angeles Angels [4/11/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Minnesota Twins
+705856|Cleveland Indians at Minnesota Twins (Monday September 10, 2012)|Minnesota Twins vs Cleveland Indians [9/10/2012] Tickets at StubHub!|Cleveland Indians at Minnesota Twins
+705857|Toronto Blue Jays at Minnesota Twins (Sunday May 13, 2012)|Minnesota Twins vs Toronto Blue Jays [5/13/2012] Tickets at StubHub!|Toronto Blue Jays at Minnesota Twins
+705858|Texas Rangers at Minnesota Twins (Friday April 13, 2012)|Minnesota Twins vs Texas Rangers [4/13/2012] Tickets at StubHub!|Texas Rangers at Minnesota Twins
+709416|Houston Astros at Milwaukee Brewers (Saturday September 29, 2012)|Milwaukee Brewers vs Houston Astros [09/29/2012] Tickets at StubHub!|Houston Astros at Milwaukee Brewers
+709417|Miami Marlins at Milwaukee Brewers (Thursday July 5, 2012)|Milwaukee Brewers vs Miami Marlins [07/05/2012] Tickets at StubHub!|Miami Marlins at Milwaukee Brewers
+709418|Cincinnati Reds at Milwaukee Brewers (Monday August 6, 2012)|Milwaukee Brewers vs Cincinnati Reds [08/06/2012] Tickets at StubHub!|Cincinnati Reds at Milwaukee Brewers
+709419|Chicago Cubs at Milwaukee Brewers (Tuesday June 5, 2012)|Milwaukee Brewers vs Chicago Cubs [06/05/2012] Tickets at StubHub!|Chicago Cubs at Milwaukee Brewers
+709420|Pittsburgh Pirates at Milwaukee Brewers (Friday June 1, 2012)|Milwaukee Brewers vs Pittsburgh Pirates [06/01/2012] Tickets at StubHub!|Pittsburgh Pirates at Milwaukee Brewers
+709421|Cincinnati Reds at Milwaukee Brewers (Wednesday May 9, 2012)|Milwaukee Brewers vs Cincinnati Reds [05/09/2012] Tickets at StubHub!|Cincinnati Reds at Milwaukee Brewers
+709422|Pittsburgh Pirates at Milwaukee Brewers (Friday August 31, 2012)|Milwaukee Brewers vs Pittsburgh Pirates [08/31/2012] Tickets at StubHub!|Pittsburgh Pirates at Milwaukee Brewers
+709423|Minnesota Twins at Milwaukee Brewers (Friday May 18, 2012)|Milwaukee Brewers vs Minnesota Twins [05/18/2012] Tickets at StubHub!|Minnesota Twins at Milwaukee Brewers
+709424|Chicago Cubs at Milwaukee Brewers (Friday May 11, 2012)|Milwaukee Brewers vs Chicago Cubs [05/11/2012] Tickets at StubHub!|Chicago Cubs at Milwaukee Brewers
+709425|San Francisco Giants at Milwaukee Brewers (Wednesday May 23, 2012)|Milwaukee Brewers vs San Francisco Giants [05/23/2012] Tickets at StubHub!|San Francisco Giants at Milwaukee Brewers
+709426|Los Angeles Dodgers at Milwaukee Brewers (Thursday April 19, 2012)|Milwaukee Brewers vs Los Angeles Dodgers [04/19/2012] Tickets at StubHub!|Los Angeles Dodgers at Milwaukee Brewers
+709427|Pittsburgh Pirates at Milwaukee Brewers (Sunday September 2, 2012)|Milwaukee Brewers vs Pittsburgh Pirates [09/02/2012] Tickets at StubHub!|Pittsburgh Pirates at Milwaukee Brewers
+709428|Washington Nationals at Milwaukee Brewers (Friday July 27, 2012)|Milwaukee Brewers vs Washington Nationals [07/27/2012] Tickets at StubHub!|Washington Nationals at Milwaukee Brewers
+709429|Colorado Rockies at Milwaukee Brewers (Saturday April 21, 2012)|Milwaukee Brewers vs Colorado Rockies [04/21/2012] Tickets at StubHub!|Colorado Rockies at Milwaukee Brewers
+709430|Arizona Diamondbacks at Milwaukee Brewers (Friday June 29, 2012)|Milwaukee Brewers vs Arizona Diamondbacks [06/29/2012] Tickets at StubHub!|Arizona Diamondbacks at Milwaukee Brewers
+709431|Washington Nationals at Milwaukee Brewers (Sunday July 29, 2012)|Milwaukee Brewers vs Washington Nationals [07/29/2012] Tickets at StubHub!|Washington Nationals at Milwaukee Brewers
+709432|Minnesota Twins at Milwaukee Brewers (Saturday May 19, 2012)|Milwaukee Brewers vs Minnesota Twins [05/19/2012] Tickets at StubHub!|Minnesota Twins at Milwaukee Brewers
+709433|San Diego Padres at Milwaukee Brewers (Sunday June 10, 2012)|Milwaukee Brewers vs San Diego Padres [06/10/2012] Tickets at StubHub!|San Diego Padres at Milwaukee Brewers
+709434|Cincinnati Reds at Milwaukee Brewers (Tuesday May 8, 2012)|Milwaukee Brewers vs Cincinnati Reds [05/08/2012] Tickets at StubHub!|Cincinnati Reds at Milwaukee Brewers
+709435|Houston Astros at Milwaukee Brewers (Tuesday July 31, 2012)|Milwaukee Brewers vs Houston Astros [07/31/2012] Tickets at StubHub!|Houston Astros at Milwaukee Brewers
+709436|San Diego Padres at Milwaukee Brewers (Tuesday October 2, 2012)|Milwaukee Brewers vs San Diego Padres [10/02/2012] Tickets at StubHub!|San Diego Padres at Milwaukee Brewers
+709437|Toronto Blue Jays at Milwaukee Brewers (Tuesday June 19, 2012)|Milwaukee Brewers vs Toronto Blue Jays [06/19/2012] Tickets at StubHub!|Toronto Blue Jays at Milwaukee Brewers
+709438|San Diego Padres at Milwaukee Brewers (Friday June 8, 2012)|Milwaukee Brewers vs San Diego Padres [06/08/2012] Tickets at StubHub!|San Diego Padres at Milwaukee Brewers
+709439|St Louis Cardinals at Milwaukee Brewers (Tuesday July 17, 2012)|Milwaukee Brewers vs St Louis Cardinals [07/17/2012] Tickets at StubHub!|St. Louis Cardinals at Milwaukee Brewers
+709440|Houston Astros at Milwaukee Brewers (Tuesday April 24, 2012)|Milwaukee Brewers vs Houston Astros [04/24/2012] Tickets at StubHub!|Houston Astros at Milwaukee Brewers
+709441|New York Mets at Milwaukee Brewers (Friday September 14, 2012)|Milwaukee Brewers vs New York Mets [09/14/2012] Tickets at StubHub!|New York Mets at Milwaukee Brewers
+709442|Arizona Diamondbacks at Milwaukee Brewers (Saturday June 30, 2012)|Milwaukee Brewers vs Arizona Diamondbacks [06/30/2012] Tickets at StubHub!|Arizona Diamondbacks at Milwaukee Brewers
+709443|Pittsburgh Pirates at Milwaukee Brewers (Saturday July 14, 2012)|Milwaukee Brewers vs Pittsburgh Pirates [07/14/2012] Tickets at StubHub!|Pittsburgh Pirates at Milwaukee Brewers
+709444|Chicago Cubs at Milwaukee Brewers (Monday August 20, 2012)|Milwaukee Brewers vs Chicago Cubs [08/20/2012] Tickets at StubHub!|Chicago Cubs at Milwaukee Brewers
+709445|Houston Astros at Milwaukee Brewers (Monday April 23, 2012)|Milwaukee Brewers vs Houston Astros [04/23/2012] Tickets at StubHub!|Houston Astros at Milwaukee Brewers
+709446|St Louis Cardinals at Milwaukee Brewers (Friday April 6, 2012)|Milwaukee Brewers vs St Louis Cardinals [04/06/2012] Tickets at StubHub!|St. Louis Cardinals at Milwaukee Brewers
+709447|Chicago Cubs at Milwaukee Brewers (Wednesday August 22, 2012)|Milwaukee Brewers vs Chicago Cubs [08/22/2012] Tickets at StubHub!|Chicago Cubs at Milwaukee Brewers
+709448|St Louis Cardinals at Milwaukee Brewers (Sunday April 8, 2012)|Milwaukee Brewers vs St Louis Cardinals [04/08/2012] Tickets at StubHub!|St. Louis Cardinals at Milwaukee Brewers
+709449|Houston Astros at Milwaukee Brewers (Sunday September 30, 2012)|Milwaukee Brewers vs Houston Astros [09/30/2012] Tickets at StubHub!|Houston Astros at Milwaukee Brewers
+709450|Miami Marlins at Milwaukee Brewers (Monday July 2, 2012)|Milwaukee Brewers vs Miami Marlins [07/02/2012] Tickets at StubHub!|Miami Marlins at Milwaukee Brewers
+709451|Philadelphia Phillies at Milwaukee Brewers (Thursday August 16, 2012)|Milwaukee Brewers vs Philadelphia Phillies [08/16/2012] Tickets at StubHub!|Philadelphia Phillies at Milwaukee Brewers
+709452|Houston Astros at Milwaukee Brewers (Friday September 28, 2012)|Milwaukee Brewers vs Houston Astros [09/28/2012] Tickets at StubHub!|Houston Astros at Milwaukee Brewers
+709453|Atlanta Braves at Milwaukee Brewers (Tuesday September 11, 2012)|Milwaukee Brewers vs Atlanta Braves [09/11/2012] Tickets at StubHub!|Atlanta Braves at Milwaukee Brewers
+709454|Miami Marlins at Milwaukee Brewers (Wednesday July 4, 2012)|Milwaukee Brewers vs Miami Marlins [07/04/2012] Tickets at StubHub!|Miami Marlins at Milwaukee Brewers
+709455|Philadelphia Phillies at Milwaukee Brewers (Saturday August 18, 2012)|Milwaukee Brewers vs Philadelphia Phillies [08/18/2012] Tickets at StubHub!|Philadelphia Phillies at Milwaukee Brewers
+709456|Cincinnati Reds at Milwaukee Brewers (Tuesday August 7, 2012)|Milwaukee Brewers vs Cincinnati Reds [08/07/2012] Tickets at StubHub!|Cincinnati Reds at Milwaukee Brewers
+709457|Chicago Cubs at Milwaukee Brewers (Wednesday June 6, 2012)|Milwaukee Brewers vs Chicago Cubs [06/06/2012] Tickets at StubHub!|Chicago Cubs at Milwaukee Brewers
+709458|Los Angeles Dodgers at Milwaukee Brewers (Tuesday April 17, 2012)|Milwaukee Brewers vs Los Angeles Dodgers [04/17/2012] Tickets at StubHub!|Los Angeles Dodgers at Milwaukee Brewers
+709459|Pittsburgh Pirates at Milwaukee Brewers (Saturday June 2, 2012)|Milwaukee Brewers vs Pittsburgh Pirates [06/02/2012] Tickets at StubHub!|Pittsburgh Pirates at Milwaukee Brewers
+709460|Houston Astros at Milwaukee Brewers (Wednesday August 1, 2012)|Milwaukee Brewers vs Houston Astros [08/01/2012] Tickets at StubHub!|Houston Astros at Milwaukee Brewers
+709461|New York Mets at Milwaukee Brewers (Sunday September 16, 2012)|Milwaukee Brewers vs New York Mets [09/16/2012] Tickets at StubHub!|New York Mets at Milwaukee Brewers
+709462|New York Mets at Milwaukee Brewers (Saturday September 15, 2012)|Milwaukee Brewers vs New York Mets [09/15/2012] Tickets at StubHub!|New York Mets at Milwaukee Brewers
+709463|San Francisco Giants at Milwaukee Brewers (Tuesday May 22, 2012)|Milwaukee Brewers vs San Francisco Giants [05/22/2012] Tickets at StubHub!|San Francisco Giants at Milwaukee Brewers
+709464|Cincinnati Reds at Milwaukee Brewers (Wednesday August 8, 2012)|Milwaukee Brewers vs Cincinnati Reds [08/08/2012] Tickets at StubHub!|Cincinnati Reds at Milwaukee Brewers
+709465|Atlanta Braves at Milwaukee Brewers (Wednesday September 12, 2012)|Milwaukee Brewers vs Atlanta Braves [09/12/2012] Tickets at StubHub!|Atlanta Braves at Milwaukee Brewers
+709466|Washington Nationals at Milwaukee Brewers (Thursday July 26, 2012)|Milwaukee Brewers vs Washington Nationals [07/26/2012] Tickets at StubHub!|Washington Nationals at Milwaukee Brewers
+709467|Houston Astros at Milwaukee Brewers (Wednesday April 25, 2012)|Milwaukee Brewers vs Houston Astros [04/25/2012] Tickets at StubHub!|Houston Astros at Milwaukee Brewers
+709468|Los Angeles Dodgers at Milwaukee Brewers (Wednesday April 18, 2012)|Milwaukee Brewers vs Los Angeles Dodgers [04/18/2012] Tickets at StubHub!|Los Angeles Dodgers at Milwaukee Brewers
+709469|Washington Nationals at Milwaukee Brewers (Saturday July 28, 2012)|Milwaukee Brewers vs Washington Nationals [07/28/2012] Tickets at StubHub!|Washington Nationals at Milwaukee Brewers
+709470|Chicago Cubs at Milwaukee Brewers (Saturday May 12, 2012)|Milwaukee Brewers vs Chicago Cubs [05/12/2012] Tickets at StubHub!|Chicago Cubs at Milwaukee Brewers
+709471|Colorado Rockies at Milwaukee Brewers (Friday April 20, 2012)|Milwaukee Brewers vs Colorado Rockies [04/20/2012] Tickets at StubHub!|Colorado Rockies at Milwaukee Brewers
+709472|Pittsburgh Pirates at Milwaukee Brewers (Saturday September 1, 2012)|Milwaukee Brewers vs Pittsburgh Pirates [09/01/2012] Tickets at StubHub!|Pittsburgh Pirates at Milwaukee Brewers
+709473|Houston Astros at Milwaukee Brewers (Monday July 30, 2012)|Milwaukee Brewers vs Houston Astros [07/30/2012] Tickets at StubHub!|Houston Astros at Milwaukee Brewers
+709474|Cincinnati Reds at Milwaukee Brewers (Monday May 7, 2012)|Milwaukee Brewers vs Cincinnati Reds [05/07/2012] Tickets at StubHub!|Cincinnati Reds at Milwaukee Brewers
+709475|San Diego Padres at Milwaukee Brewers (Wednesday October 3, 2012)|Milwaukee Brewers vs San Diego Padres [10/03/2012] Tickets at StubHub!|San Diego Padres at Milwaukee Brewers
+709476|Colorado Rockies at Milwaukee Brewers (Sunday April 22, 2012)|Milwaukee Brewers vs Colorado Rockies [04/22/2012] Tickets at StubHub!|Colorado Rockies at Milwaukee Brewers
+709477|San Diego Padres at Milwaukee Brewers (Saturday June 9, 2012)|Milwaukee Brewers vs San Diego Padres [06/09/2012] Tickets at StubHub!|San Diego Padres at Milwaukee Brewers
+709478|St Louis Cardinals at Milwaukee Brewers (Monday July 16, 2012)|Milwaukee Brewers vs St Louis Cardinals [07/16/2012] Tickets at StubHub!|St. Louis Cardinals at Milwaukee Brewers
+709479|San Diego Padres at Milwaukee Brewers (Monday October 1, 2012)|Milwaukee Brewers vs San Diego Padres [10/01/2012] Tickets at StubHub!|San Diego Padres at Milwaukee Brewers
+709480|Toronto Blue Jays at Milwaukee Brewers (Monday June 18, 2012)|Milwaukee Brewers vs Toronto Blue Jays [06/18/2012] Tickets at StubHub!|Toronto Blue Jays at Milwaukee Brewers
+709481|Minnesota Twins at Milwaukee Brewers (Sunday May 20, 2012)|Milwaukee Brewers vs Minnesota Twins [05/20/2012] Tickets at StubHub!|Minnesota Twins at Milwaukee Brewers
+709482|St Louis Cardinals at Milwaukee Brewers (Wednesday July 18, 2012)|Milwaukee Brewers vs St Louis Cardinals [07/18/2012] Tickets at StubHub!|St. Louis Cardinals at Milwaukee Brewers
+709483|Pittsburgh Pirates at Milwaukee Brewers (Friday July 13, 2012)|Milwaukee Brewers vs Pittsburgh Pirates [07/13/2012] Tickets at StubHub!|Pittsburgh Pirates at Milwaukee Brewers
+709484|Chicago Cubs at Milwaukee Brewers (Tuesday August 21, 2012)|Milwaukee Brewers vs Chicago Cubs [08/21/2012] Tickets at StubHub!|Chicago Cubs at Milwaukee Brewers
+709485|St Louis Cardinals at Milwaukee Brewers (Saturday April 7, 2012)|Milwaukee Brewers vs St Louis Cardinals [04/07/2012] Tickets at StubHub!|St. Louis Cardinals at Milwaukee Brewers
+709486|Pittsburgh Pirates at Milwaukee Brewers (Sunday July 15, 2012)|Milwaukee Brewers vs Pittsburgh Pirates [07/15/2012] Tickets at StubHub!|Pittsburgh Pirates at Milwaukee Brewers
+709487|Pittsburgh Pirates at Milwaukee Brewers (Sunday June 3, 2012)|Milwaukee Brewers vs Pittsburgh Pirates [06/03/2012] Tickets at StubHub!|Pittsburgh Pirates at Milwaukee Brewers
+709488|Chicago Cubs at Milwaukee Brewers (Sunday May 13, 2012)|Milwaukee Brewers vs Chicago Cubs [05/13/2012] Tickets at StubHub!|Chicago Cubs at Milwaukee Brewers
+709489|Arizona Diamondbacks at Milwaukee Brewers (Sunday July 1, 2012)|Milwaukee Brewers vs Arizona Diamondbacks [07/01/2012] Tickets at StubHub!|Arizona Diamondbacks at Milwaukee Brewers
+709490|Philadelphia Phillies at Milwaukee Brewers (Friday August 17, 2012)|Milwaukee Brewers vs Philadelphia Phillies [08/17/2012] Tickets at StubHub!|Philadelphia Phillies at Milwaukee Brewers
+709491|Toronto Blue Jays at Milwaukee Brewers (Wednesday June 20, 2012)|Milwaukee Brewers vs Toronto Blue Jays [06/20/2012] Tickets at StubHub!|Toronto Blue Jays at Milwaukee Brewers
+709492|San Francisco Giants at Milwaukee Brewers (Monday May 21, 2012)|Milwaukee Brewers vs San Francisco Giants [05/21/2012] Tickets at StubHub!|San Francisco Giants at Milwaukee Brewers
+709493|Atlanta Braves at Milwaukee Brewers (Monday September 10, 2012)|Milwaukee Brewers vs Atlanta Braves [09/10/2012] Tickets at StubHub!|Atlanta Braves at Milwaukee Brewers
+709494|Miami Marlins at Milwaukee Brewers (Tuesdsay July 3, 2012)|Milwaukee Brewers vs Miami Marlins [07/03/2012] Tickets at StubHub!|Miami Marlins at Milwaukee Brewers
+709495|Philadelphia Phillies at Milwaukee Brewers (Sunday August 19, 2012)|Milwaukee Brewers vs Philadelphia Phillies [08/19/2012] Tickets at StubHub!|Philadelphia Phillies at Milwaukee Brewers
+709496|Chicago Cubs at Milwaukee Brewers (Thursday June 7, 2012)|Milwaukee Brewers vs Chicago Cubs [06/07/2012] Tickets at StubHub!|Chicago Cubs at Milwaukee Brewers
+710642|Detroit Tigers at Minnesota Twins (Saturday September 29, 2012)|Minnesota Twins vs Detroit Tigers [9/29/2012] Tickets at StubHub!|Detroit Tigers at Minnesota Twins
+710643|New York Yankees at Minnesota Twins (Wednesday September 26, 2012)|Minnesota Twins vs New York Yankees [9/26/2012] Tickets at StubHub!|New York Yankees at Minnesota Twins
+710644|New York Yankees at Minnesota Twins (Monday September 24, 2012)|Minnesota Twins vs New York Yankees [9/24/2012] Tickets at StubHub!|New York Yankees at Minnesota Twins
+710645|New York Yankees at Minnesota Twins (Tuesday September 25, 2012)|Minnesota Twins vs New York Yankees [9/25/2012] Tickets at StubHub!|New York Yankees at Minnesota Twins
+710646|Detroit Tigers at Minnesota Twins (Sunday September 30, 2012)|Minnesota Twins vs Detroit Tigers [9/30/2012] Tickets at StubHub!|Detroit Tigers at Minnesota Twins
+710647|Detroit Tigers at Minnesota Twins (Friday September 28, 2012)|Minnesota Twins vs Detroit Tigers [9/28/2012] Tickets at StubHub!|Detroit Tigers at Minnesota Twins
+710685|Los Angeles Angels at Texas Rangers (Sat. 9/29/12)|Texas Rangers vs Los Angeles Angels [9/29/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Texas Rangers
+710686|Los Angeles Angels at Texas Rangers (Fri. 5/11/12)|Texas Rangers vs Los Angeles Angels [5/11/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Texas Rangers
+710687|Tampa Bay Rays at Texas Rangers (Wed. 8/29/12)|Texas Rangers vs Tampa Bay Rays [8/29/2012] Tickets at StubHub!|Tampa Bay Rays at Texas Rangers
+710688|Seattle Mariners at Texas Rangers (Fri. 9/14/12)|Texas Rangers vs Seattle Mariners [9/14/2012] Tickets at StubHub!|Seattle Mariners at Texas Rangers
+710689|Minnesota Twins at Texas Rangers (Sat. 7/7/12)|Texas Rangers vs Minnesota Twins [7/7/2012] Tickets at StubHub!|Minnesota Twins at Texas Rangers
+710690|Houston Astros at Texas Rangers (Sat. 6/16/12)|Texas Rangers vs Houston Astros [6/16/2012] Tickets at StubHub!|Houston Astros at Texas Rangers
+710691|Detroit Tigers at Texas Rangers (Wed. 6/27/12)|Texas Rangers vs Detroit Tigers [6/27/2012] Tickets at StubHub!|Detroit Tigers at Texas Rangers
+710692|Cleveland Indians at Texas Rangers (Wed. 9/12/12)|Texas Rangers vs Cleveland Indians [9/12/2012] Tickets at StubHub!|Cleveland Indians at Texas Rangers
+710693|Boston Red Sox at Texas Rangers (Wed. 7/25/12)|Texas Rangers vs Boston Red Sox [7/25/2012] Tickets at StubHub!|Boston Red Sox at Texas Rangers
+710694|Minnesota Twins at Texas Rangers (Sat. 8/25/12)|Texas Rangers vs Minnesota Twins [8/25/2012] Tickets at StubHub!|Minnesota Twins at Texas Rangers
+710695|Los Angeles Angels at Texas Rangers (Thu. 8/2/12)|Texas Rangers vs Los Angeles Angels [8/2/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Texas Rangers
+710696|Detroit Tigers at Texas Rangers (Mon. 6/25/12)|Texas Rangers vs Detroit Tigers [6/25/2012] Tickets at StubHub!|Detroit Tigers at Texas Rangers
+710697|Chicago White Sox at Texas Rangers (Fri. 7/27/12)|Texas Rangers vs Chicago White Sox [7/27/2012] Tickets at StubHub!|Chicago White Sox at Texas Rangers
+710698|Tampa Bay Rays at Texas Rangers (Mon. 8/27/12)|Texas Rangers vs Tampa Bay Rays [8/27/2012] Tickets at StubHub!|Tampa Bay Rays at Texas Rangers
+710699|Detroit Tigers at Texas Rangers (Sun. 8/12/12)|Texas Rangers vs Detroit Tigers [8/12/2012] Tickets at StubHub!|Detroit Tigers at Texas Rangers
+710700|Chicago White Sox at Texas Rangers (Sun. 7/29/12)|Texas Rangers vs Chicago White Sox [7/29/2012] Tickets at StubHub!|Chicago White Sox at Texas Rangers
+710701|Minnesota Twins at Texas Rangers (Sun. 7/8/12)|Texas Rangers vs Minnesota Twins [7/8/2012] Tickets at StubHub!|Minnesota Twins at Texas Rangers
+710702|Oakland Athletics at Texas Rangers (Fri. 6/29/12)|Texas Rangers vs Oakland Athletics [6/29/2012] Tickets at StubHub!|Oakland Athletics at Texas Rangers
+710703|Oakland Athletics at Texas Rangers (Thu. 5/17/12)|Texas Rangers vs Oakland Athletics [5/17/2012] Tickets at StubHub!|Oakland Athletics at Texas Rangers
+710704|Colorado Rockies at Texas Rangers (Sat. 6/23/12)|Texas Rangers vs Colorado Rockies [6/23/2012] Tickets at StubHub!|Colorado Rockies at Texas Rangers
+710705|New York Yankees at Texas Rangers (Wed. 4/25/12)|Texas Rangers vs New York Yankees [4/25/2012] Tickets at StubHub!|New York Yankees at Texas Rangers
+710706|Detroit Tigers at Texas Rangers (Fri. 8/10/12)|Texas Rangers vs Detroit Tigers [8/10/2012] Tickets at StubHub!|Detroit Tigers at Texas Rangers
+710707|Tampa Bay Rays at Texas Rangers (Fri. 4/27/12)|Texas Rangers vs Tampa Bay Rays [4/27/2012] Tickets at StubHub!|Tampa Bay Rays at Texas Rangers
+710708|Arizona Diamondbacks at Texas Rangers (Thu. 6/14/12)|Texas Rangers vs Arizona Diamondbacks [6/14/2012] Tickets at StubHub!|Arizona Diamondbacks at Texas Rangers
+710709|Oakland Athletics at Texas Rangers (Wed. 9/26/12)|Texas Rangers vs Oakland Athletics [9/26/2012] Tickets at StubHub!|Oakland Athletics at Texas Rangers
+710710|Seattle Mariners at Texas Rangers (Tue. 5/29/12)|Texas Rangers vs Seattle Mariners [5/29/2012] Tickets at StubHub!|Seattle Mariners at Texas Rangers
+710711|Colorado Rockies at Texas Rangers (Fri. 6/22/12)|Texas Rangers vs Colorado Rockies [6/22/2012] Tickets at StubHub!|Colorado Rockies at Texas Rangers
+710712|Baltimore Orioles at Texas Rangers (Mon. 8/20/12)|Texas Rangers vs Baltimore Orioles [8/20/2012] Tickets at StubHub!|Baltimore Orioles at Texas Rangers
+710713|Tampa Bay Rays at Texas Rangers (Sun. 4/29/12)|Texas Rangers vs Tampa Bay Rays [4/29/2012] Tickets at StubHub!|Tampa Bay Rays at Texas Rangers
+710714|Chicago White Sox at Texas Rangers (Fri. 4/6/12)|Texas Rangers vs Chicago White Sox [4/6/2012] Tickets at StubHub!|Chicago White Sox at Texas Rangers
+710715|Oakland Athletics at Texas Rangers (Mon. 9/24/12)|Texas Rangers vs Oakland Athletics [9/24/2012] Tickets at StubHub!|Oakland Athletics at Texas Rangers
+710716|Toronto Blue Jays at Texas Rangers (Sun. 5/27/12)|Texas Rangers vs Toronto Blue Jays [5/27/2012] Tickets at StubHub!|Toronto Blue Jays at Texas Rangers
+710717|Kansas City Royals at Texas Rangers (Mon. 5/14/12)|Texas Rangers vs Kansas City Royals [5/14/2012] Tickets at StubHub!|Kansas City Royals at Texas Rangers
+710718|Baltimore Orioles at Texas Rangers (Wed. 8/22/12)|Texas Rangers vs Baltimore Orioles [8/22/2012] Tickets at StubHub!|Baltimore Orioles at Texas Rangers
+710719|Chicago White Sox at Texas Rangers (Sun. 4/8/12)|Texas Rangers vs Chicago White Sox [4/8/2012] Tickets at StubHub!|Chicago White Sox at Texas Rangers
+710720|Los Angeles Angels at Texas Rangers (Sun. 9/30/12)|Texas Rangers vs Los Angeles Angels [9/30/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Texas Rangers
+710721|Toronto Blue Jays at Texas Rangers (Fri. 5/25/12)|Texas Rangers vs Toronto Blue Jays [5/25/2012] Tickets at StubHub!|Toronto Blue Jays at Texas Rangers
+710722|Los Angeles Angels at Texas Rangers (Sat. 5/12/12)|Texas Rangers vs Los Angeles Angels [5/12/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Texas Rangers
+710723|Seattle Mariners at Texas Rangers (Tue. 4/10/12)|Texas Rangers vs Seattle Mariners [4/10/2012] Tickets at StubHub!|Seattle Mariners at Texas Rangers
+710724|Los Angeles Angels at Texas Rangers (Fri. 9/28/12)|Texas Rangers vs Los Angeles Angels [9/28/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Texas Rangers
+710725|Cleveland Indians at Texas Rangers (Tue. 9/11/12)|Texas Rangers vs Cleveland Indians [9/11/2012] Tickets at StubHub!|Cleveland Indians at Texas Rangers
+710726|Los Angeles Angels at Texas Rangers (Tue. 7/31/12)|Texas Rangers vs Los Angeles Angels [7/31/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Texas Rangers
+710727|Seattle Mariners at Texas Rangers (Thu. 4/12/12)|Texas Rangers vs Seattle Mariners [4/12/2012] Tickets at StubHub!|Seattle Mariners at Texas Rangers
+710728|Arizona Diamondbacks at Texas Rangers (Tue. 6/12/12)|Texas Rangers vs Arizona Diamondbacks [6/12/2012] Tickets at StubHub!|Arizona Diamondbacks at Texas Rangers
+710729|Arizona Diamondbacks at Texas Rangers (Wed. 6/13/12)|Texas Rangers vs Arizona Diamondbacks [6/13/2012] Tickets at StubHub!|Arizona Diamondbacks at Texas Rangers
+710730|Minnesota Twins at Texas Rangers (Fri. 7/6/12)|Texas Rangers vs Minnesota Twins [7/6/2012] Tickets at StubHub!|Minnesota Twins at Texas Rangers
+710731|Tampa Bay Rays at Texas Rangers (Tue. 8/28/12)|Texas Rangers vs Tampa Bay Rays [8/28/2012] Tickets at StubHub!|Tampa Bay Rays at Texas Rangers
+710732|Los Angeles Angels at Texas Rangers (Wed. 8/1/12)|Texas Rangers vs Los Angeles Angels [8/1/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Texas Rangers
+710733|Seattle Mariners at Texas Rangers (Sun. 9/16/12)|Texas Rangers vs Seattle Mariners [9/16/2012] Tickets at StubHub!|Seattle Mariners at Texas Rangers
+710734|Seattle Mariners at Texas Rangers (Sat. 9/15/12)|Texas Rangers vs Seattle Mariners [9/15/2012] Tickets at StubHub!|Seattle Mariners at Texas Rangers
+710735|Boston Red Sox at Texas Rangers (Tue. 7/24/12)|Texas Rangers vs Boston Red Sox [7/24/2012] Tickets at StubHub!|Boston Red Sox at Texas Rangers
+710736|Los Angeles Angels at Texas Rangers (Mon. 7/30/12)|Texas Rangers vs Los Angeles Angels [7/30/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Texas Rangers
+710737|Cleveland Indians at Texas Rangers (Thu. 9/13/12)|Texas Rangers vs Cleveland Indians [9/13/2012] Tickets at StubHub!|Cleveland Indians at Texas Rangers
+710738|Boston Red Sox at Texas Rangers (Mon. 7/23/12)|Texas Rangers vs Boston Red Sox [7/23/2012] Tickets at StubHub!|Boston Red Sox at Texas Rangers
+710739|Minnesota Twins at Texas Rangers (Fri. 8/24/12)|Texas Rangers vs Minnesota Twins [8/24/2012] Tickets at StubHub!|Minnesota Twins at Texas Rangers
+710740|Colorado Rockies at Texas Rangers (Sun. 6/24/12)|Texas Rangers vs Colorado Rockies [6/24/2012] Tickets at StubHub!|Colorado Rockies at Texas Rangers
+710741|Detroit Tigers at Texas Rangers (Tue. 6/26/12)|Texas Rangers vs Detroit Tigers [6/26/2012] Tickets at StubHub!|Detroit Tigers at Texas Rangers
+710742|Chicago White Sox at Texas Rangers (Sat. 7/28/12)|Texas Rangers vs Chicago White Sox [7/28/2012] Tickets at StubHub!|Chicago White Sox at Texas Rangers
+710743|Minnesota Twins at Texas Rangers (Sun. 8/26/12)|Texas Rangers vs Minnesota Twins [8/26/2012] Tickets at StubHub!|Minnesota Twins at Texas Rangers
+710744|Oakland Athletics at Texas Rangers (Sat. 6/30/12)|Texas Rangers vs Oakland Athletics [6/30/2012] Tickets at StubHub!|Oakland Athletics at Texas Rangers
+710745|Oakland Athletics at Texas Rangers (Wed. 5/16/12)|Texas Rangers vs Oakland Athletics [5/16/2012] Tickets at StubHub!|Oakland Athletics at Texas Rangers
+710746|Oakland Athletics at Texas Rangers (Thu. 6/28/12)|Texas Rangers vs Oakland Athletics [6/28/2012] Tickets at StubHub!|Oakland Athletics at Texas Rangers
+710747|Seattle Mariners at Texas Rangers (Wed. 5/30/12)|Texas Rangers vs Seattle Mariners [5/30/2012] Tickets at StubHub!|Seattle Mariners at Texas Rangers
+710748|New York Yankees at Texas Rangers (Mon. 4/23/12)|Texas Rangers vs New York Yankees [4/23/2012] Tickets at StubHub!|New York Yankees at Texas Rangers
+710749|Detroit Tigers at Texas Rangers (Sat. 8/11/12)|Texas Rangers vs Detroit Tigers [8/11/2012] Tickets at StubHub!|Detroit Tigers at Texas Rangers
+710750|New York Yankees at Texas Rangers (Tue. 4/24/12)|Texas Rangers vs New York Yankees [4/24/2012] Tickets at StubHub!|New York Yankees at Texas Rangers
+710751|Houston Astros at Texas Rangers (Fri. 6/15/12)|Texas Rangers vs Houston Astros [6/15/2012] Tickets at StubHub!|Houston Astros at Texas Rangers
+710752|Seattle Mariners at Texas Rangers (Mon. 5/28/12)|Texas Rangers vs Seattle Mariners [5/28/2012] Tickets at StubHub!|Seattle Mariners at Texas Rangers
+710753|Baltimore Orioles at Texas Rangers (Tue. 8/21/12)|Texas Rangers vs Baltimore Orioles [8/21/2012] Tickets at StubHub!|Baltimore Orioles at Texas Rangers
+710754|Kansas City Royals at Texas Rangers (Tue. 5/15/12)|Texas Rangers vs Kansas City Royals [5/15/2012] Tickets at StubHub!|Kansas City Royals at Texas Rangers
+710755|Chicago White Sox at Texas Rangers (Sat. 4/7/12)|Texas Rangers vs Chicago White Sox [4/7/2012] Tickets at StubHub!|Chicago White Sox at Texas Rangers
+710756|Oakland Athletics at Texas Rangers (Thu. 9/27/12)|Texas Rangers vs Oakland Athletics [9/27/2012] Tickets at StubHub!|Oakland Athletics at Texas Rangers
+710757|Toronto Blue Jays at Texas Rangers (Sat. 5/26/12)|Texas Rangers vs Toronto Blue Jays [5/26/2012] Tickets at StubHub!|Toronto Blue Jays at Texas Rangers
+710758|Minnesota Twins at Texas Rangers (Thu. 8/23/12)|Texas Rangers vs Minnesota Twins [8/23/2012] Tickets at StubHub!|Minnesota Twins at Texas Rangers
+710759|Tampa Bay Rays at Texas Rangers (Sat. 4/28/12)|Texas Rangers vs Tampa Bay Rays [4/28/2012] Tickets at StubHub!|Tampa Bay Rays at Texas Rangers
+710760|Seattle Mariners at Texas Rangers (Mon. 4/9/12)|Texas Rangers vs Seattle Mariners [4/9/2012] Tickets at StubHub!|Seattle Mariners at Texas Rangers
+710761|Oakland Athletics at Texas Rangers (Tue. 9/25/12)|Texas Rangers vs Oakland Athletics [9/25/2012] Tickets at StubHub!|Oakland Athletics at Texas Rangers
+710762|Oakland Athletics at Texas Rangers (Sun. 7/1/12)|Texas Rangers vs Oakland Athletics [7/1/2012] Tickets at StubHub!|Oakland Athletics at Texas Rangers
+710763|Houston Astros at Texas Rangers (Sun. 6/17/12)|Texas Rangers vs Houston Astros [6/17/2012] Tickets at StubHub!|Houston Astros at Texas Rangers
+710764|Seattle Mariners at Texas Rangers (Wed. 4/11/12)|Texas Rangers vs Seattle Mariners [4/11/2012] Tickets at StubHub!|Seattle Mariners at Texas Rangers
+710765|Los Angeles Angels at Texas Rangers (Sun. 5/13/12)|Texas Rangers vs Los Angeles Angels [5/13/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Texas Rangers
+711261|Minnesota Twins at Detroit Tigers (Thursday July 5, 2012)|Detroit Tigers vs Minnesota Twins [7/5/2012] Tickets at StubHub!|Minnesota Twins at Detroit Tigers
+711263|Texas Rangers at Detroit Tigers (Thursday April 19, 2012)|Detroit Tigers vs Texas Rangers [4/19/2012] Tickets at StubHub!|Texas Rangers at Detroit Tigers
+711264|Minnesota Twins at Detroit Tigers (Sunday September 23, 2012)|Detroit Tigers vs Minnesota Twins [9/23/2012] Tickets at StubHub!|Minnesota Twins at Detroit Tigers
+711265|Chicago White Sox at Detroit Tigers (Sunday May 6, 2012)|Detroit Tigers vs Chicago White Sox [5/6/2012] Tickets at StubHub!|Chicago White Sox at Detroit Tigers
+711266|Minnesota Twins at Detroit Tigers (Thursday May 17, 2012)|Detroit Tigers vs Minnesota Twins [5/17/2012] Tickets at StubHub!|Minnesota Twins at Detroit Tigers
+711267|New York Yankees at Detroit Tigers (Wednesday August 8, 2012)|Detroit Tigers vs New York Yankees [8/8/2012] Tickets at StubHub!|New York Yankees at Detroit Tigers
+711268|St. Louis Cardinals at Detroit Tigers (Tuesday June 19, 2012)|Detroit Tigers vs St. Louis Cardinals [6/19/2012] Tickets at StubHub!|St. Louis Cardinals at Detroit Tigers
+711269|Cleveland Indians at Detroit Tigers (Tuesday September 4, 2012)|Detroit Tigers vs Cleveland Indians [9/4/2012] Tickets at StubHub!|Cleveland Indians at Detroit Tigers
+711270|Chicago White Sox at Detroit Tigers (Saturday July 21, 2012)|Detroit Tigers vs Chicago White Sox [7/21/2012] Tickets at StubHub!|Chicago White Sox at Detroit Tigers
+711271|New York Yankees at Detroit Tigers (Saturday June 2, 2012)|Detroit Tigers vs New York Yankees [6/2/2012] Tickets at StubHub!|New York Yankees at Detroit Tigers
+711272|Tampa Bay Rays at Detroit Tigers (Tuesday April 10, 2012)|Detroit Tigers vs Tampa Bay Rays [4/10/2012] Tickets at StubHub!|Tampa Bay Rays at Detroit Tigers
+711273|Kansas City Royals at Detroit Tigers (Friday July 6, 2012)|Detroit Tigers vs Kansas City Royals [7/6/2012] Tickets at StubHub!|Kansas City Royals at Detroit Tigers
+711274|Cleveland Indians at Detroit Tigers (Friday August 3, 2012)|Detroit Tigers vs Cleveland Indians [8/3/2012] Tickets at StubHub!|Cleveland Indians at Detroit Tigers
+711276|Oakland Athletics at Detroit Tigers (Thursday September 20, 2012)|Detroit Tigers vs Oakland Athletics [9/20/2012] Tickets at StubHub!|Oakland Athletics at Detroit Tigers
+711277|Boston Red Sox at Detroit Tigers (Thursday April 5, 2012)|Detroit Tigers vs Boston Red Sox [4/5/2012] Tickets at StubHub!|Boston Red Sox at Detroit Tigers
+711278|Cleveland Indians at Detroit Tigers (Wednesday September 5, 2012)|Detroit Tigers vs Cleveland Indians [9/5/2012] Tickets at StubHub!|Cleveland Indians at Detroit Tigers
+711279|Seattle Mariners at Detroit Tigers (Thursday April 26, 2012)|Detroit Tigers vs Seattle Mariners [4/26/2012] Tickets at StubHub!|Seattle Mariners at Detroit Tigers
+711280|Chicago White Sox at Detroit Tigers (Sunday July 22, 2012)|Detroit Tigers vs Chicago White Sox [7/22/2012] Tickets at StubHub!|Chicago White Sox at Detroit Tigers
+711281|New York Yankees at Detroit Tigers (Friday June 1, 2012)|Detroit Tigers vs New York Yankees [6/1/2012] Tickets at StubHub!|New York Yankees at Detroit Tigers
+711282|Baltimore Orioles at Detroit Tigers (Sunday August 19, 2012)|Detroit Tigers vs Baltimore Orioles [8/19/2012] Tickets at StubHub!|Baltimore Orioles at Detroit Tigers
+711283|Kansas City Royals at Detroit Tigers (Saturday July 7, 2012)|Detroit Tigers vs Kansas City Royals [7/7/2012] Tickets at StubHub!|Kansas City Royals at Detroit Tigers
+711284|Chicago White Sox at Detroit Tigers (Sunday September 2, 2012)|Detroit Tigers vs Chicago White Sox [9/2/2012] Tickets at StubHub!|Chicago White Sox at Detroit Tigers
+711285|Texas Rangers at Detroit Tigers (Saturday April 21, 2012)|Detroit Tigers vs Texas Rangers [4/21/2012] Tickets at StubHub!|Texas Rangers at Detroit Tigers
+711286|Minnesota Twins at Detroit Tigers (Friday September 21, 2012)|Detroit Tigers vs Minnesota Twins [9/21/2012] Tickets at StubHub!|Minnesota Twins at Detroit Tigers
+711287|Kansas City Royals at Detroit Tigers (Sunday July 8, 2012)|Detroit Tigers vs Kansas City Royals [7/8/2012] Tickets at StubHub!|Kansas City Royals at Detroit Tigers
+711288|Chicago White Sox at Detroit Tigers (Friday May 4, 2012)|Detroit Tigers vs Chicago White Sox [5/4/2012] Tickets at StubHub!|Chicago White Sox at Detroit Tigers
+711289|Colorado Rockies at Detroit Tigers (Sunday June 17, 2012)|Detroit Tigers vs Colorado Rockies [6/17/2012] Tickets at StubHub!|Colorado Rockies at Detroit Tigers
+711290|Kansas City Royals at Detroit Tigers (Wednesday September 26, 2012)|Detroit Tigers vs Kansas City Royals [9/26/2012] Tickets at StubHub!|Kansas City Royals at Detroit Tigers
+711291|Cleveland Indians at Detroit Tigers (Sunday August 5, 2012)|Detroit Tigers vs Cleveland Indians [8/5/2012] Tickets at StubHub!|Cleveland Indians at Detroit Tigers
+711292|Baltimore Orioles at Detroit Tigers (Saturday August 18, 2012)|Detroit Tigers vs Baltimore Orioles [8/18/2012] Tickets at StubHub!|Baltimore Orioles at Detroit Tigers
+711293|Tampa Bay Rays at Detroit Tigers (Thursday April 12, 2012)|Detroit Tigers vs Tampa Bay Rays [4/12/2012] Tickets at StubHub!|Tampa Bay Rays at Detroit Tigers
+711294|Oakland Athletics at Detroit Tigers (Tuesday September 18, 2012)|Detroit Tigers vs Oakland Athletics [9/18/2012] Tickets at StubHub!|Oakland Athletics at Detroit Tigers
+711295|Pittsburgh Pirates at Detroit Tigers (Sunday May 20, 2012)|Detroit Tigers vs Pittsburgh Pirates [5/20/2012] Tickets at StubHub!|Pittsburgh Pirates at Detroit Tigers
+711296|Cleveland Indians at Detroit Tigers (Monday September 3, 2012)|Detroit Tigers vs Cleveland Indians [9/3/2012] Tickets at StubHub!|Cleveland Indians at Detroit Tigers
+711298|Texas Rangers at Detroit Tigers (Friday April 20, 2012)|Detroit Tigers vs Texas Rangers [4/20/2012] Tickets at StubHub!|Texas Rangers at Detroit Tigers
+711300|Chicago White Sox at Detroit Tigers (Saturday May 5, 2012)|Detroit Tigers vs Chicago White Sox [5/5/2012] Tickets at StubHub!|Chicago White Sox at Detroit Tigers
+711301|Colorado Rockies at Detroit Tigers (Friday June 15, 2012)|Detroit Tigers vs Colorado Rockies [6/15/2012] Tickets at StubHub!|Colorado Rockies at Detroit Tigers
+711302|Toronto Blue Jays at Detroit Tigers (Tuesday August 21, 2012)|Detroit Tigers vs Toronto Blue Jays [8/21/2012] Tickets at StubHub!|Toronto Blue Jays at Detroit Tigers
+711303|Colorado Rockies at Detroit Tigers (Saturday June 16, 2012)|Detroit Tigers vs Colorado Rockies [6/16/2012] Tickets at StubHub!|Colorado Rockies at Detroit Tigers
+711304|Boston Red Sox at Detroit Tigers (Saturday April 7, 2012)|Detroit Tigers vs Boston Red Sox [4/7/2012] Tickets at StubHub!|Boston Red Sox at Detroit Tigers
+711305|Kansas City Royals at Detroit Tigers (Thursday September 27, 2012)|Detroit Tigers vs Kansas City Royals [9/27/2012] Tickets at StubHub!|Kansas City Royals at Detroit Tigers
+711306|Cleveland Indians at Detroit Tigers (Saturday August 4, 2012)|Detroit Tigers vs Cleveland Indians [8/4/2012] Tickets at StubHub!|Cleveland Indians at Detroit Tigers
+711307|Cleveland Indians at Detroit Tigers (Thursday June 7, 2012)|Detroit Tigers vs Cleveland Indians [6/7/2012] Tickets at StubHub!|Cleveland Indians at Detroit Tigers
+711308|Oakland Athletics at Detroit Tigers (Wednesday September 19, 2012)|Detroit Tigers vs Oakland Athletics [9/19/2012] Tickets at StubHub!|Oakland Athletics at Detroit Tigers
+711311|Minnesota Twins at Detroit Tigers (Monday July 2, 2012)|Detroit Tigers vs Minnesota Twins [7/2/2012] Tickets at StubHub!|Minnesota Twins at Detroit Tigers
+711312|New York Yankees at Detroit Tigers (Tuesday August 7, 2012)|Detroit Tigers vs New York Yankees [8/7/2012] Tickets at StubHub!|New York Yankees at Detroit Tigers
+711313|Cleveland Indians at Detroit Tigers (Wednesday June 6, 2012)|Detroit Tigers vs Cleveland Indians [6/6/2012] Tickets at StubHub!|Cleveland Indians at Detroit Tigers
+711314|Pittsburgh Pirates at Detroit Tigers (Friday May 18, 2012)|Detroit Tigers vs Pittsburgh Pirates [5/18/2012] Tickets at StubHub!|Pittsburgh Pirates at Detroit Tigers
+711315|Chicago White Sox at Detroit Tigers (Saturday September 1, 2012)|Detroit Tigers vs Chicago White Sox [9/1/2012] Tickets at StubHub!|Chicago White Sox at Detroit Tigers
+711316|Texas Rangers at Detroit Tigers (Sunday April 22, 2012)|Detroit Tigers vs Texas Rangers [4/22/2012] Tickets at StubHub!|Texas Rangers at Detroit Tigers
+711318|Toronto Blue Jays at Detroit Tigers (Thursday August 23, 2012)|Detroit Tigers vs Toronto Blue Jays [8/23/2012] Tickets at StubHub!|Toronto Blue Jays at Detroit Tigers
+711319|Kansas City Royals at Detroit Tigers (Tuesday September 25, 2012)|Detroit Tigers vs Kansas City Royals [9/25/2012] Tickets at StubHub!|Kansas City Royals at Detroit Tigers
+711321|Minnesota Twins at Detroit Tigers (Tuesday July 3, 2012)|Detroit Tigers vs Minnesota Twins [7/3/2012] Tickets at StubHub!|Minnesota Twins at Detroit Tigers
+711322|New York Yankees at Detroit Tigers (Monday August 6, 2012)|Detroit Tigers vs New York Yankees [8/6/2012] Tickets at StubHub!|New York Yankees at Detroit Tigers
+711323|Cleveland Indians at Detroit Tigers (Tuesday June 5, 2012)|Detroit Tigers vs Cleveland Indians [6/5/2012] Tickets at StubHub!|Cleveland Indians at Detroit Tigers
+711324|Chicago White Sox at Detroit Tigers (Friday August 31, 2012)|Detroit Tigers vs Chicago White Sox [8/31/2012] Tickets at StubHub!|Chicago White Sox at Detroit Tigers
+711325|Pittsburgh Pirates at Detroit Tigers (Saturday May 19, 2012)|Detroit Tigers vs Pittsburgh Pirates [5/19/2012] Tickets at StubHub!|Pittsburgh Pirates at Detroit Tigers
+711326|Seattle Mariners at Detroit Tigers (Wednesday April 25, 2012)|Detroit Tigers vs Seattle Mariners [4/25/2012] Tickets at StubHub!|Seattle Mariners at Detroit Tigers
+711328|Toronto Blue Jays at Detroit Tigers (Wednesday August 22, 20120|Detroit Tigers vs Toronto Blue Jays [8/22/2012] Tickets at StubHub!|Toronto Blue Jays at Detroit Tigers
+711329|St. Louis Cardinals at Detroit Tigers (Thursday June 21, 2012)|Detroit Tigers vs St. Louis Cardinals [6/21/2012] Tickets at StubHub!|St. Louis Cardinals at Detroit Tigers
+711330|Boston Red Sox at Detroit Tigers (Sunday April 8, 2012)|Detroit Tigers vs Boston Red Sox [4/8/2012] Tickets at StubHub!|Boston Red Sox at Detroit Tigers
+711331|Minnesota Twins at Detroit Tigers (Wednesday July 4, 2012)|Detroit Tigers vs Minnesota Twins [7/4/2012] Tickets at StubHub!|Minnesota Twins at Detroit Tigers
+711332|Minnesota Twins at Detroit Tigers (Saturday September 22, 2012)|Detroit Tigers vs Minnesota Twins [9/22/2012] Tickets at StubHub!|Minnesota Twins at Detroit Tigers
+711333|Minnesota Twins at Detroit Tigers (Wednesday May 16, 2012)|Detroit Tigers vs Minnesota Twins [5/16/2012] Tickets at StubHub!|Minnesota Twins at Detroit Tigers
+711334|New York Yankees at Detroit Tigers (Thursday August 9, 2012)|Detroit Tigers vs New York Yankees [8/9/2012] Tickets at StubHub!|New York Yankees at Detroit Tigers
+711335|Seattle Mariners at Detroit Tigers (Tuesday April 24, 2012)|Detroit Tigers vs Seattle Mariners [4/24/2012] Tickets at StubHub!|Seattle Mariners at Detroit Tigers
+711336|Chicago White Sox at Detroit Tigers (Friday July 20, 2012)|Detroit Tigers vs Chicago White Sox [7/20/2012] Tickets at StubHub!|Chicago White Sox at Detroit Tigers
+711338|New York Yankees at Detroit Tigers (Sunday June 3, 2012)|Detroit Tigers vs New York Yankees [6/3/2012] Tickets at StubHub!|New York Yankees at Detroit Tigers
+711339|Baltimore Orioles at Detroit Tigers (Friday August 17, 2012)|Detroit Tigers vs Baltimore Orioles [8/17/2012] Tickets at StubHub!|Baltimore Orioles at Detroit Tigers
+711340|St. Louis Cardinals at Detroit Tigers (Wednesday June 20, 2012)|Detroit Tigers vs St. Louis Cardinals [6/20/2012] Tickets at StubHub!|St. Louis Cardinals at Detroit Tigers
+711341|Tampa Bay Rays at Detroit Tigers (Wednesday April 11, 2012)|Detroit Tigers vs Tampa Bay Rays [4/11/2012] Tickets at StubHub!|Tampa Bay Rays at Detroit Tigers
+711342|San Francisco Giants at Arizona Diamondbacks|Arizona Diamondbacks vs San Francisco Giants [4/6/2012] Tickets at StubHub!|San Francisco Giants at Arizona Diamondbacks
+711891|Houston Astros at Chicago Cubs|Chicago Cubs vs Houston Astros [10/3/2012] Tickets at StubHub!|Houston Astros at Chicago Cubs
+713106|Colorado Rockies at St Louis Cardinals|St Louis Cardinals vs Colorado Rockies [7/5/2012] Tickets at StubHub!|Colorado Rockies at St. Louis Cardinals
+713107|Cincinnati Reds at St Louis Cardinals|St Louis Cardinals vs Cincinnati Reds [4/19/2012] Tickets at StubHub!|Cincinnati Reds at St. Louis Cardinals
+713108|Cleveland Indians at St Louis Cardinals|St Louis Cardinals vs Cleveland Indians [6/10/2012] Tickets at StubHub!|Cleveland Indians at St. Louis Cardinals
+713109|San Francisco Giants at St Louis Cardinals|St Louis Cardinals vs San Francisco Giants [8/8/2012] Tickets at StubHub!|San Francisco Giants at St. Louis Cardinals
+713110|New York Mets at St Louis Cardinals|St Louis Cardinals vs New York Mets [9/4/2012] Tickets at StubHub!|New York Mets at St. Louis Cardinals
+713111|Milwaukee Brewers at St Louis Cardinals|St Louis Cardinals vs Milwaukee Brewers [4/27/2012] Tickets at StubHub!|Milwaukee Brewers at St. Louis Cardinals
+713112|Chicago Cubs at St Louis Cardinals|St Louis Cardinals vs Chicago Cubs [7/21/2012] Tickets at StubHub!|Chicago Cubs at St. Louis Cardinals
+713113|Chicago Cubs at St Louis Cardinals|St Louis Cardinals vs Chicago Cubs [5/14/2012] Tickets at StubHub!|Chicago Cubs at St. Louis Cardinals
+713114|Philadelphia Phillies at St Louis Cardinals|St Louis Cardinals vs Philadelphia Phillies [5/25/2012] Tickets at StubHub!|Philadelphia Phillies at St. Louis Cardinals
+713115|Arizona Diamondbacks at St Louis Cardinals|St Louis Cardinals vs Arizona Diamondbacks [8/16/2012] Tickets at StubHub!|Arizona Diamondbacks at St. Louis Cardinals
+713116|Washington Nationals at St Louis Cardinals|St Louis Cardinals vs Washington Nationals [9/28/2012] Tickets at StubHub!|Washington Nationals at St. Louis Cardinals
+713117|Miami Marlins at St Louis Cardinals|St Louis Cardinals vs Miami Marlins [7/6/2012] Tickets at StubHub!|Miami Marlins at St. Louis Cardinals
+713118|San Diego Padres at St Louis Cardinals|St Louis Cardinals vs San Diego Padres [5/22/2012] Tickets at StubHub!|San Diego Padres at St. Louis Cardinals
+713119|Milwaukee Brewers at St Louis Cardinals|St Louis Cardinals vs Milwaukee Brewers [8/3/2012] Tickets at StubHub!|Milwaukee Brewers at St. Louis Cardinals
+713120|Cincinnati Reds at St Louis Cardinals|St Louis Cardinals vs Cincinnati Reds [4/18/2012] Tickets at StubHub!|Cincinnati Reds at St. Louis Cardinals
+713121|Houston Astros at St Louis Cardinals|St Louis Cardinals vs Houston Astros [9/20/2012] Tickets at StubHub!|Houston Astros at St. Louis Cardinals
+713122|Cincinnati Reds at St Louis Cardinals|St Louis Cardinals vs Cincinnati Reds [10/3/2012] Tickets at StubHub!|Cincinnati Reds at St. Louis Cardinals
+713123|Cleveland Indians at St Louis Cardinals|St Louis Cardinals vs Cleveland Indians [6/9/2012] Tickets at StubHub!|Cleveland Indians at St. Louis Cardinals
+713124|New York Mets at St Louis Cardinals|St Louis Cardinals vs New York Mets [9/5/2012] Tickets at StubHub!|New York Mets at St. Louis Cardinals
+713125|Chicago Cubs at St Louis Cardinals|St Louis Cardinals vs Chicago Cubs [7/22/2012] Tickets at StubHub!|Chicago Cubs at St. Louis Cardinals
+713126|Chicago Cubs at St Louis Cardinals|St Louis Cardinals vs Chicago Cubs [5/15/2012] Tickets at StubHub!|Chicago Cubs at St. Louis Cardinals
+713127|Pittsburgh Pirates at St Louis Cardinals|St Louis Cardinals vs Pittsburgh Pirates [8/19/2012] Tickets at StubHub!|Pittsburgh Pirates at St. Louis Cardinals
+713128|Chicago Cubs at St Louis Cardinals|St Louis Cardinals vs Chicago Cubs [4/13/2012] Tickets at StubHub!|Chicago Cubs at St. Louis Cardinals
+713129|Washington Nationals at St Louis Cardinals|St Louis Cardinals vs Washington Nationals [9/29/2012] Tickets at StubHub!|Washington Nationals at St. Louis Cardinals
+713130|Miami Marlins at St Louis Cardinals|St Louis Cardinals vs Miami Marlins [7/7/2012] Tickets at StubHub!|Miami Marlins at St. Louis Cardinals
+713131|San Diego Padres at St Louis Cardinals|St Louis Cardinals vs San Diego Padres [5/23/2012] Tickets at StubHub!|San Diego Padres at St. Louis Cardinals
+713132|Miami Marlins at St Louis Cardinals|St Louis Cardinals vs Miami Marlins [7/8/2012] Tickets at StubHub!|Miami Marlins at St. Louis Cardinals
+713133|Cincinnati Reds at St Louis Cardinals|St Louis Cardinals vs Cincinnati Reds [10/2/2012] Tickets at StubHub!|Cincinnati Reds at St. Louis Cardinals
+713134|Cleveland Indians at St Louis Cardinals|St Louis Cardinals vs Cleveland Indians [6/8/2012] Tickets at StubHub!|Cleveland Indians at St. Louis Cardinals
+713135|Kansas City Royals at St Louis Cardinals|St Louis Cardinals vs Kansas City Royals [6/17/2012] Tickets at StubHub!|Kansas City Royals at St. Louis Cardinals
+713136|Milwaukee Brewers at St Louis Cardinals|St Louis Cardinals vs Milwaukee Brewers [4/29/2012] Tickets at StubHub!|Milwaukee Brewers at St. Louis Cardinals
+713137|Los Angeles Dodgers at St Louis Cardinals|St Louis Cardinals vs Los Angeles Dodgers [7/23/2012] Tickets at StubHub!|Los Angeles Dodgers at St. Louis Cardinals
+713138|Atlanta Braves at St Louis Cardinals|St Louis Cardinals vs Atlanta Braves [5/12/2012] Tickets at StubHub!|Atlanta Braves at St. Louis Cardinals
+713139|Milwaukee Brewers at St Louis Cardinals|St Louis Cardinals vs Milwaukee Brewers [8/5/2012] Tickets at StubHub!|Milwaukee Brewers at St. Louis Cardinals
+713140|Pittsburgh Pirates at St Louis Cardinals|St Louis Cardinals vs Pittsburgh Pirates [8/18/2012] Tickets at StubHub!|Pittsburgh Pirates at St. Louis Cardinals
+713141|Houston Astros at St Louis Cardinals|St Louis Cardinals vs Houston Astros [9/18/2012] Tickets at StubHub!|Houston Astros at St. Louis Cardinals
+713142|Los Angeles Dodgers at St Louis Cardinals|St Louis Cardinals vs Los Angeles Dodgers [7/24/2012] Tickets at StubHub!|Los Angeles Dodgers at St. Louis Cardinals
+713143|New York Mets at St Louis Cardinals|St Louis Cardinals vs New York Mets [9/3/2012] Tickets at StubHub!|New York Mets at St. Louis Cardinals
+713144|Cincinnati Reds at St Louis Cardinals (Mon. 10/1/12)|St Louis Cardinals vs Cincinnati Reds [10/1/2012] Tickets at StubHub!|Cincinnati Reds at St. Louis Cardinals
+713145|Kansas City Royals at St Louis Cardinals|St Louis Cardinals vs Kansas City Royals [6/15/2012] Tickets at StubHub!|Kansas City Royals at St. Louis Cardinals
+713146|Houston Astros at St Louis Cardinals|St Louis Cardinals vs Houston Astros [8/21/2012] Tickets at StubHub!|Houston Astros at St. Louis Cardinals
+713147|Kansas City Royals at St Louis Cardinals|St Louis Cardinals vs Kansas City Royals [6/16/2012] Tickets at StubHub!|Kansas City Royals at St. Louis Cardinals
+713148|Milwaukee Brewers at St Louis Cardinals|St Louis Cardinals vs Milwaukee Brewers [4/28/2012] Tickets at StubHub!|Milwaukee Brewers at St. Louis Cardinals
+713149|Pittsburgh Pirates at St Louis Cardinals|St Louis Cardinals vs Pittsburgh Pirates [7/1/2012] Tickets at StubHub!|Pittsburgh Pirates at St. Louis Cardinals
+713150|Atlanta Braves at St Louis Cardinals|St Louis Cardinals vs Atlanta Braves [5/13/2012] Tickets at StubHub!|Atlanta Braves at St. Louis Cardinals
+713151|Milwaukee Brewers at St Louis Cardinals|St Louis Cardinals vs Milwaukee Brewers [8/4/2012] Tickets at StubHub!|Milwaukee Brewers at St. Louis Cardinals
+713152|Milwaukee Brewers at St Louis Cardinals|St Louis Cardinals vs Milwaukee Brewers [9/8/2012] Tickets at StubHub!|Milwaukee Brewers at St. Louis Cardinals
+713153|Chicago Cubs at St Louis Cardinals|St Louis Cardinals vs Chicago Cubs [4/15/2012] Tickets at StubHub!|Chicago Cubs at St. Louis Cardinals
+713154|Houston Astros at St Louis Cardinals|St Louis Cardinals vs Houston Astros [9/19/2012] Tickets at StubHub!|Houston Astros at St. Louis Cardinals
+713155|Los Angeles Dodgers at St Louis Cardinals|St Louis Cardinals vs Los Angeles Dodgers [7/25/2012] Tickets at StubHub!|Los Angeles Dodgers at St. Louis Cardinals
+713156|San Diego Padres at St Louis Cardinals|St Louis Cardinals vs San Diego Padres [5/21/2012] Tickets at StubHub!|San Diego Padres at St. Louis Cardinals
+713157|Pittsburgh Pirates at St Louis Cardinals|St Louis Cardinals vs Pittsburgh Pirates [5/2/2012] Tickets at StubHub!|Pittsburgh Pirates at St. Louis Cardinals
+713158|Chicago White Sox at St Louis Cardinals|St Louis Cardinals vs Chicago White Sox [6/14/2012] Tickets at StubHub!|Chicago White Sox at St. Louis Cardinals
+713159|Colorado Rockies at St Louis Cardinals|St Louis Cardinals vs Colorado Rockies [7/2/2012] Tickets at StubHub!|Colorado Rockies at St. Louis Cardinals
+713160|San Francisco Giants at St Louis Cardinals|St Louis Cardinals vs San Francisco Giants [8/7/2012] Tickets at StubHub!|San Francisco Giants at St. Louis Cardinals
+713161|Milwaukee Brewers at St Louis Cardinals|St Louis Cardinals vs Milwaukee Brewers [9/9/2012] Tickets at StubHub!|Milwaukee Brewers at St. Louis Cardinals
+713162|Chicago Cubs at St Louis Cardinals|St Louis Cardinals vs Chicago Cubs [4/14/2012] Tickets at StubHub!|Chicago Cubs at St. Louis Cardinals
+713163|Los Angeles Dodgers at St Louis Cardinals|St Louis Cardinals vs Los Angeles Dodgers [7/26/2012] Tickets at StubHub!|Los Angeles Dodgers at St. Louis Cardinals
+713164|Arizona Diamondbacks at St Louis Cardinals|St Louis Cardinals vs Arizona Diamondbacks [8/15/2012] Tickets at StubHub!|Arizona Diamondbacks at St. Louis Cardinals
+713165|Pittsburgh Pirates at St Louis Cardinals|St Louis Cardinals vs Pittsburgh Pirates [6/30/2012] Tickets at StubHub!|Pittsburgh Pirates at St. Louis Cardinals
+713166|Pittsburgh Pirates at St Louis Cardinals|St Louis Cardinals vs Pittsburgh Pirates [5/3/2012] Tickets at StubHub!|Pittsburgh Pirates at St. Louis Cardinals
+713167|Chicago White Sox at St Louis Cardinals|St Louis Cardinals vs Chicago White Sox [6/13/2012] Tickets at StubHub!|Chicago White Sox at St. Louis Cardinals
+713168|Philadelphia Phillies at St Louis Cardinals|St Louis Cardinals vs Philadelphia Phillies [5/26/2012] Tickets at StubHub!|Philadelphia Phillies at St. Louis Cardinals
+713169|Houston Astros at St Louis Cardinals|St Louis Cardinals vs Houston Astros [8/23/2012] Tickets at StubHub!|Houston Astros at St. Louis Cardinals
+713170|Colorado Rockies at St Louis Cardinals|St Louis Cardinals vs Colorado Rockies [7/3/2012] Tickets at StubHub!|Colorado Rockies at St. Louis Cardinals
+713171|Atlanta Braves at St Louis Cardinals|St Louis Cardinals vs Atlanta Braves [5/11/2012] Tickets at StubHub!|Atlanta Braves at St. Louis Cardinals
+713172|San Francisco Giants at St Louis Cardinals|St Louis Cardinals vs San Francisco Giants [8/6/2012] Tickets at StubHub!|San Francisco Giants at St. Louis Cardinals
+713173|Cincinnati Reds at St Louis Cardinals|St Louis Cardinals vs Cincinnati Reds [4/17/2012] Tickets at StubHub!|Cincinnati Reds at St. Louis Cardinals
+713174|Arizona Diamondbacks at St Louis Cardinals|St Louis Cardinals vs Arizona Diamondbacks [8/14/2012] Tickets at StubHub!|Arizona Diamondbacks at St. Louis Cardinals
+713175|Pittsburgh Pirates at St Louis Cardinals|St Louis Cardinals vs Pittsburgh Pirates [6/29/2012] Tickets at StubHub!|Pittsburgh Pirates at St. Louis Cardinals
+713176|Chicago White Sox at St Louis Cardinals|St Louis Cardinals vs Chicago White Sox [6/12/2012] Tickets at StubHub!|Chicago White Sox at St. Louis Cardinals
+713177|Philadelphia Phillies at St Louis Cardinals|St Louis Cardinals vs Philadelphia Phillies [5/27/2012] Tickets at StubHub!|Philadelphia Phillies at St. Louis Cardinals
+713178|Houston Astros at St Louis Cardinals|St Louis Cardinals vs Houston Astros [8/22/2012] Tickets at StubHub!|Houston Astros at St. Louis Cardinals
+713179|Washington Nationals at St Louis Cardinals|St Louis Cardinals vs Washington Nationals [9/30/2012] Tickets at StubHub!|Washington Nationals at St. Louis Cardinals
+713180|Colorado Rockies at St Louis Cardinals|St Louis Cardinals vs Colorado Rockies [7/4/2012] Tickets at StubHub!|Colorado Rockies at St. Louis Cardinals
+713181|San Francisco Giants at St Louis Cardinals|St Louis Cardinals vs San Francisco Giants [8/9/2012] Tickets at StubHub!|San Francisco Giants at St. Louis Cardinals
+713182|Milwaukee Brewers at St Louis Cardinals|St Louis Cardinals vs Milwaukee Brewers [9/7/2012] Tickets at StubHub!|Milwaukee Brewers at St. Louis Cardinals
+713183|Chicago Cubs at St Louis Cardinals|St Louis Cardinals vs Chicago Cubs [7/20/2012] Tickets at StubHub!|Chicago Cubs at St. Louis Cardinals
+713184|Pittsburgh Pirates at St Louis Cardinals|St Louis Cardinals vs Pittsburgh Pirates [5/1/2012] Tickets at StubHub!|Pittsburgh Pirates at St. Louis Cardinals
+713185|Philadelphia Phillies at St Louis Cardinals|St Louis Cardinals vs Philadelphia Phillies [5/24/2012] Tickets at StubHub!|Philadelphia Phillies at St. Louis Cardinals
+713186|Pittsburgh Pirates at St Louis Cardinals|St Louis Cardinals vs Pittsburgh Pirates [8/17/2012] Tickets at StubHub!|Pittsburgh Pirates at St. Louis Cardinals
+713378|Baltimore Orioles at Los Angeles Angels (Thursday July 5, 2012)|Los Angeles Angels vs Baltimore Orioles [7/5/2012] Tickets at StubHub!|Baltimore Orioles at Los Angeles Angels of Anaheim
+713379|Oakland Athletics at Los Angeles Angels (Wednesday September 12, 2012)|Los Angeles Angels vs Oakland Athletics [9/12/2012] Tickets at StubHub!|Oakland Athletics at Los Angeles Angels of Anaheim
+713380|Oakland Athletics at Los Angeles Angels (Thursday April 19, 2012)|Los Angeles Angels vs Oakland Athletics [4/19/2012] Tickets at StubHub!|Oakland Athletics at Los Angeles Angels of Anaheim
+713381|Chicago White Sox at Los Angeles Angels (Sunday September 23, 2012)|Los Angeles Angels vs Chicago White Sox [9/23/2012] Tickets at StubHub!|Chicago White Sox at Los Angeles Angels of Anaheim
+713382|Tampa Bay Rays at Los Angeles Angels (Sunday July 29, 2012)|Los Angeles Angels vs Tampa Bay Rays [7/29/2012] Tickets at StubHub!|Tampa Bay Rays at Los Angeles Angels of Anaheim
+713383|Toronto Blue Jays at Los Angeles Angels (Sunday May 6, 2012)|Los Angeles Angels vs Toronto Blue Jays [5/6/2012] Tickets at StubHub!|Toronto Blue Jays at Los Angeles Angels of Anaheim
+713384|Chicago White Sox at Los Angeles Angels (Thursday May 17, 2012)|Los Angeles Angels vs Chicago White Sox [5/17/2012] Tickets at StubHub!|Chicago White Sox at Los Angeles Angels of Anaheim
+713385|San Francisco Giants at Los Angeles Angels (Tuesday June 19, 2012)|Los Angeles Angels vs San Francisco Giants [6/19/2012] Tickets at StubHub!|San Francisco Giants at Los Angeles Angels of Anaheim
+713386|Texas Rangers at Los Angeles Angels (Saturday July 21, 2012)|Los Angeles Angels vs Texas Rangers [7/21/2012] Tickets at StubHub!|Texas Rangers at Los Angeles Angels of Anaheim
+713387|Oakland Athletics at Los Angeles Angels (Monday May 14, 2012)|Los Angeles Angels vs Oakland Athletics [5/14/2012] Tickets at StubHub!|Oakland Athletics at Los Angeles Angels of Anaheim
+713388|Texas Rangers at Los Angeles Angels (Saturday June 2, 2012)|Los Angeles Angels vs Texas Rangers [6/2/2012] Tickets at StubHub!|Texas Rangers at Los Angeles Angels of Anaheim
+713389|Tampa Bay Rays at Los Angeles Angels (Thursday August 16, 2012)|Los Angeles Angels vs Tampa Bay Rays [8/16/2012] Tickets at StubHub!|Tampa Bay Rays at Los Angeles Angels of Anaheim
+713390|Baltimore Orioles at Los Angeles Angels (Friday July 6, 2012)|Los Angeles Angels vs Baltimore Orioles [7/6/2012] Tickets at StubHub!|Baltimore Orioles at Los Angeles Angels of Anaheim
+713391|Oakland Athletics at Los Angeles Angels (Thursday September 13, 2012)|Los Angeles Angels vs Oakland Athletics [9/13/2012] Tickets at StubHub!|Oakland Athletics at Los Angeles Angels of Anaheim
+713392|Oakland Athletics at Los Angeles Angels (Wednesday April 18, 2012)|Los Angeles Angels vs Oakland Athletics [4/18/2012] Tickets at StubHub!|Oakland Athletics at Los Angeles Angels of Anaheim
+713393|Texas Rangers at Los Angeles Angels (Thursday September 20, 2012)|Los Angeles Angels vs Texas Rangers [9/20/2012] Tickets at StubHub!|Texas Rangers at Los Angeles Angels of Anaheim
+713394|New York Yankees at Los Angeles Angels (Wednesday May 30, 2012)|Los Angeles Angels vs New York Yankees [5/30/2012] Tickets at StubHub!|New York Yankees at Los Angeles Angels of Anaheim
+713395|Seattle Mariners at Los Angeles Angels (Saturday August 11, 2012)|Los Angeles Angels vs Seattle Mariners [8/11/2012] Tickets at StubHub!|Seattle Mariners at Los Angeles Angels of Anaheim
+713396|San Francisco Giants at Los Angeles Angels (Monday June 18, 2012)|Los Angeles Angels vs San Francisco Giants [6/18/2012] Tickets at StubHub!|San Francisco Giants at Los Angeles Angels of Anaheim
+713397|Texas Rangers at Los Angeles Angels (Sunday July 22, 2012)|Los Angeles Angels vs Texas Rangers [7/22/2012] Tickets at StubHub!|Texas Rangers at Los Angeles Angels of Anaheim
+713398|Oakland Athletics at Los Angeles Angels (Tuesday May 15, 2012)|Los Angeles Angels vs Oakland Athletics [5/15/2012] Tickets at StubHub!|Oakland Athletics at Los Angeles Angels of Anaheim
+713399|Texas Rangers at Los Angeles Angels (Friday June 1, 2012)|Los Angeles Angels vs Texas Rangers [6/1/2012] Tickets at StubHub!|Texas Rangers at Los Angeles Angels of Anaheim
+713400|Oakland Athletics at Los Angeles Angels (Monday September 10, 2012)|Los Angeles Angels vs Oakland Athletics [9/10/2012] Tickets at StubHub!|Oakland Athletics at Los Angeles Angels of Anaheim
+713401|Tampa Bay Rays at Los Angeles Angels (Sunday August 19, 2012)|Los Angeles Angels vs Tampa Bay Rays [8/19/2012] Tickets at StubHub!|Tampa Bay Rays at Los Angeles Angels of Anaheim
+713402|Baltimore Orioles at Los Angeles Angels (Saturday July 7, 2012)|Los Angeles Angels vs Baltimore Orioles [7/7/2012] Tickets at StubHub!|Baltimore Orioles at Los Angeles Angels of Anaheim
+713403|Baltimore Orioles at Los Angeles Angels (Saturday April 21, 2012)|Los Angeles Angels vs Baltimore Orioles [4/21/2012] Tickets at StubHub!|Baltimore Orioles at Los Angeles Angels of Anaheim
+713404|Chicago White Sox at Los Angeles Angels (Friday September 21, 2012)|Los Angeles Angels vs Chicago White Sox [9/21/2012] Tickets at StubHub!|Chicago White Sox at Los Angeles Angels of Anaheim
+713405|Baltimore Orioles at Los Angeles Angels (Sunday July 8, 2012)|Los Angeles Angels vs Baltimore Orioles [7/8/2012] Tickets at StubHub!|Baltimore Orioles at Los Angeles Angels of Anaheim
+713406|Toronto Blue Jays at Los Angeles Angels (Friday May 4, 2012)|Los Angeles Angels vs Toronto Blue Jays [5/4/2012] Tickets at StubHub!|Toronto Blue Jays at Los Angeles Angels of Anaheim
+713407|Seattle Mariners at Los Angeles Angels (Friday August 10, 2012)|Los Angeles Angels vs Seattle Mariners [8/10/2012] Tickets at StubHub!|Seattle Mariners at Los Angeles Angels of Anaheim
+713408|Arizona Diamondbacks at Los Angeles Angels (Sunday June 17, 2012)|Los Angeles Angels vs Arizona Diamondbacks [6/17/2012] Tickets at StubHub!|Arizona Diamondbacks at Los Angeles Angels of Anaheim
+713409|Seattle Mariners at Los Angeles Angels (Wednesday September 26, 2012)|Los Angeles Angels vs Seattle Mariners [9/26/2012] Tickets at StubHub!|Seattle Mariners at Los Angeles Angels of Anaheim
+713410|Kansas City Royals at Los Angeles Angels (Monday July 23, 2012)|Los Angeles Angels vs Kansas City Royals [7/23/2012] Tickets at StubHub!|Kansas City Royals at Los Angeles Angels of Anaheim
+713411|Oakland Athletics at Los Angeles Angels (Tuesday September 11, 2012)|Los Angeles Angels vs Oakland Athletics [9/11/2012] Tickets at StubHub!|Oakland Athletics at Los Angeles Angels of Anaheim
+713412|Tampa Bay Rays at Los Angeles Angels (Saturday August 18, 2012)|Los Angeles Angels vs Tampa Bay Rays [8/18/2012] Tickets at StubHub!|Tampa Bay Rays at Los Angeles Angels of Anaheim
+713413|Texas Rangers at Los Angeles Angels (Tuesday September 18, 2012)|Los Angeles Angels vs Texas Rangers [9/18/2012] Tickets at StubHub!|Texas Rangers at Los Angeles Angels of Anaheim
+713414|Kansas City Royals at Los Angeles Angels (Tuesday July 24, 2012)|Los Angeles Angels vs Kansas City Royals [7/24/2012] Tickets at StubHub!|Kansas City Royals at Los Angeles Angels of Anaheim
+713415|Cleveland Indians at Los Angeles Angels (Monday August 13, 2012)|Los Angeles Angels vs Cleveland Indians [8/13/2012] Tickets at StubHub!|Cleveland Indians at Los Angeles Angels of Anaheim
+713416|Los Angeles Dodgers at Los Angeles Angels (June 24, 2012)|Los Angeles Angels vs Los Angeles Dodgers [6/24/2012] Tickets at StubHub!|Los Angeles Dodgers at Los Angeles Angels of Anaheim
+713417|Baltimore Orioles at Los Angeles Angels (Friday April 20, 2012)|Los Angeles Angels vs Baltimore Orioles [4/20/2012] Tickets at StubHub!|Baltimore Orioles at Los Angeles Angels of Anaheim
+713418|Toronto Blue Jays at Los Angeles Angels (Saturday May 5, 2012)|Los Angeles Angels vs Toronto Blue Jays [5/5/2012] Tickets at StubHub!|Toronto Blue Jays at Los Angeles Angels of Anaheim
+713419|Arizona Diamondbacks at Los Angeles Angels (Friday June 15, 2012)|Los Angeles Angels vs Arizona Diamondbacks [6/15/2012] Tickets at StubHub!|Arizona Diamondbacks at Los Angeles Angels of Anaheim
+713420|New York Yankees at Los Angeles Angels (Monday May 28, 2012)|Los Angeles Angels vs New York Yankees [5/28/2012] Tickets at StubHub!|New York Yankees at Los Angeles Angels of Anaheim
+713421|Arizona Diamondbacks at Los Angeles Angels (Saturday June 16, 2012)|Los Angeles Angels vs Arizona Diamondbacks [6/16/2012] Tickets at StubHub!|Arizona Diamondbacks at Los Angeles Angels of Anaheim
+713422|Kansas City Royals at Los Angeles Angels (Saturday April 7, 2012)|Los Angeles Angels vs Kansas City Royals [4/7/2012] Tickets at StubHub!|Kansas City Royals at Los Angeles Angels of Anaheim
+713423|Detroit Tigers at Los Angeles Angels (Saturday September 8, 2012)|Los Angeles Angels vs Detroit Tigers [9/8/2012] Tickets at StubHub!|Detroit Tigers at Los Angeles Angels of Anaheim
+713424|Boston Red Sox at Los Angeles Angels (Wednesday September 29, 2012)|Los Angeles Angels vs Boston Red Sox [8/29/2012] Tickets at StubHub!|Boston Red Sox at Los Angeles Angels of Anaheim
+713425|Texas Rangers at Los Angeles Angels (Wednesday September 19, 2012)|Los Angeles Angels vs Texas Rangers [9/19/2012] Tickets at StubHub!|Texas Rangers at Los Angeles Angels of Anaheim
+713426|Kansas City Royals at Los Angeles Angels (Wednesday July 25, 2012)|Los Angeles Angels vs Kansas City Royals [7/25/2012] Tickets at StubHub!|Kansas City Royals at Los Angeles Angels of Anaheim
+713427|Seattle Mariners at Los Angeles Angels (Sunday August 12, 2012)|Los Angeles Angels vs Seattle Mariners [8/12/2012] Tickets at StubHub!|Seattle Mariners at Los Angeles Angels of Anaheim
+713428|Minnesota Twins at Los Angeles Angels (Wednesday May 2, 2012)|Los Angeles Angels vs Minnesota Twins [5/2/2012] Tickets at StubHub!|Minnesota Twins at Los Angeles Angels of Anaheim
+713429|New York Yankees at Los Angeles Angels (Tuesday May 29, 2012)|Los Angeles Angels vs New York Yankees [5/29/2012] Tickets at StubHub!|New York Yankees at Los Angeles Angels of Anaheim
+713430|Los Angeles Dodgers at Los Angeles Angels (Saturday June 23, 2012)|Los Angeles Angels vs Los Angeles Dodgers [6/23/2012] Tickets at StubHub!|Los Angeles Dodgers at Los Angeles Angels of Anaheim
+713431|Kansas City Royals at Los Angeles Angels (Friday April 6, 2012)|Los Angeles Angels vs Kansas City Royals [4/6/2012] Tickets at StubHub!|Kansas City Royals at Los Angeles Angels of Anaheim
+713433|Seattle Mariners at Los Angeles Angels (Wednesday June 6, 2012)|Los Angeles Angels vs Seattle Mariners [6/6/2012] Tickets at StubHub!|Seattle Mariners at Los Angeles Angels of Anaheim
+713434|Detroit Tigers at Los Angeles Angels (Sunday September 9, 2012)|Los Angeles Angels vs Detroit Tigers [9/9/2012] Tickets at StubHub!|Detroit Tigers at Los Angeles Angels of Anaheim
+713435|Boston Red Sox at Los Angeles Angels (Tuesday August 28, 2012)|Los Angeles Angels vs Boston Red Sox [8/28/2012] Tickets at StubHub!|Boston Red Sox at Los Angeles Angels of Anaheim
+713436|Cleveland Indians at Los Angeles Angels (Wednesday August 15, 2012)|Los Angeles Angels vs Cleveland Indians [8/15/2012] Tickets at StubHub!|Cleveland Indians at Los Angeles Angels of Anaheim
+713437|Baltimore Orioles at Los Angeles Angels (Sunday April 22, 2012)|Los Angeles Angels vs Baltimore Orioles [4/22/2012] Tickets at StubHub!|Baltimore Orioles at Los Angeles Angels of Anaheim
+713438|Toronto Blue Jays at Los Angeles Angels (Thursday May 3, 2012)|Los Angeles Angels vs Toronto Blue Jays [5/3/2012] Tickets at StubHub!|Toronto Blue Jays at Los Angeles Angels of Anaheim
+713439|Los Angeles Dodgers at Los Angeles Angels (Friday June 22, 2012)|Los Angeles Angels vs Los Angeles Dodgers [6/22/2012] Tickets at StubHub!|Los Angeles Dodgers at Los Angeles Angels of Anaheim
+713440|Seattle Mariners at Los Angeles Angels (Tuesday September 25, 2012)|Los Angeles Angels vs Seattle Mariners [9/25/2012] Tickets at StubHub!|Seattle Mariners at Los Angeles Angels of Anaheim
+713441|Minnesota Twins at Los Angeles Angels (Monday April 30, 2012)|Los Angeles Angels vs Minnesota Twins [4/30/2012] Tickets at StubHub!|Minnesota Twins at Los Angeles Angels of Anaheim
+713442|Seattle Mariners at Los Angeles Angels (Tuesday June 5, 2012)|Los Angeles Angels vs Seattle Mariners [6/5/2012] Tickets at StubHub!|Seattle Mariners at Los Angeles Angels of Anaheim
+713443|Oakland Athletics at Los Angeles Angels (Tuesday April 17, 2012)|Los Angeles Angels vs Oakland Athletics [4/17/2012] Tickets at StubHub!|Oakland Athletics at Los Angeles Angels of Anaheim
+713444|Tampa Bay Rays at Los Angeles Angels (Friday July 27, 2012)|Los Angeles Angels vs Tampa Bay Rays [7/27/2012] Tickets at StubHub!|Tampa Bay Rays at Los Angeles Angels of Anaheim
+713445|Cleveland Indians at Los Angeles Angels (Tuesday August 14, 2012)|Los Angeles Angels vs Cleveland Indians [8/14/2012] Tickets at StubHub!|Cleveland Indians at Los Angeles Angels of Anaheim
+713446|Kansas City Royals at Los Angeles Angels (Sunday April 8, 2012)|Los Angeles Angels vs Kansas City Royals [4/8/2012] Tickets at StubHub!|Kansas City Royals at Los Angeles Angels of Anaheim
+713447|Seattle Mariners at Los Angeles Angels (Monday June 4, 2012)|Los Angeles Angels vs Seattle Mariners [6/4/2012] Tickets at StubHub!|Seattle Mariners at Los Angeles Angels of Anaheim
+713448|Boston Red Sox at Los Angeles Angels (Thursday August 30, 2012)|Los Angeles Angels vs Boston Red Sox [8/30/2012] Tickets at StubHub!|Boston Red Sox at Los Angeles Angels of Anaheim
+713449|Oakland Athletics at Los Angeles Angels (Monday April 16, 2012)|Los Angeles Angels vs Oakland Athletics [4/16/2012] Tickets at StubHub!|Oakland Athletics at Los Angeles Angels of Anaheim
+713450|Chicago White Sox at Los Angeles Angels (Saturday September 22, 2012)|Los Angeles Angels vs Chicago White Sox [9/22/2012] Tickets at StubHub!|Chicago White Sox at Los Angeles Angels of Anaheim
+713451|Tampa Bay Rays at Los Angeles Angels (Saturday July 28, 2012)|Los Angeles Angels vs Tampa Bay Rays [7/28/2012] Tickets at StubHub!|Tampa Bay Rays at Los Angeles Angels of Anaheim
+713452|Chicago White Sox at Los Angeles Angels (Wednesday May 16, 2012)|Los Angeles Angels vs Chicago White Sox [5/16/2012] Tickets at StubHub!|Chicago White Sox at Los Angeles Angels of Anaheim
+713453|Detroit Tigers at Los Angeles Angels (Friday September 7, 2012)|Los Angeles Angels vs Detroit Tigers [9/7/2012] Tickets at StubHub!|Detroit Tigers at Los Angeles Angels of Anaheim
+713454|Texas Rangers at Los Angeles Angels (Friday July 20, 2012)|Los Angeles Angels vs Texas Rangers [7/20/2012] Tickets at StubHub!|Texas Rangers at Los Angeles Angels of Anaheim
+713455|Minnesota Twins at Los Angeles Angels (Tuesday May 1, 2012)|Los Angeles Angels vs Minnesota Twins [5/1/2012] Tickets at StubHub!|Minnesota Twins at Los Angeles Angels of Anaheim
+713456|Texas Rangers at Los Angeles Angels (Sunday June 3, 2012)|Los Angeles Angels vs Texas Rangers [6/3/2012] Tickets at StubHub!|Texas Rangers at Los Angeles Angels of Anaheim
+713457|Tampa Bay Rays at Los Angeles Angels (Friday August 17, 2012)|Los Angeles Angels vs Tampa Bay Rays [8/17/2012] Tickets at StubHub!|Tampa Bay Rays at Los Angeles Angels of Anaheim
+713458|San Francisco Giants at Los Angeles Angels (Wednesday June 20, 2012)|Los Angeles Angels vs San Francisco Giants [6/20/2012] Tickets at StubHub!|San Francisco Giants at Los Angeles Angels of Anaheim
+714210|Milwaukee Brewers at Chicago Cubs|Chicago Cubs vs Milwaukee Brewers [8/29/2012] Tickets at StubHub!|Milwaukee Brewers at Chicago Cubs
+714211|Cincinnati Reds at Chicago Cubs|Chicago Cubs vs Cincinnati Reds [9/19/2012] Tickets at StubHub!|Cincinnati Reds at Chicago Cubs
+714212|Pittsburgh Pirates at Chicago Cubs|Chicago Cubs vs Pittsburgh Pirates [9/14/2012] Tickets at StubHub!|Pittsburgh Pirates at Chicago Cubs
+714213|Atlanta Braves at Chicago Cubs|Chicago Cubs vs Atlanta Braves [5/9/2012] Tickets at StubHub!|Atlanta Braves at Chicago Cubs
+714214|Miami Marlins at Chicago Cubs|Chicago Cubs vs Miami Marlins [7/19/2012] Tickets at StubHub!|Miami Marlins at Chicago Cubs
+714215|New York Mets at Chicago Cubs|Chicago Cubs vs New York Mets [6/27/2012] Tickets at StubHub!|New York Mets at Chicago Cubs
+714216|Pittsburgh Pirates at Chicago Cubs|Chicago Cubs vs Pittsburgh Pirates [9/17/2012] Tickets at StubHub!|Pittsburgh Pirates at Chicago Cubs
+714217|Detroit Tigers at Chicago Cubs|Chicago Cubs vs Detroit Tigers [6/13/2012] Tickets at StubHub!|Detroit Tigers at Chicago Cubs
+714218|New York Mets at Chicago Cubs|Chicago Cubs vs New York Mets [6/25/2012] Tickets at StubHub!|New York Mets at Chicago Cubs
+714219|St Louis Cardinals at Chicago Cubs (Sunday September 23, 2012)|Chicago Cubs vs St Louis Cardinals [9/23/2012] Tickets at StubHub!|St. Louis Cardinals at Chicago Cubs
+714220|San Francisco Giants at Chicago Cubs (Sunday September 2, 2012)|Chicago Cubs vs San Francisco Giants [9/2/2012] Tickets at StubHub!|San Francisco Giants at Chicago Cubs
+714221|St Louis Cardinals at Chicago Cubs|Chicago Cubs vs St Louis Cardinals [7/27/2012] Tickets at StubHub!|St. Louis Cardinals at Chicago Cubs
+714222|Milwaukee Brewers at Chicago Cubs|Chicago Cubs vs Milwaukee Brewers [8/27/2012] Tickets at StubHub!|Milwaukee Brewers at Chicago Cubs
+714223|Cincinnati Reds at Chicago Cubs|Chicago Cubs vs Cincinnati Reds [8/12/2012] Tickets at StubHub!|Cincinnati Reds at Chicago Cubs
+714224|Cincinnati Reds at Chicago Cubs|Chicago Cubs vs Cincinnati Reds [4/21/2012] Tickets at StubHub!|Cincinnati Reds at Chicago Cubs
+714225|St Louis Cardinals at Chicago Cubs|Chicago Cubs vs St Louis Cardinals [9/21/2012] Tickets at StubHub!|St. Louis Cardinals at Chicago Cubs
+714226|Chicago White Sox at Chicago Cubs|Chicago Cubs vs Chicago White Sox [5/19/2012] Tickets at StubHub!|Chicago White Sox at Chicago Cubs
+714227|Los Angeles Dodgers at Chicago Cubs|Chicago Cubs vs Los Angeles Dodgers [5/6/2012] Tickets at StubHub!|Los Angeles Dodgers at Chicago Cubs
+714228|Houston Astros at Chicago Cubs|Chicago Cubs vs Houston Astros [8/14/2012] Tickets at StubHub!|Houston Astros at Chicago Cubs
+714229|St Louis Cardinals at Chicago Cubs|Chicago Cubs vs St Louis Cardinals [4/23/2012] Tickets at StubHub!|St. Louis Cardinals at Chicago Cubs
+714230|Philadelphia Phillies at Chicago Cubs|Chicago Cubs vs Philadelphia Phillies [5/17/2012] Tickets at StubHub!|Philadelphia Phillies at Chicago Cubs
+714231|Los Angeles Dodgers at Chicago Cubs|Chicago Cubs vs Los Angeles Dodgers [5/4/2012] Tickets at StubHub!|Los Angeles Dodgers at Chicago Cubs
+714232|St Louis Cardinals at Chicago Cubs|Chicago Cubs vs St Louis Cardinals [4/25/2012] Tickets at StubHub!|St. Louis Cardinals at Chicago Cubs
+714233|St Louis Cardinals at Chicago Cubs (Sunday July 29, 2012)|Chicago Cubs vs St Louis Cardinals [7/29/2012] Tickets at StubHub!|St. Louis Cardinals at Chicago Cubs
+714234|Houston Astros at Chicago Cubs|Chicago Cubs vs Houston Astros [6/30/2012] Tickets at StubHub!|Houston Astros at Chicago Cubs
+714235|Miami Marlins at Chicago Cubs|Chicago Cubs vs Miami Marlins [7/17/2012] Tickets at StubHub!|Miami Marlins at Chicago Cubs
+714236|Cincinnati Reds at Chicago Cubs|Chicago Cubs vs Cincinnati Reds [8/10/2012] Tickets at StubHub!|Cincinnati Reds at Chicago Cubs
+714237|Boston Red Sox at Chicago Cubs (Sunday June 17, 2012)|Chicago Cubs vs Boston Red Sox [6/17/2012] Tickets at StubHub!|Boston Red Sox at Chicago Cubs
+714239|San Diego Padres at Chicago Cubs|Chicago Cubs vs San Diego Padres [5/29/2012] Tickets at StubHub!|San Diego Padres at Chicago Cubs
+714240|Arizona Diamondbacks at Chicago Cubs|Chicago Cubs vs Arizona Diamondbacks [7/14/2012] Tickets at StubHub!|Arizona Diamondbacks at Chicago Cubs
+714241|Houston Astros at Chicago Cubs|Chicago Cubs vs Houston Astros [6/29/2012] Tickets at StubHub!|Houston Astros at Chicago Cubs
+714242|Detroit Tigers at Chicago Cubs|Chicago Cubs vs Detroit Tigers [6/12/2012] Tickets at StubHub!|Detroit Tigers at Chicago Cubs
+714243|Washington Nationals at Chicago Cubs|Chicago Cubs vs Washington Nationals [4/8/2012] Tickets at StubHub!|Washington Nationals at Chicago Cubs
+714244|San Francisco Giants at Chicago Cubs|Chicago Cubs vs San Francisco Giants [8/31/2012] Tickets at StubHub!|San Francisco Giants at Chicago Cubs
+714245|Milwaukee Brewers at Chicago Cubs|Chicago Cubs vs Milwaukee Brewers [4/10/2012] Tickets at StubHub!|Milwaukee Brewers at Chicago Cubs
+714246|Pittsburgh Pirates at Chicago Cubs|Chicago Cubs vs Pittsburgh Pirates [9/15/2012] Tickets at StubHub!|Pittsburgh Pirates at Chicago Cubs
+714247|Pittsburgh Pirates at Chicago Cubs|Chicago Cubs vs Pittsburgh Pirates [7/31/2012] Tickets at StubHub!|Pittsburgh Pirates at Chicago Cubs
+714248|Milwaukee Brewers at Chicago Cubs|Chicago Cubs vs Milwaukee Brewers [4/12/2012] Tickets at StubHub!|Milwaukee Brewers at Chicago Cubs
+714249|Cincinnati Reds at Chicago Cubs|Chicago Cubs vs Cincinnati Reds [9/18/2012] Tickets at StubHub!|Cincinnati Reds at Chicago Cubs
+714250|Atlanta Braves at Chicago Cubs|Chicago Cubs vs Atlanta Braves [5/8/2012] Tickets at StubHub!|Atlanta Braves at Chicago Cubs
+714251|Milwaukee Brewers at Chicago Cubs|Chicago Cubs vs Milwaukee Brewers [8/28/2012] Tickets at StubHub!|Milwaukee Brewers at Chicago Cubs
+714252|Pittsburgh Pirates at Chicago Cubs|Chicago Cubs vs Pittsburgh Pirates [8/1/2012] Tickets at StubHub!|Pittsburgh Pirates at Chicago Cubs
+714253|Pittsburgh Pirates at Chicago Cubs|Chicago Cubs vs Pittsburgh Pirates [9/16/2012] Tickets at StubHub!|Pittsburgh Pirates at Chicago Cubs
+714254|Pittsburgh Pirates at Chicago Cubs|Chicago Cubs vs Pittsburgh Pirates [7/30/2012] Tickets at StubHub!|Pittsburgh Pirates at Chicago Cubs
+714255|Milwaukee Brewers at Chicago Cubs|Chicago Cubs vs Milwaukee Brewers [8/30/2012] Tickets at StubHub!|Milwaukee Brewers at Chicago Cubs
+714256|New York Mets at Chicago Cubs|Chicago Cubs vs New York Mets [6/26/2012] Tickets at StubHub!|New York Mets at Chicago Cubs
+714257|St Louis Cardinals at Chicago Cubs (Saturday September 22, 2012)|Chicago Cubs vs St Louis Cardinals [9/22/2012] Tickets at StubHub!|St. Louis Cardinals at Chicago Cubs
+714258|Chicago White Sox at Chicago Cubs (Sunday May 20, 2012)|Chicago Cubs vs Chicago White Sox [5/20/2012] Tickets at StubHub!|Chicago White Sox at Chicago Cubs
+714259|Colorado Rockies at Chicago Cubs|Chicago Cubs vs Colorado Rockies [8/24/2012] Tickets at StubHub!|Colorado Rockies at Chicago Cubs
+714260|Houston Astros at Chicago Cubs|Chicago Cubs vs Houston Astros [8/13/2012] Tickets at StubHub!|Houston Astros at Chicago Cubs
+714261|Cincinnati Reds at Chicago Cubs|Chicago Cubs vs Cincinnati Reds [9/20/2012] Tickets at StubHub!|Cincinnati Reds at Chicago Cubs
+714262|Chicago White Sox at Chicago Cubs|Chicago Cubs vs Chicago White Sox [5/18/2012] Tickets at StubHub!|Chicago White Sox at Chicago Cubs
+714263|Colorado Rockies at Chicago Cubs|Chicago Cubs vs Colorado Rockies [8/26/2012] Tickets at StubHub!|Colorado Rockies at Chicago Cubs
+714264|Houston Astros at Chicago Cubs|Chicago Cubs vs Houston Astros [8/15/2012] Tickets at StubHub!|Houston Astros at Chicago Cubs
+714265|Cincinnati Reds at Chicago Cubs|Chicago Cubs vs Cincinnati Reds [4/20/2012] Tickets at StubHub!|Cincinnati Reds at Chicago Cubs
+714266|Colorado Rockies at Chicago Cubs|Chicago Cubs vs Colorado Rockies [8/25/2012] Tickets at StubHub!|Colorado Rockies at Chicago Cubs
+714267|San Francisco Giants at Chicago Cubs|Chicago Cubs vs San Francisco Giants [9/1/2012] Tickets at StubHub!|San Francisco Giants at Chicago Cubs
+714268|Philadelphia Phillies at Chicago Cubs|Chicago Cubs vs Philadelphia Phillies [5/16/2012] Tickets at StubHub!|Philadelphia Phillies at Chicago Cubs
+714269|Atlanta Braves at Chicago Cubs|Chicago Cubs vs Atlanta Braves [5/7/2012] Tickets at StubHub!|Atlanta Braves at Chicago Cubs
+714270|Cincinnati Reds at Chicago Cubs|Chicago Cubs vs Cincinnati Reds [8/9/2012] Tickets at StubHub!|Cincinnati Reds at Chicago Cubs
+714271|Cincinnati Reds at Chicago Cubs|Chicago Cubs vs Cincinnati Reds [4/22/2012] Tickets at StubHub!|Cincinnati Reds at Chicago Cubs
+714272|St Louis Cardinals at Chicago Cubs|Chicago Cubs vs St Louis Cardinals [7/28/2012] Tickets at StubHub!|St. Louis Cardinals at Chicago Cubs
+714273|San Diego Padres at Chicago Cubs|Chicago Cubs vs San Diego Padres [5/30/2012] Tickets at StubHub!|San Diego Padres at Chicago Cubs
+714274|Los Angeles Dodgers at Chicago Cubs|Chicago Cubs vs Los Angeles Dodgers [5/5/2012] Tickets at StubHub!|Los Angeles Dodgers at Chicago Cubs
+714275|Cincinnati Reds at Chicago Cubs|Chicago Cubs vs Cincinnati Reds [8/11/2012] Tickets at StubHub!|Cincinnati Reds at Chicago Cubs
+714276|St Louis Cardinals at Chicago Cubs|Chicago Cubs vs St Louis Cardinals [4/24/2012] Tickets at StubHub!|St. Louis Cardinals at Chicago Cubs
+714277|Washington Nationals at Chicago Cubs|Chicago Cubs vs Washington Nationals [4/5/2012] Tickets at StubHub!|Washington Nationals at Chicago Cubs
+714278|San Diego Padres at Chicago Cubs|Chicago Cubs vs San Diego Padres [5/28/2012] Tickets at StubHub!|San Diego Padres at Chicago Cubs
+714279|Arizona Diamondbacks at Chicago Cubs|Chicago Cubs vs Arizona Diamondbacks [7/13/2012] Tickets at StubHub!|Arizona Diamondbacks at Chicago Cubs
+714280|Boston Red Sox at Chicago Cubs|Chicago Cubs vs Boston Red Sox [6/15/2012] Tickets at StubHub!|Boston Red Sox at Chicago Cubs
+714281|Boston Red Sox at Chicago Cubs|Chicago Cubs vs Boston Red Sox [6/16/2012] Tickets at StubHub!|Boston Red Sox at Chicago Cubs
+714282|Washington Nationals at Chicago Cubs|Chicago Cubs vs Washington Nationals [4/7/2012] Tickets at StubHub!|Washington Nationals at Chicago Cubs
+714283|Arizona Diamondbacks at Chicago Cubs|Chicago Cubs vs Arizona Diamondbacks [7/15/2012] Tickets at StubHub!|Arizona Diamondbacks at Chicago Cubs
+714284|Milwaukee Brewers at Chicago Cubs|Chicago Cubs vs Milwaukee Brewers [4/9/2012] Tickets at StubHub!|Milwaukee Brewers at Chicago Cubs
+714285|Houston Astros at Chicago Cubs|Chicago Cubs vs Houston Astros [7/1/2012] Tickets at StubHub!|Houston Astros at Chicago Cubs
+714286|Miami Marlins at Chicago Cubs|Chicago Cubs vs Miami Marlins [7/18/2012] Tickets at StubHub!|Miami Marlins at Chicago Cubs
+714287|Milwaukee Brewers at Chicago Cubs|Chicago Cubs vs Milwaukee Brewers [4/11/2012] Tickets at StubHub!|Milwaukee Brewers at Chicago Cubs
+714343|Houston Astros at Chicago Cubs|Chicago Cubs vs Houston Astros [10/2/2012] Tickets at StubHub!|Houston Astros at Chicago Cubs
+714346|Detroit Tigers at Chicago Cubs|Chicago Cubs vs Detroit Tigers [6/14/2012] Tickets at StubHub!|Detroit Tigers at Chicago Cubs
+714353|Houston Astros at Chicago Cubs|Chicago Cubs vs Houston Astros [10/1/2012] Tickets at StubHub!|Houston Astros at Chicago Cubs
+714435|Los Angeles Dodgers at Arizona Diamondbacks|Arizona Diamondbacks vs Los Angeles Dodgers [7/5/2012] Tickets at StubHub!|Los Angeles Dodgers at Arizona Diamondbacks
+714436|St Louis Cardinals at Arizona Diamondbacks|Arizona Diamondbacks vs St Louis Cardinals [5/9/2012] Tickets at StubHub!|St. Louis Cardinals at Arizona Diamondbacks
+714437|Los Angeles Dodgers at Arizona Diamondbacks|Arizona Diamondbacks vs Los Angeles Dodgers [9/12/2012] Tickets at StubHub!|Los Angeles Dodgers at Arizona Diamondbacks
+714438|San Diego Padres at Arizona Diamondbacks|Arizona Diamondbacks vs San Diego Padres [8/25/2012] Tickets at StubHub!|San Diego Padres at Arizona Diamondbacks
+714439|Atlanta Braves at Arizona Diamondbacks|Arizona Diamondbacks vs Atlanta Braves [4/19/2012] Tickets at StubHub!|Atlanta Braves at Arizona Diamondbacks
+714440|New York Mets at Arizona Diamondbacks|Arizona Diamondbacks vs New York Mets [7/29/2012] Tickets at StubHub!|New York Mets at Arizona Diamondbacks
+714441|Oakland Athletic at Arizona Diamondbacks|Arizona Diamondbacks vs Oakland Athletic [6/10/2012] Tickets at StubHub!|Oakland Athletics at Arizona Diamondbacks
+714443|Houston Astros at Arizona Diamondbacks|Arizona Diamondbacks vs Houston Astros [7/21/2012] Tickets at StubHub!|Houston Astros at Arizona Diamondbacks
+714444|Milwaukee Brewers at Arizona Diamondbacks|Arizona Diamondbacks vs Milwaukee Brewers [5/25/2012] Tickets at StubHub!|Milwaukee Brewers at Arizona Diamondbacks
+714445|Chicago Cubs at Arizona Diamondbacks|Arizona Diamondbacks vs Chicago Cubs [9/28/2012] Tickets at StubHub!|Chicago Cubs at Arizona Diamondbacks
+714446|Los Angeles Dodgers at Arizona Diamondbacks|Arizona Diamondbacks vs Los Angeles Dodgers [7/6/2012] Tickets at StubHub!|Los Angeles Dodgers at Arizona Diamondbacks
+714447|San Diego Padres at Arizona Diamondbacks|Arizona Diamondbacks vs San Diego Padres [8/24/2012] Tickets at StubHub!|San Diego Padres at Arizona Diamondbacks
+714448|Pittsburgh Pirates at Arizona Diamondbacks|Arizona Diamondbacks vs Pittsburgh Pirates [4/18/2012] Tickets at StubHub!|Pittsburgh Pirates at Arizona Diamondbacks
+714449|San Diego Padres at Arizona Diamondbacks|Arizona Diamondbacks vs San Diego Padres [9/20/2012] Tickets at StubHub!|San Diego Padres at Arizona Diamondbacks
+714450|St Louis Cardinals at Arizona Diamondbacks|Arizona Diamondbacks vs St Louis Cardinals [5/7/2012] Tickets at StubHub!|St. Louis Cardinals at Arizona Diamondbacks
+714452|Oakland Athletic at Arizona Diamondbacks|Arizona Diamondbacks vs Oakland Athletic [6/9/2012] Tickets at StubHub!|Oakland Athletics at Arizona Diamondbacks
+714453|Washington Nationals at Arizona Diamondbacks|Arizona Diamondbacks vs Washington Nationals [8/11/2012] Tickets at StubHub!|Washington Nationals at Arizona Diamondbacks
+714455|Houston Astros at Arizona Diamondbacks|Arizona Diamondbacks vs Houston Astros [7/22/2012] Tickets at StubHub!|Houston Astros at Arizona Diamondbacks
+714456|Chicago Cubs at Arizona Diamondbacks|Arizona Diamondbacks vs Chicago Cubs [9/29/2012] Tickets at StubHub!|Chicago Cubs at Arizona Diamondbacks
+714457|Los Angeles Dodgers at Arizona Diamondbacks|Arizona Diamondbacks vs Los Angeles Dodgers [7/7/2012] Tickets at StubHub!|Los Angeles Dodgers at Arizona Diamondbacks
+714458|Cincinnati Reds at Arizona Diamondbacks|Arizona Diamondbacks vs Cincinnati Reds [8/27/2012] Tickets at StubHub!|Cincinnati Reds at Arizona Diamondbacks
+714459|Atlanta Braves at Arizona Diamondbacks|Arizona Diamondbacks vs Atlanta Braves [4/21/2012] Tickets at StubHub!|Atlanta Braves at Arizona Diamondbacks
+714460|Los Angeles Dodgers at Arizona Diamondbacks|Arizona Diamondbacks vs Los Angeles Dodgers [7/8/2012] Tickets at StubHub!|Los Angeles Dodgers at Arizona Diamondbacks
+714461|Colorado Rockies at Arizona Diamondbacks|Arizona Diamondbacks vs Colorado Rockies [10/2/2012] Tickets at StubHub!|Colorado Rockies at Arizona Diamondbacks
+714462|Oakland Athletic at Arizona Diamondbacks|Arizona Diamondbacks vs Oakland Athletic [6/8/2012] Tickets at StubHub!|Oakland Athletics at Arizona Diamondbacks
+714463|Washington Nationals at Arizona Diamondbacks|Arizona Diamondbacks vs Washington Nationals [8/10/2012] Tickets at StubHub!|Washington Nationals at Arizona Diamondbacks
+714464|Colorado Rockies at Arizona Diamondbacks|Arizona Diamondbacks vs Colorado Rockies [7/23/2012] Tickets at StubHub!|Colorado Rockies at Arizona Diamondbacks
+714465|San Francisco Giants at Arizona Diamondbacks|Arizona Diamondbacks vs San Francisco Giants [5/12/2012] Tickets at StubHub!|San Francisco Giants at Arizona Diamondbacks
+714466|Los Angeles Dodgers at Arizona Diamondbacks|Arizona Diamondbacks vs Los Angeles Dodgers [9/11/2012] Tickets at StubHub!|Los Angeles Dodgers at Arizona Diamondbacks
+714467|San Diego Padres at Arizona Diamondbacks|Arizona Diamondbacks vs San Diego Padres [9/18/2012] Tickets at StubHub!|San Diego Padres at Arizona Diamondbacks
+714468|Colorado Rockies at Arizona Diamondbacks|Arizona Diamondbacks vs Colorado Rockies [7/24/2012] Tickets at StubHub!|Colorado Rockies at Arizona Diamondbacks
+714469|Chicago Cubs at Arizona Diamondbacks|Arizona Diamondbacks vs Chicago Cubs [6/24/2012] Tickets at StubHub!|Chicago Cubs at Arizona Diamondbacks
+714470|San Diego Padres at Arizona Diamondbacks|Arizona Diamondbacks vs San Diego Padres [8/26/2012] Tickets at StubHub!|San Diego Padres at Arizona Diamondbacks
+714471|Atlanta Braves at Arizona Diamondbacks|Arizona Diamondbacks vs Atlanta Braves [4/20/2012] Tickets at StubHub!|Atlanta Braves at Arizona Diamondbacks
+714472|Colorado Rockies at Arizona Diamondbacks|Arizona Diamondbacks vs Colorado Rockies [10/1/2012] Tickets at StubHub!|Colorado Rockies at Arizona Diamondbacks
+714473|Miami Marlins at Arizona Diamondbacks|Arizona Diamondbacks vs Miami Marlins [8/21/2012] Tickets at StubHub!|Miami Marlins at Arizona Diamondbacks
+714474|San Francisco Giants at Arizona Diamondbacks|Arizona Diamondbacks vs San Francisco Giants [4/7/2012] Tickets at StubHub!|San Francisco Giants  at Arizona Diamondbacks
+714475|San Francisco Giants at Arizona Diamondbacks|Arizona Diamondbacks vs San Francisco Giants [5/13/2012] Tickets at StubHub!|San Francisco Giants at Arizona Diamondbacks
+714476|Colorado Rockies at Arizona Diamondbacks|Arizona Diamondbacks vs Colorado Rockies [6/7/2012] Tickets at StubHub!|Colorado Rockies at Arizona Diamondbacks
+714477|Cincinnati Reds at Arizona Diamondbacks|Arizona Diamondbacks vs Cincinnati Reds [8/29/2012] Tickets at StubHub!|Cincinnati Reds at Arizona Diamondbacks
+714478|San Diego Padres at Arizona Diamondbacks|Arizona Diamondbacks vs San Diego Padres [9/19/2012] Tickets at StubHub!|San Diego Padres at Arizona Diamondbacks
+714479|Colorado Rockies at Arizona Diamondbacks|Arizona Diamondbacks vs Colorado Rockies [7/25/2012] Tickets at StubHub!|Colorado Rockies at Arizona Diamondbacks
+714480|Los Angeles Dodgers at Arizona Diamondbacks|Arizona Diamondbacks vs Los Angeles Dodgers [5/21/2012] Tickets at StubHub!|Los Angeles Dodgers at Arizona Diamondbacks
+714481|Washington Nationals at Arizona Diamondbacks|Arizona Diamondbacks vs Washington Nationals [8/12/2012] Tickets at StubHub!|Washington Nationals at Arizona Diamondbacks
+714482|Philadelphia Phillies at Arizona Diamondbacks|Arizona Diamondbacks vs Philadelphia Phillies [4/23/2012] Tickets at StubHub!|Philadelphia Phillies at Arizona Diamondbacks
+714483|Miami Marlins at Arizona Diamondbacks|Arizona Diamondbacks vs Miami Marlins [8/20/2012] Tickets at StubHub!|Miami Marlins at Arizona Diamondbacks
+714484|Chicago Cubs at Arizona Diamondbacks|Arizona Diamondbacks vs Chicago Cubs [6/23/2012] Tickets at StubHub!|Chicago Cubs at Arizona Diamondbacks
+714485|San Diego Padres at Arizona Diamondbacks|Arizona Diamondbacks vs San Diego Padres [7/2/2012] Tickets at StubHub!|San Diego Padres at Arizona Diamondbacks
+714486|Colorado Rockies at Arizona Diamondbacks|Arizona Diamondbacks vs Colorado Rockies [6/6/2012] Tickets at StubHub!|Colorado Rockies at Arizona Diamondbacks
+714487|Cincinnati Reds at Arizona Diamondbacks|Arizona Diamondbacks vs Cincinnati Reds [8/28/2012] Tickets at StubHub!|Cincinnati Reds at Arizona Diamondbacks
+714488|San Francisco Giants at Arizona Diamondbacks|Arizona Diamondbacks vs San Francisco Giants [9/16/2012] Tickets at StubHub!|San Francisco Giants at Arizona Diamondbacks
+714489|New York Mets at Arizona Diamondbacks|Arizona Diamondbacks vs New York Mets [7/26/2012] Tickets at StubHub!|New York Mets at Arizona Diamondbacks
+714490|Atlanta Braves at Arizona Diamondbacks|Arizona Diamondbacks vs Atlanta Braves [4/22/2012] Tickets at StubHub!|Atlanta Braves at Arizona Diamondbacks
+714491|Milwaukee Brewers at Arizona Diamondbacks|Arizona Diamondbacks vs Milwaukee Brewers [5/26/2012] Tickets at StubHub!|Milwaukee Brewers at Arizona Diamondbacks
+714492|Miami Marlins at Arizona Diamondbacks|Arizona Diamondbacks vs Miami Marlins [8/23/2012] Tickets at StubHub!|Miami Marlins at Arizona Diamondbacks
+714493|Chicago Cubs at Arizona Diamondbacks|Arizona Diamondbacks vs Chicago Cubs [6/22/2012] Tickets at StubHub!|Chicago Cubs at Arizona Diamondbacks
+714494|San Diego Padres at Arizona Diamondbacks|Arizona Diamondbacks vs San Diego Padres [7/3/2012] Tickets at StubHub!|San Diego Padres at Arizona Diamondbacks
+714495|San Francisco Giants at Arizona Diamondbacks|Arizona Diamondbacks vs San Francisco Giants [5/11/2012] Tickets at StubHub!|San Francisco Giants at Arizona Diamondbacks
+714496|Colorado Rockies at Arizona Diamondbacks|Arizona Diamondbacks vs Colorado Rockies [6/5/2012] Tickets at StubHub!|Colorado Rockies at Arizona Diamondbacks
+714497|San Francisco Giants at Arizona Diamondbacks|Arizona Diamondbacks vs San Francisco Giants [9/14/2012] Tickets at StubHub!|San Francisco Giants at Arizona Diamondbacks
+714498|Pittsburgh Pirates at Arizona Diamondbacks|Arizona Diamondbacks vs Pittsburgh Pirates [4/17/2012] Tickets at StubHub!|Pittsburgh Pirates at Arizona Diamondbacks
+714499|New York Mets at Arizona Diamondbacks|Arizona Diamondbacks vs New York Mets [7/27/2012] Tickets at StubHub!|New York Mets at Arizona Diamondbacks
+714500|Philadelphia Phillies at Arizona Diamondbacks|Arizona Diamondbacks vs Philadelphia Phillies [4/25/2012] Tickets at StubHub!|Philadelphia Phillies at Arizona Diamondbacks
+714501|Milwaukee Brewers at Arizona Diamondbacks|Arizona Diamondbacks vs Milwaukee Brewers [5/27/2012] Tickets at StubHub!|Milwaukee Brewers at Arizona Diamondbacks
+714502|Miami Marlins at Arizona Diamondbacks|Arizona Diamondbacks vs Miami Marlins [8/22/2012] Tickets at StubHub!|Miami Marlins at Arizona Diamondbacks
+714503|San Francisco Giants at Arizona Diamondbacks|Arizona Diamondbacks vs San Francisco Giants [4/8/2012] Tickets at StubHub!|San Francisco Giants at Arizona Diamondbacks
+714504|Chicago Cubs at Arizona Diamondbacks|Arizona Diamondbacks vs Chicago Cubs [9/30/2012] Tickets at StubHub!|Chicago Cubs at Arizona Diamondbacks
+714505|San Diego Padres at Arizona Diamondbacks|Arizona Diamondbacks vs San Diego Padres [7/4/2012] Tickets at StubHub!|San Diego Padres at Arizona Diamondbacks
+714506|St Louis Cardinals at Arizona Diamondbacks|Arizona Diamondbacks vs St Louis Cardinals [5/8/2012] Tickets at StubHub!|St. Louis Cardinals at Arizona Diamondbacks
+714507|San Francisco Giants at Arizona Diamondbacks|Arizona Diamondbacks vs San Francisco Giants [9/15/2012] Tickets at StubHub!|San Francisco Giants at Arizona Diamondbacks
+714508|Pittsburgh Pirates at Arizona Diamondbacks|Arizona Diamondbacks vs Pittsburgh Pirates [4/16/2012] Tickets at StubHub!|Pittsburgh Pirates at Arizona Diamondbacks
+714509|New York Mets at Arizona Diamondbacks|Arizona Diamondbacks vs New York Mets [7/28/2012] Tickets at StubHub!|New York Mets at Arizona Diamondbacks
+714510|Philadelphia Phillies at Arizona Diamondbacks|Arizona Diamondbacks vs Philadelphia Phillies [4/24/2012] Tickets at StubHub!|Philadelphia Phillies at Arizona Diamondbacks
+714511|Houston Astros at Arizona Diamondbacks|Arizona Diamondbacks vs Houston Astros [7/20/2012] Tickets at StubHub!|Houston Astros at Arizona Diamondbacks
+715361|Detroit Tigers at Kansas City Royals (Wednesday August 29, 2012)|Kansas City Royals vs Detroit Tigers [8/29/2012] Tickets at StubHub!|Detroit Tigers at Kansas City Royals
+715362|Texas Rangers at Kansas City Royals (Thursday September 6, 2012)|Kansas City Royals vs Texas Rangers [9/6/2012] Tickets at StubHub!|Texas Rangers at Kansas City Royals
+715363|Minnesota Twins at Kansas City Royals (Tuesday June 5, 2012)|Kansas City Royals vs Minnesota Twins [6/5/2012] Tickets at StubHub!|Minnesota Twins at Kansas City Royals
+715364|Chicago White Sox at Kansas City Royals (Wednesday September 19, 2012)|Kansas City Royals vs Chicago White Sox [9/19/2012] Tickets at StubHub!|Chicago White Sox at Kansas City Royals
+715365|Los Angeles Angels at Kansas City Royals (Friday September 14, 2012)|Kansas City Royals vs Los Angeles Angels [9/14/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Kansas City Royals
+715366|Boston Red Sox at Kansas City Royals (Wednesday May 9, 2012)|Kansas City Royals vs Boston Red Sox [5/9/2012] Tickets at StubHub!|Boston Red Sox at Kansas City Royals
+715367|Minnesota Twins at Kansas City Royals (Friday August 31, 2012)|Kansas City Royals vs Minnesota Twins [8/31/2012] Tickets at StubHub!|Minnesota Twins at Kansas City Royals
+715368|Detroit Tigers at Kansas City Royals (Tuesday April 17, 2012)|Kansas City Royals vs Detroit Tigers [4/17/2012] Tickets at StubHub!|Detroit Tigers at Kansas City Royals
+715369|Chicago White Sox at Kansas City Royals (Friday July 13, 2012)|Kansas City Royals vs Chicago White Sox [7/13/2012] Tickets at StubHub!|Chicago White Sox at Kansas City Royals
+715370|Cleveland Indians at Kansas City Royals (Thursday August 2, 2012)|Kansas City Royals vs Cleveland Indians [8/2/2012] Tickets at StubHub!|Cleveland Indians at Kansas City Royals
+715371|Tampa Bay Rays at Kansas City Royals (Monday June 25, 2012)|Kansas City Royals vs Tampa Bay Rays [6/25/2012] Tickets at StubHub!|Tampa Bay Rays at Kansas City Royals
+715372|Cleveland Indians at Kansas City Royals (Sunday September 23, 2012)|Kansas City Royals vs Cleveland Indians [9/23/2012] Tickets at StubHub!|Cleveland Indians at Kansas City Royals
+715373|Minnesota Twins at Kansas City Royals (Sunday September 2, 2012)|Kansas City Royals vs Minnesota Twins [9/2/2012] Tickets at StubHub!|Minnesota Twins at Kansas City Royals
+715374|Toronto Blue Jays at Kansas City Royals (Saturday April 21, 2012)|Kansas City Royals vs Toronto Blue Jays [4/21/2012] Tickets at StubHub!|Toronto Blue Jays at Kansas City Royals
+715375|Cleveland Indians at Kansas City Royals (Friday September 21, 2012)|Kansas City Royals vs Cleveland Indians [9/21/2012] Tickets at StubHub!|Cleveland Indians at Kansas City Royals
+715376|Arizona Diamondbacks at Kansas City Royals (Saturday May 19, 2012)|Kansas City Royals vs Arizona Diamondbacks [5/19/2012] Tickets at StubHub!|Arizona Diamondbacks at Kansas City Royals
+715377|New York Yankees at Kansas City Royals (Sunday May 6, 2012)|Kansas City Royals vs New York Yankees [5/6/2012] Tickets at StubHub!|New York Yankees at Kansas City Royals
+715378|Oakland Athletics at Kansas City Royals (Tuesday August 14, 2012)|Kansas City Royals vs Oakland Athletics [8/14/2012] Tickets at StubHub!|Oakland Athletics at Kansas City Royals
+715379|Toronto Blue Jays at Kansas City Royals (Monday April 23, 2012)|Kansas City Royals vs Toronto Blue Jays [4/23/2012] Tickets at StubHub!|Toronto Blue Jays at Kansas City Royals
+715380|Cleveland Indians at Kansas City Royals (Sunday April 15, 2012)|Kansas City Royals vs Cleveland Indians [4/15/2012] Tickets at StubHub!|Cleveland Indians at Kansas City Royals
+715381|Cleveland Indians at Kansas City Royals (Tuesday July 31, 2012)|Kansas City Royals vs Cleveland Indians [7/31/2012] Tickets at StubHub!|Cleveland Indians at Kansas City Royals
+715382|New York Yankees at Kansas City Royals (Friday May 4, 2012)|Kansas City Royals vs New York Yankees [5/4/2012] Tickets at StubHub!|New York Yankees at Kansas City Royals
+715383|Detroit Tigers at Kansas City Royals (Tuesday October 2, 2012)|Kansas City Royals vs Detroit Tigers [10/2/2012] Tickets at StubHub!|Detroit Tigers at Kansas City Royals
+715384|Texas Rangers at Kansas City Royals (Tuesday September 4, 2012)|Kansas City Royals vs Texas Rangers [9/4/2012] Tickets at StubHub!|Texas Rangers at Kansas City Royals
+715385|Seattle Mariners at Kansas City Royals (Tuesday July 17, 2012)|Kansas City Royals vs Seattle Mariners [7/17/2012] Tickets at StubHub!|Seattle Mariners at Kansas City Royals
+715386|Milwaukee Brewers at Kansas City Royals (Thursday June 14, 2012)|Kansas City Royals vs Milwaukee Brewers [6/14/2012] Tickets at StubHub!|Milwaukee Brewers at Kansas City Royals
+715387|Seattle Mariners at Kansas City Royals (Thursday July 19, 2012)|Kansas City Royals vs Seattle Mariners [7/19/2012] Tickets at StubHub!|Seattle Mariners at Kansas City Royals
+715388|Chicago White Sox at Kansas City Royals (Saturday July 14, 2012)|Kansas City Royals vs Chicago White Sox [7/14/2012] Tickets at StubHub!|Chicago White Sox at Kansas City Royals
+715389|St. Louis Cardinals at Kansas City Royals (Saturday June 23, 2012)|Kansas City Royals vs St. Louis Cardinals [6/23/2012] Tickets at StubHub!|St. Louis Cardinals at Kansas City Royals
+715390|Milwaukee Brewers at Kansas City Royals (Tuesday June 12, 2012)|Kansas City Royals vs Milwaukee Brewers [6/12/2012] Tickets at StubHub!|Milwaukee Brewers at Kansas City Royals
+715391|Cleveland Indians at Kansas City Royals (Saturday April 14, 2012)|Kansas City Royals vs Cleveland Indians [4/14/2012] Tickets at StubHub!|Cleveland Indians at Kansas City Royals
+715392|Minnesota Twins at Kansas City Royals (Saturday July 21, 2012)|Kansas City Royals vs Minnesota Twins [7/21/2012] Tickets at StubHub!|Minnesota Twins at Kansas City Royals
+715393|Oakland Athletics at Kansas City Royals (Saturday June 2, 2012)|Kansas City Royals vs Oakland Athletics [6/2/2012] Tickets at StubHub!|Oakland Athletics at Kansas City Royals
+715394|Oakland Athletics at Kansas City Royals (Thursday August 16, 2012)|Kansas City Royals vs Oakland Athletics [8/16/2012] Tickets at StubHub!|Oakland Athletics at Kansas City Royals
+715395|Texas Rangers at Kansas City Royals (Sunday August 5, 2012)|Kansas City Royals vs Texas Rangers [8/5/2012] Tickets at StubHub!|Texas Rangers at Kansas City Royals
+715396|Chicago White Sox at Kansas City Royals (Saturday August 18, 2012)|Kansas City Royals vs Chicago White Sox [8/18/2012] Tickets at StubHub!|Chicago White Sox at Kansas City Royals
+715397|Baltimore Orioles at Kansas City Royals (Thursday May 17, 2012)|Kansas City Royals vs Baltimore Orioles [5/17/2012] Tickets at StubHub!|Baltimore Orioles at Kansas City Royals
+715398|Minnesota Twins at Kansas City Royals (Wednesday June 6, 2012)|Kansas City Royals vs Minnesota Twins [6/6/2012] Tickets at StubHub!|Minnesota Twins at Kansas City Royals
+715399|Chicago White Sox at Kansas City Royals (Tuesday September 18, 2012)|Kansas City Royals vs Chicago White Sox [9/18/2012] Tickets at StubHub!|Chicago White Sox at Kansas City Royals
+715400|Boston Red Sox at Kansas City Royals (Tuesday May 8, 2012)|Kansas City Royals vs Boston Red Sox [5/8/2012] Tickets at StubHub!|Boston Red Sox at Kansas City Royals
+715401|Detroit Tigers at Kansas City Royals (Tuesday August 28, 2012)|Kansas City Royals vs Detroit Tigers [8/28/2012] Tickets at StubHub!|Detroit Tigers at Kansas City Royals
+715402|Cleveland Indians at Kansas City Royals (Wednesday August 1, 2012)|Kansas City Royals vs Cleveland Indians [8/1/2012] Tickets at StubHub!|Cleveland Indians at Kansas City Royals
+715403|Minnesota Twins at Kansas City Royals (Monday June 4, 2012)|Kansas City Royals vs Minnesota Twins [6/4/2012] Tickets at StubHub!|Minnesota Twins at Kansas City Royals
+715404|Los Angeles Angels at Kansas City Royals (Sunday September 16, 2012)|Kansas City Royals vs Los Angeles Angels [9/16/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Kansas City Royals
+715405|Los Angeles Angels at Kansas City Royals (Saturday September 15, 2012)|Kansas City Royals vs Los Angeles Angels [9/15/2012] Tickets at StubHub!|
+715406|Detroit Tigers at Kansas City Royals (Thursday August 30, 2012)|Kansas City Royals vs Detroit Tigers [8/30/2012] Tickets at StubHub!|Detroit Tigers at Kansas City Royals
+715407|Texas Rangers at Kansas City Royals (Friday August 3, 2012)|Kansas City Royals vs Texas Rangers [8/3/2012] Tickets at StubHub!|Texas Rangers at Kansas City Royals
+715408|Tampa Bay Rays at Kansas City Royals (Tuesday June 26, 2012)|Kansas City Royals vs Tampa Bay Rays [6/26/2012] Tickets at StubHub!|Tampa Bay Rays at Kansas City Royals
+715409|Cleveland Indians at Kansas City Royals (Saturday September 22, 2012)|Kansas City Royals vs Cleveland Indians [9/22/2012] Tickets at StubHub!|Cleveland Indians at Kansas City Royals
+715410|Arizona Diamondbacks at Kansas City Royals (Sunday May 20, 2012)|Kansas City Royals vs Arizona Diamondbacks [5/20/2012] Tickets at StubHub!|Arizona Diamondbacks at Kansas City Royals
+715411|St. Louis Cardinals at Kansas City Royals (Sunday June 24, 2012)|Kansas City Royals vs St. Louis Cardinals [6/24/2012] Tickets at StubHub!|St. Louis Cardinals at Kansas City Royals
+715412|Detroit Tigers at Kansas City Royals (Monday April 16, 2012)|Kansas City Royals vs Detroit Tigers [4/16/2012] Tickets at StubHub!|Detroit Tigers at Kansas City Royals
+715413|Texas Rangers at Kansas City Royals (Monday September 3, 2012)|Kansas City Royals vs Texas Rangers [9/3/2012] Tickets at StubHub!|Texas Rangers at Kansas City Royals
+715414|Arizona Diamondbacks at Kansas City Royals (Friday May 18, 2012)|Kansas City Royals vs Arizona Diamondbacks [5/18/2012] Tickets at StubHub!|Arizona Diamondbacks at Kansas City Royals
+715415|Oakland Athletics at Kansas City Royals (Wednesday August 15, 2012)|Kansas City Royals vs Oakland Athletics [8/15/2012] Tickets at StubHub!|Oakland Athletics at Kansas City Royals
+715416|Toronto Blue Jays at Kansas City Royals (Friday April 20, 2012)|Kansas City Royals vs Toronto Blue Jays [4/20/2012] Tickets at StubHub!|Toronto Blue Jays at Kansas City Royals
+715417|Minnesota Twins at Kansas City Royals (Saturday September 1, 2012)|Kansas City Royals vs Minnesota Twins [9/1/2012] Tickets at StubHub!|Minnesota Twins at Kansas City Royals
+715418|Baltimore Orioles at Kansas City Royals (Wednesday May 16, 2012)|Kansas City Royals vs Baltimore Orioles [5/16/2012] Tickets at StubHub!|Baltimore Orioles at Kansas City Royals
+715419|Boston Red Sox at Kansas City Royals (Monday May 7, 2012)|Kansas City Royals vs Boston Red Sox [5/7/2012] Tickets at StubHub!|Boston Red Sox at Kansas City Royals
+715420|Detroit Tigers at Kansas City Royals (Wednesday October 3, 2012)|Kansas City Royals vs Detroit Tigers [10/3/2012] Tickets at StubHub!|Detroit Tigers at Kansas City Royals
+715421|Toronto Blue Jays at Kansas City Royals (Sunday April 22, 2012)|Kansas City Royals vs Toronto Blue Jays [4/22/2012] Tickets at StubHub!|Toronto Blue Jays at Kansas City Royals
+715422|Seattle Mariners at Kansas City Royals (Monday July 16, 2012)|Kansas City Royals vs Seattle Mariners [7/16/2012] Tickets at StubHub!|Seattle Mariners at Kansas City Royals
+715423|New York Yankees at Kansas City Royals (Saturday May 5, 2012)|Kansas City Royals vs New York Yankees [5/5/2012] Tickets at StubHub!|New York Yankees at Kansas City Royals
+715424|Detroit Tigers at Kansas City Royals (Monday October 1, 2012)|Kansas City Royals vs Detroit Tigers [10/1/2012] Tickets at StubHub!|Detroit Tigers at Kansas City Royals
+715425|Texas Rangers at Kansas City Royals (Wednesday September 5, 2012)|Kansas City Royals vs Texas Rangers [9/5/2012] Tickets at StubHub!|Texas Rangers at Kansas City Royals
+715426|Seattle Mariners at Kansas City Royals (Wednesday July 18, 2012)|Kansas City Royals vs Seattle Mariners [7/18/2012] Tickets at StubHub!|Seattle Mariners at Kansas City Royals
+715427|New York Yankees at Kansas City Royals (Thursday May 3, 2012)|Kansas City Royals vs New York Yankees [5/3/2012] Tickets at StubHub!|New York Yankees at Kansas City Royals
+715428|Detroit Tigers at Kansas City Royals (Wednesday April 18, 2012)|Kansas City Royals vs Detroit Tigers [4/18/2012] Tickets at StubHub!|Detroit Tigers at Kansas City Royals
+715429|Milwaukee Brewers at Kansas City Royals (Wednesday June 13, 2012)|Kansas City Royals vs Milwaukee Brewers [6/13/2012] Tickets at StubHub!|Milwaukee Brewers at Kansas City Royals
+715430|Minnesota Twins at Kansas City Royals (Friday July 20, 2012)|Kansas City Royals vs Minnesota Twins [7/20/2012] Tickets at StubHub!|Minnesota Twins at Kansas City Royals
+715431|Chicago White Sox at Kansas City Royals (Sunday July 15, 2012)|Kansas City Royals vs Chicago White Sox [7/15/2012] Tickets at StubHub!|Chicago White Sox at Kansas City Royals
+715432|Tampa Bay Rays at Kansas City Royals (Wednesday June 27, 2012)|Kansas City Royals vs Tampa Bay Rays [6/27/2012] Tickets at StubHub!|Tampa Bay Rays at Kansas City Royals
+715433|St. Louis Cardinals at Kansas City Royals (Friday June 22, 2012)|Kansas City Royals vs St. Louis Cardinals [6/22/2012] Tickets at StubHub!|St. Louis Cardinals at Kansas City Royals
+715434|Oakland Athletics at Kansas City Royals (Sunday June 3, 2012)|Kansas City Royals vs Oakland Athletics [6/3/2012] Tickets at StubHub!|Oakland Athletics at Kansas City Royals
+715435|Minnesota Twins at Kansas City Royals (Sunday July 22, 2012)|Kansas City Royals vs Minnesota Twins [7/22/2012] Tickets at StubHub!|Minnesota Twins at Kansas City Royals
+715436|Chicago White Sox at Kansas City Royals (Friday August 17, 2012)|Kansas City Royals vs Chicago White Sox [8/17/2012] Tickets at StubHub!|Chicago White Sox at Kansas City Royals
+715437|Oakland Athletics at Kansas City Royals (Friday June 1, 2012)|Kansas City Royals vs Oakland Athletics [6/1/2012] Tickets at StubHub!|Oakland Athletics at Kansas City Royals
+715438|Cleveland Indians at Kansas City Royals (Friday April 13, 2012)|Kansas City Royals vs Cleveland Indians [4/13/2012] Tickets at StubHub!|Cleveland Indians at Kansas City Royals
+715439|Chicago White Sox at Kansas City Royals (Sunday August 19, 2012)|Kansas City Royals vs Chicago White Sox [8/19/2012] Tickets at StubHub!|Chicago White Sox at Kansas City Royals
+715440|Texas Rangers at Kansas City Royals (Saturday August 4, 20120|Kansas City Royals vs Texas Rangers [8/4/2012] Tickets at StubHub!|Texas Rangers at Kansas City Royals
+715441|Chicago White Sox at Kansas City Royals (Thursday September 20, 2012)|Kansas City Royals vs Chicago White Sox [9/20/2012] Tickets at StubHub!|Chicago White Sox at Kansas City Royals
+715443|Kansas City Royals at Toronto Blue Jays (Thu. 7/5/12)|Toronto Blue Jays vs Kansas City Royals [7/5/2012] Tickets at StubHub!|Kansas City Royals at Toronto Blue Jays
+715444|Seattle Mariners at Toronto Blue Jays (Wed. 9/12/12)|Toronto Blue Jays vs Seattle Mariners [9/12/2012] Tickets at StubHub!|Seattle Mariners at Toronto Blue Jays
+715445|Tampa Bay Rays at Toronto Blue Jays (Thu. 4/19/12)|Toronto Blue Jays vs Tampa Bay Rays [4/19/2012] Tickets at StubHub!|Tampa Bay Rays at Toronto Blue Jays
+715446|Detroit Tigers at Toronto Blue Jays (Sun. 7/29/12)|Toronto Blue Jays vs Detroit Tigers [7/29/2012] Tickets at StubHub!|Detroit Tigers at Toronto Blue Jays
+715447|New York Yankees at Toronto Blue Jays (Thu. 5/17/12)|Toronto Blue Jays vs New York Yankees [5/17/2012] Tickets at StubHub!|New York Yankees at Toronto Blue Jays
+715448|Baltimore Orioles at Toronto Blue Jays (Tue. 9/4/12)|Toronto Blue Jays vs Baltimore Orioles [9/4/2012] Tickets at StubHub!|Baltimore Orioles at Toronto Blue Jays
+715449|Seattle Mariners at Toronto Blue Jays (Fri. 4/27/12)|Toronto Blue Jays vs Seattle Mariners [4/27/2012] Tickets at StubHub!|Seattle Mariners at Toronto Blue Jays
+715450|Cleveland Indians at Toronto Blue Jays (Sat. 7/14/12)|Toronto Blue Jays vs Cleveland Indians [7/14/2012] Tickets at StubHub!|Cleveland Indians at Toronto Blue Jays
+715451|Tampa Bay Rays at Toronto Blue Jays (Mon. 5/14/12)|Toronto Blue Jays vs Tampa Bay Rays [5/14/2012] Tickets at StubHub!|Tampa Bay Rays at Toronto Blue Jays
+715452|Boston Red Sox at Toronto Blue Jays (Sat. 6/2/12)|Toronto Blue Jays vs Boston Red Sox [6/2/2012] Tickets at StubHub!|Boston Red Sox at Toronto Blue Jays
+715453|Chicago White Sox at Toronto Blue Jays (Thu. 8/16/12)|Toronto Blue Jays vs Chicago White Sox [8/16/2012] Tickets at StubHub!|Chicago White Sox at Toronto Blue Jays
+715454|Boston Red Sox at Toronto Blue Jays (Tue. 4/10/12)|Toronto Blue Jays vs Boston Red Sox [4/10/2012] Tickets at StubHub!|Boston Red Sox at Toronto Blue Jays
+715455|New York Yankees at Toronto Blue Jays (Fri. 9/28/12)|Toronto Blue Jays vs New York Yankees [9/28/2012] Tickets at StubHub!|New York Yankees at Toronto Blue Jays
+715456|Seattle Mariners at Toronto Blue Jays (Thu. 9/13/12)|Toronto Blue Jays vs Seattle Mariners [9/13/2012] Tickets at StubHub!|Seattle Mariners at Toronto Blue Jays
+715457|Tampa Bay Rays at Toronto Blue Jays (Wed. 4/18/12)|Toronto Blue Jays vs Tampa Bay Rays [4/18/2012] Tickets at StubHub!|Tampa Bay Rays at Toronto Blue Jays
+715458|Minnesota Twins at Toronto Blue Jays (Wed. 10/3/12)|Toronto Blue Jays vs Minnesota Twins [10/3/2012] Tickets at StubHub!|Minnesota Twins at Toronto Blue Jays
+715459|Baltimore Orioles at Toronto Blue Jays (Wed. 5/30/12)|Toronto Blue Jays vs Baltimore Orioles [5/30/2012] Tickets at StubHub!|Baltimore Orioles at Toronto Blue Jays
+715460|New York Yankees at Toronto Blue Jays (Sat. 8/11/12)|Toronto Blue Jays vs New York Yankees [8/11/2012] Tickets at StubHub!|New York Yankees at Toronto Blue Jays
+715461|Baltimore Orioles at Toronto Blue Jays (Wed. 9/5/12)|Toronto Blue Jays vs Baltimore Orioles [9/5/2012] Tickets at StubHub!|Baltimore Orioles at Toronto Blue Jays
+715462|Cleveland Indians at Toronto Blue Jays (Sun. 7/15/12)|Toronto Blue Jays vs Cleveland Indians [7/15/2012] Tickets at StubHub!|Cleveland Indians at Toronto Blue Jays
+715463|Tampa Bay Rays at Toronto Blue Jays (Tue. 5/15/12)|Toronto Blue Jays vs Tampa Bay Rays [5/15/2012] Tickets at StubHub!|Tampa Bay Rays at Toronto Blue Jays
+715464|Boston Red Sox at Toronto Blue Jays (Fri. 6/1/12)|Toronto Blue Jays vs Boston Red Sox [6/1/2012] Tickets at StubHub!|Boston Red Sox at Toronto Blue Jays
+715465|Texas Rangers at Toronto Blue Jays (Sun. 8/19/12)|Toronto Blue Jays vs Texas Rangers [8/19/2012] Tickets at StubHub!|Texas Rangers at Toronto Blue Jays
+715466|Baltimore Orioles at Toronto Blue Jays (Fri. 4/13/12)|Toronto Blue Jays vs Baltimore Orioles [4/13/2012] Tickets at StubHub!|Baltimore Orioles at Toronto Blue Jays
+715467|New York Yankees at Toronto Blue Jays (Sat. 9/29/12)|Toronto Blue Jays vs New York Yankees [9/29/2012] Tickets at StubHub!|New York Yankees at Toronto Blue Jays
+715468|Texas Rangers at Toronto Blue Jays (Sat. 8/18/12)|Toronto Blue Jays vs Texas Rangers [8/18/2012] Tickets at StubHub!|Texas Rangers at Toronto Blue Jays
+715469|Tampa Bay Rays at Toronto Blue Jays (Sun. 9/2/12)|Toronto Blue Jays vs Tampa Bay Rays [9/2/2012] Tickets at StubHub!|Tampa Bay Rays at Toronto Blue Jays
+715470|Minnesota Twins at Toronto Blue Jays (Tue. 10/2/12)|Toronto Blue Jays vs Minnesota Twins [10/2/2012] Tickets at StubHub!|Minnesota Twins at Toronto Blue Jays
+715471|New York Yankees at Toronto Blue Jays (Fri. 8/10/12)|Toronto Blue Jays vs New York Yankees [8/10/2012] Tickets at StubHub!|New York Yankees at Toronto Blue Jays
+715472|Philadelphia Phillies at Toronto Blue Jays (Sun. 6/17/12)|Toronto Blue Jays vs Philadelphia Phillies [6/17/2012] Tickets at StubHub!|Philadelphia Phillies at Toronto Blue Jays
+715473|Seattle Mariners at Toronto Blue Jays (Sun. 4/29/12)|Toronto Blue Jays vs Seattle Mariners [4/29/2012] Tickets at StubHub!|Seattle Mariners at Toronto Blue Jays
+715474|Seattle Mariners at Toronto Blue Jays (Tue. 9/11/12)|Toronto Blue Jays vs Seattle Mariners [9/11/2012] Tickets at StubHub!|Seattle Mariners at Toronto Blue Jays
+715475|Oakland Athletics at Toronto Blue Jays (Tue. 7/24/12)|Toronto Blue Jays vs Oakland Athletics [7/24/2012] Tickets at StubHub!|Oakland Athletics at Toronto Blue Jays
+715476|New York Mets at Toronto Blue Jays (Sun. 5/20/12)|Toronto Blue Jays vs New York Mets [5/20/2012] Tickets at StubHub!|New York Mets at Toronto Blue Jays
+715477|Chicago White Sox at Toronto Blue Jays (Mon. 8/13/12)|Toronto Blue Jays vs Chicago White Sox [8/13/2012] Tickets at StubHub!|Chicago White Sox at Toronto Blue Jays
+715478|Baltimore Orioles at Toronto Blue Jays (Mon. 9/3/12)|Toronto Blue Jays vs Baltimore Orioles [9/3/2012] Tickets at StubHub!|Baltimore Orioles at Toronto Blue Jays
+715479|Minnesota Twins at Toronto Blue Jays (Mon. 10/1/12)|Toronto Blue Jays vs Minnesota Twins [10/1/2012] Tickets at StubHub!|Minnesota Twins at Toronto Blue Jays
+715480|Philadelphia Phillies at Toronto Blue Jays (Fri. 6/15/12)|Toronto Blue Jays vs Philadelphia Phillies [6/15/2012] Tickets at StubHub!|Philadelphia Phillies at Toronto Blue Jays
+715481|Baltimore Orioles at Toronto Blue Jays (Mon. 5/28/12)|Toronto Blue Jays vs Baltimore Orioles [5/28/2012] Tickets at StubHub!|Baltimore Orioles at Toronto Blue Jays
+715482|Philadelphia Phillies at Toronto Blue Jays (Sat. 6/16/12)|Toronto Blue Jays vs Philadelphia Phillies [6/16/2012] Tickets at StubHub!|Philadelphia Phillies at Toronto Blue Jays
+715483|New York Yankees at Toronto Blue Jays (Thu. 9/27/12)|Toronto Blue Jays vs New York Yankees [9/27/2012] Tickets at StubHub!|New York Yankees at Toronto Blue Jays
+715484|Seattle Mariners at Toronto Blue Jays (Sat. 4/28/12)|Toronto Blue Jays vs Seattle Mariners [4/28/2012] Tickets at StubHub!|Seattle Mariners at Toronto Blue Jays
+715485|Los Angeles Angels at Toronto Blue Jays (Sun. 7/1/12)|Toronto Blue Jays vs Los Angeles Angels [7/1/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Toronto Blue Jays
+715486|Baltimore Orioles at Toronto Blue Jays (Sun. 4/15/12)|Toronto Blue Jays vs Baltimore Orioles [4/15/2012] Tickets at StubHub!|Baltimore Orioles at Toronto Blue Jays
+715487|Oakland Athletics at Toronto Blue Jays (Wed. 7/25/12)|Toronto Blue Jays vs Oakland Athletics [7/25/2012] Tickets at StubHub!|Oakland Athletics at Toronto Blue Jays
+715488|New York Yankees at Toronto Blue Jays (Sun. 8/12/12)|Toronto Blue Jays vs New York Yankees [8/12/2012] Tickets at StubHub!|New York Yankees at Toronto Blue Jays
+715489|Texas Rangers at Toronto Blue Jays (Wed. 5/2/12)|Toronto Blue Jays vs Texas Rangers [5/2/2012] Tickets at StubHub!|Texas Rangers at Toronto Blue Jays
+715490|Baltimore Orioles at Toronto Blue Jays (Tue. 5/29/12)|Toronto Blue Jays vs Baltimore Orioles [5/29/2012] Tickets at StubHub!|Baltimore Orioles at Toronto Blue Jays
+715491|Kansas City Royals at Toronto Blue Jays (Mon. 7/2/12)|Toronto Blue Jays vs Kansas City Royals [7/2/2012] Tickets at StubHub!|Kansas City Royals at Toronto Blue Jays
+715492|Baltimore Orioles at Toronto Blue Jays (Sat. 4/14/12)|Toronto Blue Jays vs Baltimore Orioles [4/14/2012] Tickets at StubHub!|Baltimore Orioles at Toronto Blue Jays
+715493|Boston Red Sox at Toronto Blue Jays (Sun. 9/16/12)|Toronto Blue Jays vs Boston Red Sox [9/16/2012] Tickets at StubHub!|Boston Red Sox at Toronto Blue Jays
+715494|Oakland Athletics at Toronto Blue Jays (Thu. 7/26/12)|Toronto Blue Jays vs Oakland Athletics [7/26/2012] Tickets at StubHub!|Oakland Athletics at Toronto Blue Jays
+715495|New York Mets at Toronto Blue Jays (Fri. 5/18/12)|Toronto Blue Jays vs New York Mets [5/18/2012] Tickets at StubHub!|New York Mets at Toronto Blue Jays
+715496|Chicago White Sox at Toronto Blue Jays (Wed. 8/15/12)|Toronto Blue Jays vs Chicago White Sox [8/15/2012] Tickets at StubHub!|Chicago White Sox at Toronto Blue Jays
+715497|Los Angeles Angels at Toronto Blue Jays (Sat. 6/30/12)|Toronto Blue Jays vs Los Angeles Angels [6/30/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Toronto Blue Jays
+715498|Tampa Bay Rays at Toronto Blue Jays (Sat. 9/1/12)|Toronto Blue Jays vs Tampa Bay Rays [9/1/2012] Tickets at StubHub!|Tampa Bay Rays at Toronto Blue Jays
+715499|Washington Nationals at Toronto Blue Jays (Wed. 6/13/12)|Toronto Blue Jays vs Washington Nationals [6/13/2012] Tickets at StubHub!|Washington Nationals at Toronto Blue Jays
+715500|Boston Red Sox at Toronto Blue Jays (Mon. 4/9/12)|Toronto Blue Jays vs Boston Red Sox [4/9/2012] Tickets at StubHub!|Boston Red Sox at Toronto Blue Jays
+715501|Texas Rangers at Toronto Blue Jays (Mon. 4/30/12)|Toronto Blue Jays vs Texas Rangers [4/30/2012] Tickets at StubHub!|Texas Rangers at Toronto Blue Jays
+715502|Kansas City Royals at Toronto Blue Jays (Tue. 7/3/12)|Toronto Blue Jays vs Kansas City Royals [7/3/2012] Tickets at StubHub!|Kansas City Royals at Toronto Blue Jays
+715503|Boston Red Sox at Toronto Blue Jays (Fri. 9/14/12)|Toronto Blue Jays vs Boston Red Sox [9/14/2012] Tickets at StubHub!|Boston Red Sox at Toronto Blue Jays
+715504|Tampa Bay Rays at Toronto Blue Jays (Fri. 8/31/12)|Toronto Blue Jays vs Tampa Bay Rays [8/31/2012] Tickets at StubHub!|Tampa Bay Rays at Toronto Blue Jays
+715505|Tampa Bay Rays at Toronto Blue Jays (Tue. 4/17/12)|Toronto Blue Jays vs Tampa Bay Rays [4/17/2012] Tickets at StubHub!|Tampa Bay Rays at Toronto Blue Jays
+715506|Detroit Tigers at Toronto Blue Jays (Fri. 7/27/12)|Toronto Blue Jays vs Detroit Tigers [7/27/2012] Tickets at StubHub!|Detroit Tigers at Toronto Blue Jays
+715507|New York Mets at Toronto Blue Jays (Sat. 5/19/12)|Toronto Blue Jays vs New York Mets [5/19/2012] Tickets at StubHub!|New York Mets at Toronto Blue Jays
+715508|Chicago White Sox at Toronto Blue Jays (Tue. 8/14/12)|Toronto Blue Jays vs Chicago White Sox [8/14/2012] Tickets at StubHub!|Chicago White Sox at Toronto Blue Jays
+715509|Los Angeles Angels at Toronto Blue Jays (Fri. 6/29/12)|Toronto Blue Jays vs Los Angeles Angels [6/29/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Toronto Blue Jays
+715510|Washington Nationals at Toronto Blue Jays (Tue. 6/12/12)|Toronto Blue Jays vs Washington Nationals [6/12/2012] Tickets at StubHub!|Washington Nationals at Toronto Blue Jays
+715511|New York Yankees at Toronto Blue Jays (Sun. 9/30/12)|Toronto Blue Jays vs New York Yankees [9/30/2012] Tickets at StubHub!|New York Yankees at Toronto Blue Jays
+715512|Kansas City Royals at Toronto Blue Jays (Wed. 7/4/12)|Toronto Blue Jays vs Kansas City Royals [7/4/2012] Tickets at StubHub!|Kansas City Royals at Toronto Blue Jays
+715513|Boston Red Sox at Toronto Blue Jays (Sat. 9/15/12)|Toronto Blue Jays vs Boston Red Sox [9/15/2012] Tickets at StubHub!|Boston Red Sox at Toronto Blue Jays
+715514|Tampa Bay Rays at Toronto Blue Jays (Thu. 8/30/12)|Toronto Blue Jays vs Tampa Bay Rays [8/30/2012] Tickets at StubHub!|Tampa Bay Rays at Toronto Blue Jays
+715515|Detroit Tigers at Toronto Blue Jays (Sat. 7/28/12)|Toronto Blue Jays vs Detroit Tigers [7/28/2012] Tickets at StubHub!|Detroit Tigers at Toronto Blue Jays
+715516|Washington Nationals at Toronto Blue Jays (Mon. 6/11/12)|Toronto Blue Jays vs Washington Nationals [6/11/2012] Tickets at StubHub!|Washington Nationals at Toronto Blue Jays
+715517|New York Yankees at Toronto Blue Jays (Wed. 5/16/12)|Toronto Blue Jays vs New York Yankees [5/16/2012] Tickets at StubHub!|New York Yankees at Toronto Blue Jays
+715518|Los Angeles Angels at Toronto Blue Jays (Thu. 6/28/12)|Toronto Blue Jays vs Los Angeles Angels [6/28/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Toronto Blue Jays
+715519|Cleveland Indians at Toronto Blue Jays (Fri. 7/13/12)|Toronto Blue Jays vs Cleveland Indians [7/13/2012] Tickets at StubHub!|Cleveland Indians at Toronto Blue Jays
+715520|Texas Rangers at Toronto Blue Jays (Tue. 5/1/12)|Toronto Blue Jays vs Texas Rangers [5/1/2012] Tickets at StubHub!|Texas Rangers at Toronto Blue Jays
+715521|Boston Red Sox at Toronto Blue Jays (Sun. 6/3/12)|Toronto Blue Jays vs Boston Red Sox [6/3/2012] Tickets at StubHub!|Boston Red Sox at Toronto Blue Jays
+715522|Texas Rangers at Toronto Blue Jays (Fri. 8/17/12)|Toronto Blue Jays vs Texas Rangers [8/17/2012] Tickets at StubHub!|Texas Rangers at Toronto Blue Jays
+715523|Boston Red Sox at Toronto Blue Jays (Wed. 4/11/12)|Toronto Blue Jays vs Boston Red Sox [4/11/2012] Tickets at StubHub!|Boston Red Sox at Toronto Blue Jays
+715606|Los Angeles Angels at Baltimore Orioles (Wednesday June 27, 2012)|Baltimore Orioles vs Los Angeles Angels [6/27/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Baltimore Orioles
+715607|Los Angeles Angels at Baltimore Orioles (Tuesday June 26, 2012)|Baltimore Orioles vs Los Angeles Angels [6/26/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Baltimore Orioles
+715609|Los Angeles Angels at Boston Red Sox (Tuesday August 21, 2012)|Boston Red Sox vs Los Angeles Angels [8/21/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Boston Red Sox
+715610|Los Angeles Angels at Boston Red Sox (Thursday August 23, 2012)|Boston Red Sox vs Los Angeles Angels [8/23/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Boston Red Sox
+715611|Los Angeles Angels at Boston Red Sox (Wednesday August 22, 2012)|Boston Red Sox vs Los Angeles Angels [8/22/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Boston Red Sox
+715755|Los Angeles Dodgers at Arizona Diamondbacks|Arizona Diamondbacks vs Los Angeles Dodgers [5/22/2012] Tickets at StubHub!|Los Angeles Dodgers at Arizona Diamondbacks
+715756|Los Angeles Dodgers at Arizona Diamondbacks|Arizona Diamondbacks vs Los Angeles Dodgers [5/23/2012] Tickets at StubHub!|Los Angeles Dodgers at Arizona Diamondbacks
+717685|Seattle Mariners at Los Angeles Angels (Thursday September 27, 2012)|Los Angeles Angels vs Seattle Mariners [9/27/2012] Tickets at StubHub!|Seattle Mariners at Los Angeles Angels of Anaheim
+718160|Pittsburgh Pirates at San Francisco Giants|San Francisco Giants vs Pittsburgh Pirates [4/15/2012] Tickets at StubHub!|Pittsburgh Pirates at San Francisco Giants
+718161|Pittsburgh Pirates at San Francisco Giants|San Francisco Giants vs Pittsburgh Pirates [4/14/2012] Tickets at StubHub!|Pittsburgh Pirates at San Francisco Giants
+718162|Pittsburgh Pirates at San Francisco Giants|San Francisco Giants vs Pittsburgh Pirates [4/13/2012] Tickets at StubHub!|Pittsburgh Pirates at San Francisco Giants
+719085|San Diego Padres at San Francisco Giants|San Francisco Giants vs San Diego Padres [4/27/2012] Tickets at StubHub!|San Diego Padres at San Francisco Giants
+719086|Philadelphia Phillies at San Francisco Giants|San Francisco Giants vs Philadelphia Phillies [4/16/2012] Tickets at StubHub!|Philadelphia Phillies at San Francisco Giants
+719087|San Diego Padres at San Francisco Giants|San Francisco Giants vs San Diego Padres [4/28/2012] Tickets at StubHub!|San Diego Padres at San Francisco Giants
+719838|Philadelphia Phillies at San Francisco Giants|San Francisco Giants vs Philadelphia Phillies [4/17/2012] Tickets at StubHub!|Philadelphia Phillies at San Francisco Giants
+719839|San Diego Padres at San Francisco Giants|San Francisco Giants vs San Diego Padres [4/29/2012] Tickets at StubHub!|San Diego Padres at San Francisco Giants
+719840|Miami Marlins at San Francisco Giants|San Francisco Giants vs Miami Marlins [5/1/2012] Tickets at StubHub!|Miami Marlins at San Francisco Giants
+719841|Oakland Athletics at San Francisco Giants|San Francisco Giants vs Oakland Athletics [5/18/2012] Tickets at StubHub!|Oakland Athletics at San Francisco Giants
+719842|Philadelphia Phillies at San Francisco Giants|San Francisco Giants vs Philadelphia Phillies [4/18/2012] Tickets at StubHub!|Philadelphia Phillies at San Francisco Giants
+720490|Philadelphia Phillies at New York Mets (Thursday July 5, 2012)|New York Mets vs Philadelphia Phillies [07/05/2012] Tickets at StubHub!|Philadelphia Phillies at New York Mets
+720491|Philadelphia Phillies at New York Mets (Tuesday September 18, 2012)|New York Mets vs Philadelphia Phillies [09/18/2012] Tickets at StubHub!|Philadelphia Phillies at New York Mets
+720492|Philadelphia Phillies at New York Mets (Wednesday September 19, 2012)|New York Mets vs Philadelphia Phillies [09/19/2012] Tickets at StubHub!|Philadelphia Phillies at New York Mets
+720493|Atlanta Braves at New York Mets (Thursday April 5, 2012)|New York Mets vs Atlanta Braves [04/05/2012] Tickets at StubHub!|Atlanta Braves at New York Mets
+720494|Philadelphia Phillies at New York Mets (Tuesday May 29, 2012)|New York Mets vs Philadelphia Phillies [05/29/2012] Tickets at StubHub!|Philadelphia Phillies at New York Mets
+720495|Pittsburgh Pirates at New York Mets (Wednesday September 26, 2012)|New York Mets vs Pittsburgh Pirates [09/26/2012] Tickets at StubHub!|Pittsburgh Pirates at New York Mets
+720496|Philadelphia Phillies at New York Mets (Monday September 17, 2012)|New York Mets vs Philadelphia Phillies [09/17/2012] Tickets at StubHub!|Philadelphia Phillies at New York Mets
+720497|Pittsburgh Pirates at New York Mets (Thursday September 27, 2012)|New York Mets vs Pittsburgh Pirates [09/27/2012] Tickets at StubHub!|Pittsburgh Pirates at New York Mets
+720498|New York Yankees at New York Mets (Saturday June 23, 2012)|New York Mets vs New York Yankees [06/23/2012] Tickets at StubHub!|New York Yankees at New York Mets
+720499|New York Yankees at New York Mets (Friday June 22, 2012)|New York Mets vs New York Yankees [06/22/2012] Tickets at StubHub!|New York Yankees at New York Mets
+720500|Philadelphia Phillies at New York Mets (Wednesday May 30, 2012)|New York Mets vs Philadelphia Phillies [05/30/2012] Tickets at StubHub!|Philadelphia Phillies at New York Mets
+720501|New York Yankees at New York Mets (Sunday June 24, 2012)|New York Mets vs New York Yankees [06/24/2012] Tickets at StubHub!|New York Yankees at New York Mets
+720502|Philadelphia Phillies at New York Mets (Monday May 28, 2012)|New York Mets vs Philadelphia Phillies [05/28/2012] Tickets at StubHub!|Philadelphia Phillies at New York Mets
+720503|Philadelphia Phillies at New York Mets (Tuesday July 3, 2012)|New York Mets vs Philadelphia Phillies [07/03/2012] Tickets at StubHub!|Philadelphia Phillies at New York Mets
+720504|Philadelphia Phillies at New York Mets (Wednesday July 4, 2012)|New York Mets vs Philadelphia Phillies [07/04/2012] Tickets at StubHub!|Philadelphia Phillies at New York Mets
+720959|Los Angeles Dodgers at San Francisco Giants|San Francisco Giants vs Los Angeles Dodgers [6/27/2012] Tickets at StubHub!|Los Angeles Dodgers at San Francisco Giants
+720960|San Diego Padres at San Francisco Giants|San Francisco Giants vs San Diego Padres [7/25/2012] Tickets at StubHub!|San Diego Padres at San Francisco Giants
+720961|Los Angeles Dodgers at San Francisco Giants|San Francisco Giants vs Los Angeles Dodgers [6/25/2012] Tickets at StubHub!|Los Angeles Dodgers at San Francisco Giants
+720962|Texas Rangers at San Francisco Giants|San Francisco Giants vs Texas Rangers [6/10/2012] Tickets at StubHub!|Texas Rangers at San Francisco Giants
+720963|Milwaukee Brewers at San Francisco Giants|San Francisco Giants vs Milwaukee Brewers [5/4/2012] Tickets at StubHub!|Milwaukee Brewers at San Francisco Giants
+720964|Texas Rangers at San Francisco Giants|San Francisco Giants vs Texas Rangers [6/8/2012] Tickets at StubHub!|Texas Rangers at San Francisco Giants
+720965|Miami Marlins at San Francisco Giants|San Francisco Giants vs Miami Marlins [5/2/2012] Tickets at StubHub!|Miami Marlins at San Francisco Giants
+720966|Houston Astros at San Francisco Giants|San Francisco Giants vs Houston Astros [6/14/2012] Tickets at StubHub!|Houston Astros at San Francisco Giants
+720967|Arizona Diamondbacks at San Francisco Giants|San Francisco Giants vs Arizona Diamondbacks [5/29/2012] Tickets at StubHub!|Arizona Diamondbacks at San Francisco Giants
+720968|Houston Astros at San Francisco Giants|San Francisco Giants vs Houston Astros [7/14/2012] Tickets at StubHub!|Houston Astros at San Francisco Giants
+720969|Houston Astros at San Francisco Giants|San Francisco Giants vs Houston Astros [6/12/2012] Tickets at StubHub!|Houston Astros at San Francisco Giants
+720970|Colorado Rockies at San Francisco Giants|San Francisco Giants vs Colorado Rockies [5/14/2012] Tickets at StubHub!|Colorado Rockies at San Francisco Giants
+720971|San Diego Padres at San Francisco Giants|San Francisco Giants vs San Diego Padres [7/23/2012] Tickets at StubHub!|San Diego Padres at San Francisco Giants
+720972|San Diego Padres at San Francisco Giants|San Francisco Giants vs San Diego Padres [7/24/2012] Tickets at StubHub!|San Diego Padres at San Francisco Giants
+720973|Los Angeles Dodgers at San Francisco Giants|San Francisco Giants vs Los Angeles Dodgers [6/26/2012] Tickets at StubHub!|Los Angeles Dodgers at San Francisco Giants
+720974|Atlanta Braves at San Francisco Giants|San Francisco Giants vs Atlanta Braves [8/26/2012] Tickets at StubHub!|Atlanta Braves at San Francisco Giants
+720975|Cincinnati Reds at San Francisco Giants|San Francisco Giants vs Cincinnati Reds [6/30/2012] Tickets at StubHub!|Cincinnati Reds at San Francisco Giants
+720976|Arizona Diamondbacks at San Francisco Giants|San Francisco Giants vs Arizona Diamondbacks [5/30/2012] Tickets at StubHub!|Arizona Diamondbacks at San Francisco Giants
+720977|Milwaukee Brewers at San Francisco Giants|San Francisco Giants vs Milwaukee Brewers [5/5/2012] Tickets at StubHub!|Milwaukee Brewers at San Francisco Giants
+720978|Colorado Rockies at San Francisco Giants|San Francisco Giants vs Colorado Rockies [8/11/2012] Tickets at StubHub!|Colorado Rockies at San Francisco Giants
+720979|Arizona Diamondbacks at San Francisco Giants|San Francisco Giants vs Arizona Diamondbacks [5/28/2012] Tickets at StubHub!|Arizona Diamondbacks at San Francisco Giants
+720980|Miami Marlins at San Francisco Giants|San Francisco Giants vs Miami Marlins [5/3/2012] Tickets at StubHub!|Miami Marlins at San Francisco Giants
+720981|Houston Astros at San Francisco Giants|San Francisco Giants vs Houston Astros [6/13/2012] Tickets at StubHub!|Houston Astros at San Francisco Giants
+720982|Arizona Diamondbacks at San Francisco Giants|San Francisco Giants vs Arizona Diamondbacks [9/27/2012] Tickets at StubHub!|Arizona Diamondbacks at San Francisco Giants
+720983|Chicago Cubs at San Francisco Giants|San Francisco Giants vs Chicago Cubs [6/3/2012] Tickets at StubHub!|Chicago Cubs at San Francisco Giants
+720984|Colorado Rockies at San Francisco Giants|San Francisco Giants vs Colorado Rockies [5/15/2012] Tickets at StubHub!|Colorado Rockies at San Francisco Giants
+720985|Chicago Cubs at San Francisco Giants|San Francisco Giants vs Chicago Cubs [6/1/2012] Tickets at StubHub!|Chicago Cubs at San Francisco Giants
+720987|Oakland Athletics at Seattle Mariners|Seattle Mariners vs Oakland Athletics [9/8/2012] Tickets at StubHub!|Oakland Athletics at Seattle Mariners
+720988|Kansas City Royals at Seattle Mariners|Seattle Mariners vs Kansas City Royals [7/26/2012] Tickets at StubHub!|Kansas City Royals at Seattle Mariners
+720989|Oakland Athletics at Seattle Mariners|Seattle Mariners vs Oakland Athletics [4/15/2012] Tickets at StubHub!|Oakland Athletics at Seattle Mariners
+720990|Baltimore Orioles at Seattle Mariners|Seattle Mariners vs Baltimore Orioles [9/19/2012] Tickets at StubHub!|Baltimore Orioles at Seattle Mariners
+720991|Detroit Tigers at Seattle Mariners|Seattle Mariners vs Detroit Tigers [5/9/2012] Tickets at StubHub!|Detroit Tigers at Seattle Mariners
+720992|Los Angeles Angels at Seattle Mariners|Seattle Mariners vs Los Angeles Angels [8/31/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Seattle Mariners
+720993|Cleveland Indians at Seattle Mariners|Seattle Mariners vs Cleveland Indians [4/17/2012] Tickets at StubHub!|Cleveland Indians at Seattle Mariners
+720994|Baltimore Orioles at Seattle Mariners|Seattle Mariners vs Baltimore Orioles [9/17/2012] Tickets at StubHub!|Baltimore Orioles at Seattle Mariners
+720996|Cleveland Indians at Seattle Mariners|Seattle Mariners vs Cleveland Indians [4/19/2012] Tickets at StubHub!|Cleveland Indians at Seattle Mariners
+720997|Texas Rangers at Seattle Mariners|Seattle Mariners vs Texas Rangers [9/23/2012] Tickets at StubHub!|Texas Rangers at Seattle Mariners
+720998|Los Angeles Angels at Seattle Mariners|Seattle Mariners vs Los Angeles Angels [9/2/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Seattle Mariners
+720999|Texas Rangers at Seattle Mariners|Seattle Mariners vs Texas Rangers [5/21/2012] Tickets at StubHub!|Texas Rangers at Seattle Mariners
+721000|Baltimore Orioles at Seattle Mariners|Seattle Mariners vs Baltimore Orioles [9/18/2012] Tickets at StubHub!|Baltimore Orioles at Seattle Mariners
+721001|Chicago White Sox at Seattle Mariners|Seattle Mariners vs Chicago White Sox [4/21/2012] Tickets at StubHub!|Chicago White Sox at Seattle Mariners
+721002|Texas Rangers at Seattle Mariners|Seattle Mariners vs Texas Rangers [9/21/2012] Tickets at StubHub!|Texas Rangers at Seattle Mariners
+721003|Kansas City Royals at Seattle Mariners|Seattle Mariners vs Kansas City Royals [7/29/2012] Tickets at StubHub!|Kansas City Royals at Seattle Mariners
+721004|Minnesota Twins at Seattle Mariners|Seattle Mariners vs Minnesota Twins [5/6/2012] Tickets at StubHub!|Minnesota Twins at Seattle Mariners
+721005|Tampa Bay Rays at Seattle Mariners|Seattle Mariners vs Tampa Bay Rays [8/14/2012] Tickets at StubHub!|Tampa Bay Rays at Seattle Mariners
+721006|Boston Red Sox at Seattle Mariners|Seattle Mariners vs Boston Red Sox [6/29/2012] Tickets at StubHub!|Boston Red Sox at Seattle Mariners
+721007|Los Angeles Dodgers at Seattle Mariners|Seattle Mariners vs Los Angeles Dodgers [6/10/2012] Tickets at StubHub!|Los Angeles Dodgers at Seattle Mariners
+721008|Toronto Blue Jays at Seattle Mariners|Seattle Mariners vs Toronto Blue Jays [7/31/2012] Tickets at StubHub!|Toronto Blue Jays at Seattle Mariners
+721009|Minnesota Twins at Seattle Mariners|Seattle Mariners vs Minnesota Twins [5/4/2012] Tickets at StubHub!|Minnesota Twins at Seattle Mariners
+721010|Los Angeles Angels at Seattle Mariners|Seattle Mariners vs Los Angeles Angels [10/2/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Seattle Mariners
+721011|Los Angeles Dodgers at Seattle Mariners|Seattle Mariners vs Los Angeles Dodgers [6/8/2012] Tickets at StubHub!|Los Angeles Dodgers at Seattle Mariners
+721012|Boston Red Sox at Seattle Mariners|Seattle Mariners vs Boston Red Sox [9/4/2012] Tickets at StubHub!|Boston Red Sox at Seattle Mariners
+721013|San Francisco Giants at Seattle Mariners|Seattle Mariners vs San Francisco Giants [6/17/2012] Tickets at StubHub!|San Francisco Giants at Seattle Mariners
+721014|San Diego Padres at Seattle Mariners|Seattle Mariners vs San Diego Padres [6/14/2012] Tickets at StubHub!|San Diego Padres at Seattle Mariners
+721015|Boston Red Sox at Seattle Mariners|Seattle Mariners vs Boston Red Sox [6/30/2012] Tickets at StubHub!|Boston Red Sox at Seattle Mariners
+721016|Texas Rangers at Seattle Mariners|Seattle Mariners vs Texas Rangers [7/14/2012] Tickets at StubHub!|Texas Rangers at Seattle Mariners
+721017|Cleveland Indians at Seattle Mariners|Seattle Mariners vs Cleveland Indians [8/20/2012] Tickets at StubHub!|Cleveland Indians at Seattle Mariners
+721018|San Diego Padres at Seattle Mariners|Seattle Mariners vs San Diego Padres [6/12/2012] Tickets at StubHub!|San Diego Padres at Seattle Mariners
+721019|Los Angeles Angels at Seattle Mariners|Seattle Mariners vs Los Angeles Angels [5/27/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Seattle Mariners
+721020|Cleveland Indians at Seattle Mariners|Seattle Mariners vs Cleveland Indians [8/22/2012] Tickets at StubHub!|Cleveland Indians at Seattle Mariners
+721021|Los Angeles Angels at Seattle Mariners|Seattle Mariners vs Los Angeles Angels [5/25/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Seattle Mariners
+721022|Baltimore Orioles at Seattle Mariners|Seattle Mariners vs Baltimore Orioles [7/2/2012] Tickets at StubHub!|Baltimore Orioles at Seattle Mariners
+721023|Baltimore Orioles at Seattle Mariners|Seattle Mariners vs Baltimore Orioles [7/4/2012] Tickets at StubHub!|Baltimore Orioles at Seattle Mariners
+721024|Minnesota Twins at Seattle Mariners|Seattle Mariners vs Minnesota Twins [8/18/2012] Tickets at StubHub!|Minnesota Twins at Seattle Mariners
+721025|Boston Red Sox at Seattle Mariners|Seattle Mariners vs Boston Red Sox [6/28/2012] Tickets at StubHub!|Boston Red Sox at Seattle Mariners
+721026|Oakland Athletics at Seattle Mariners|Seattle Mariners vs Oakland Athletics [6/27/2012] Tickets at StubHub!|Oakland Athletics at Seattle Mariners
+721027|Oakland Athletics at Seattle Mariners|Seattle Mariners vs Oakland Athletics [9/9/2012] Tickets at StubHub!|Oakland Athletics at Seattle Mariners
+721028|Detroit Tigers at Seattle Mariners|Seattle Mariners vs Detroit Tigers [5/8/2012] Tickets at StubHub!|Detroit Tigers at Seattle Mariners
+721029|New York Yankees at Seattle Mariners|Seattle Mariners vs New York Yankees [7/24/2012] Tickets at StubHub!|New York Yankees at Seattle Mariners
+721030|Toronto Blue Jays at Seattle Mariners|Seattle Mariners vs Toronto Blue Jays [8/1/2012] Tickets at StubHub!|Toronto Blue Jays at Seattle Mariners
+721031|Oakland Athletics at Seattle Mariners|Seattle Mariners vs Oakland Athletics [4/14/2012] Tickets at StubHub!|Oakland Athletics at Seattle Mariners
+721032|Texas Rangers at Seattle Mariners|Seattle Mariners vs Texas Rangers [5/22/2012] Tickets at StubHub!|Texas Rangers at Seattle Mariners
+721033|Oakland Athletics at Seattle Mariners|Seattle Mariners vs Oakland Athletics [6/26/2012] Tickets at StubHub!|Oakland Athletics at Seattle Mariners
+721034|Texas Rangers at Seattle Mariners|Seattle Mariners vs Texas Rangers [9/22/2012] Tickets at StubHub!|Texas Rangers at Seattle Mariners
+721035|New York Yankees at Seattle Mariners|Seattle Mariners vs New York Yankees [7/23/2012] Tickets at StubHub!|New York Yankees at Seattle Mariners
+721036|Tampa Bay Rays at Seattle Mariners|Seattle Mariners vs Tampa Bay Rays [8/13/2012] Tickets at StubHub!|Tampa Bay Rays at Seattle Mariners
+721037|Cleveland Indians at Seattle Mariners|Seattle Mariners vs Cleveland Indians [4/18/2012] Tickets at StubHub!|Cleveland Indians at Seattle Mariners
+721038|New York Yankees at Seattle Mariners|Seattle Mariners vs New York Yankees [7/25/2012] Tickets at StubHub!|New York Yankees at Seattle Mariners
+721039|Boston Red Sox at Seattle Mariners|Seattle Mariners vs Boston Red Sox [9/3/2012] Tickets at StubHub!|Boston Red Sox at Seattle Mariners
+721040|Kansas City Royals at Seattle Mariners|Seattle Mariners vs Kansas City Royals [7/28/2012] Tickets at StubHub!|Kansas City Royals at Seattle Mariners
+721041|Tampa Bay Rays at Seattle Mariners|Seattle Mariners vs Tampa Bay Rays [8/15/2012] Tickets at StubHub!|Tampa Bay Rays at Seattle Mariners
+721042|Chicago White Sox at Seattle Mariners|Seattle Mariners vs Chicago White Sox [4/20/2012] Tickets at StubHub!|Chicago White Sox at Seattle Mariners
+721043|Los Angeles Angels at Seattle Mariners|Seattle Mariners vs Los Angeles Angels [9/1/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Seattle Mariners
+721044|Toronto Blue Jays at Seattle Mariners|Seattle Mariners vs Toronto Blue Jays [7/30/2012] Tickets at StubHub!|Toronto Blue Jays at Seattle Mariners
+721045|Detroit Tigers at Seattle Mariners|Seattle Mariners vs Detroit Tigers [5/7/2012] Tickets at StubHub!|Detroit Tigers at Seattle Mariners
+721046|Los Angeles Angels at Seattle Mariners|Seattle Mariners vs Los Angeles Angels [10/3/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Seattle Mariners
+721047|Chicago White Sox at Seattle Mariners|Seattle Mariners vs Chicago White Sox [4/22/2012] Tickets at StubHub!|Chicago White Sox at Seattle Mariners
+721048|Los Angeles Dodgers at Seattle Mariners|Seattle Mariners vs Los Angeles Dodgers [6/9/2012] Tickets at StubHub!|Los Angeles Dodgers at Seattle Mariners
+721049|Oakland Athletics at Seattle Mariners|Seattle Mariners vs Oakland Athletics [9/7/2012] Tickets at StubHub!|Oakland Athletics at Seattle Mariners
+721050|Minnesota Twins at Seattle Mariners|Seattle Mariners vs Minnesota Twins [5/5/2012] Tickets at StubHub!|Minnesota Twins at Seattle Mariners
+721051|Los Angeles Angels at Seattle Mariners|Seattle Mariners vs Los Angeles Angels [10/1/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Seattle Mariners
+721052|San Francisco Giants at Seattle Mariners|Seattle Mariners vs San Francisco Giants [6/15/2012] Tickets at StubHub!|San Francisco Giants at Seattle Mariners
+721053|Oakland Athletics at Seattle Mariners|Seattle Mariners vs Oakland Athletics [6/25/2012] Tickets at StubHub!|Oakland Athletics at Seattle Mariners
+721054|Texas Rangers at Seattle Mariners|Seattle Mariners vs Texas Rangers [7/13/2012] Tickets at StubHub!|Texas Rangers at Seattle Mariners
+721055|Cleveland Indians at Seattle Mariners|Seattle Mariners vs Cleveland Indians [8/21/2012] Tickets at StubHub!|Cleveland Indians at Seattle Mariners
+721056|San Francisco Giants at Seattle Mariners|Seattle Mariners vs San Francisco Giants [6/16/2012] Tickets at StubHub!|San Francisco Giants at Seattle Mariners
+721057|San Diego Padres at Seattle Mariners|Seattle Mariners vs San Diego Padres [6/13/2012] Tickets at StubHub!|San Diego Padres at Seattle Mariners
+721058|Los Angeles Angels at Seattle Mariners|Seattle Mariners vs Los Angeles Angels [5/26/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Seattle Mariners
+721059|Texas Rangers at Seattle Mariners|Seattle Mariners vs Texas Rangers [7/15/2012] Tickets at StubHub!|Texas Rangers at Seattle Mariners
+721060|Boston Red Sox at Seattle Mariners|Seattle Mariners vs Boston Red Sox [9/5/2012] Tickets at StubHub!|Boston Red Sox at Seattle Mariners
+721061|Los Angeles Angels at Seattle Mariners|Seattle Mariners vs Los Angeles Angels [5/24/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Seattle Mariners
+721062|Boston Red Sox at Seattle Mariners|Seattle Mariners vs Boston Red Sox [7/1/2012] Tickets at StubHub!|Boston Red Sox at Seattle Mariners
+721063|Minnesota Twins at Seattle Mariners|Seattle Mariners vs Minnesota Twins [8/17/2012] Tickets at StubHub!|Minnesota Twins at Seattle Mariners
+721064|Kansas City Royals at Seattle Mariners|Seattle Mariners vs Kansas City Royals [7/27/2012] Tickets at StubHub!|Kansas City Royals at Seattle Mariners
+721065|Baltimore Orioles at Seattle Mariners|Seattle Mariners vs Baltimore Orioles [7/3/2012] Tickets at StubHub!|Baltimore Orioles at Seattle Mariners
+721066|Minnesota Twins at Seattle Mariners|Seattle Mariners vs Minnesota Twins [8/19/2012] Tickets at StubHub!|Minnesota Twins at Seattle Mariners
+721067|Oakland Athletics at Seattle Mariners|Seattle Mariners vs Oakland Athletics [4/13/2012] Tickets at StubHub!|Oakland Athletics at Seattle Mariners
+721135|Texas Rangers at Seattle Mariners|Seattle Mariners vs Texas Rangers [5/23/2012] Tickets at StubHub!|Texas Rangers at Seattle Mariners
+721656|Los Angeles Dodgers at San Francisco Giants|San Francisco Giants vs Los Angeles Dodgers [9/8/2012] Tickets at StubHub!|Los Angeles Dodgers at San Francisco Giants
+721657|Colorado Rockies at San Francisco Giants|San Francisco Giants vs Colorado Rockies [9/19/2012] Tickets at StubHub!|Colorado Rockies at San Francisco Giants
+721658|Colorado Rockies at San Francisco Giants|San Francisco Giants vs Colorado Rockies [9/17/2012] Tickets at StubHub!|Colorado Rockies at San Francisco Giants
+721659|Atlanta Braves at San Francisco Giants|San Francisco Giants vs Atlanta Braves [8/25/2012] Tickets at StubHub!|Atlanta Braves at San Francisco Giants
+721660|New York Mets at San Francisco Giants|San Francisco Giants vs New York Mets [8/2/2012] Tickets at StubHub!|New York Mets at San Francisco Giants
+721661|San Diego Padres at San Francisco Giants|San Francisco Giants vs San Diego Padres [9/23/2012] Tickets at StubHub!|San Diego Padres at San Francisco Giants
+721662|Los Angeles Dodgers at San Francisco Giants|San Francisco Giants vs Los Angeles Dodgers [7/27/2012] Tickets at StubHub!|Los Angeles Dodgers at San Francisco Giants
+721663|Colorado Rockies at San Francisco Giants|San Francisco Giants vs Colorado Rockies [8/12/2012] Tickets at StubHub!|Colorado Rockies at San Francisco Giants
+721664|San Diego Padres at San Francisco Giants|San Francisco Giants vs San Diego Padres [9/21/2012] Tickets at StubHub!|San Diego Padres at San Francisco Giants
+721665|Los Angeles Dodgers at San Francisco Giants|San Francisco Giants vs Los Angeles Dodgers [7/29/2012] Tickets at StubHub!|Los Angeles Dodgers at San Francisco Giants
+721666|Milwaukee Brewers at San Francisco Giants|San Francisco Giants vs Milwaukee Brewers [5/6/2012] Tickets at StubHub!|Milwaukee Brewers at San Francisco Giants
+721667|Washington Nationals at San Francisco Giants|San Francisco Giants vs Washington Nationals [8/14/2012] Tickets at StubHub!|Washington Nationals at San Francisco Giants
+721668|Oakland Athletics at San Francisco Giants|San Francisco Giants vs Oakland Athletics [5/19/2012] Tickets at StubHub!|Oakland Athletics at San Francisco Giants
+721669|St Louis Cardinals at San Francisco Giants|San Francisco Giants vs St Louis Cardinals [5/17/2012] Tickets at StubHub!|St. Louis Cardinals at San Francisco Giants
+721670|Arizona Diamondbacks at San Francisco Giants|San Francisco Giants vs Arizona Diamondbacks [9/4/2012] Tickets at StubHub!|Arizona Diamondbacks at San Francisco Giants
+721671|Colorado Rockies at San Francisco Giants|San Francisco Giants vs Colorado Rockies [8/10/2012] Tickets at StubHub!|Colorado Rockies at San Francisco Giants
+721672|Arizona Diamondbacks at San Francisco Giants|San Francisco Giants vs Arizona Diamondbacks [9/26/2012] Tickets at StubHub!|Arizona Diamondbacks at San Francisco Giants
+721673|St Louis Cardinals at San Francisco Giants|San Francisco Giants vs St Louis Cardinals [5/16/2012] Tickets at StubHub!|St. Louis Cardinals at San Francisco Giants
+721674|Chicago Cubs at San Francisco Giants|San Francisco Giants vs Chicago Cubs [6/2/2012] Tickets at StubHub!|Chicago Cubs at San Francisco Giants
+721675|New York Mets at San Francisco Giants|San Francisco Giants vs New York Mets [7/31/2012] Tickets at StubHub!|New York Mets at San Francisco Giants
+721676|Colorado Rockies at San Francisco Giants|San Francisco Giants vs Colorado Rockies [9/18/2012] Tickets at StubHub!|Colorado Rockies at San Francisco Giants
+721677|Los Angeles Dodgers at San Francisco Giants|San Francisco Giants vs Los Angeles Dodgers [9/9/2012] Tickets at StubHub!|Los Angeles Dodgers at San Francisco Giants
+721678|New York Mets at San Francisco Giants|San Francisco Giants vs New York Mets [8/1/2012] Tickets at StubHub!|New York Mets at San Francisco Giants
+721679|Chicago Cubs at San Francisco Giants|San Francisco Giants vs Chicago Cubs [6/4/2012] Tickets at StubHub!|Chicago Cubs at San Francisco Giants
+721680|San Diego Padres at San Francisco Giants|San Francisco Giants vs San Diego Padres [9/22/2012] Tickets at StubHub!|San Diego Padres at San Francisco Giants
+721681|Oakland Athletics at San Francisco Giants|San Francisco Giants vs Oakland Athletics [5/20/2012] Tickets at StubHub!|Oakland Athletics at San Francisco Giants
+721682|Atlanta Braves at San Francisco Giants|San Francisco Giants vs Atlanta Braves [8/24/2012] Tickets at StubHub!|Atlanta Braves at San Francisco Giants
+721683|Washington Nationals at San Francisco Giants|San Francisco Giants vs Washington Nationals [8/13/2012] Tickets at StubHub!|Washington Nationals at San Francisco Giants
+721684|Colorado Rockies at San Francisco Giants|San Francisco Giants vs Colorado Rockies [9/20/2012] Tickets at StubHub!|Colorado Rockies at San Francisco Giants
+721685|Arizona Diamondbacks at San Francisco Giants|San Francisco Giants vs Arizona Diamondbacks [9/3/2012] Tickets at StubHub!|Arizona Diamondbacks at San Francisco Giants
+721686|Los Angeles Dodgers at San Francisco Giants|San Francisco Giants vs Los Angeles Dodgers [7/28/2012] Tickets at StubHub!|Los Angeles Dodgers at San Francisco Giants
+721687|Washington Nationals at San Francisco Giants|San Francisco Giants vs Washington Nationals [8/15/2012] Tickets at StubHub!|Washington Nationals at San Francisco Giants
+721688|New York Mets at San Francisco Giants|San Francisco Giants vs New York Mets [7/30/2012] Tickets at StubHub!|New York Mets at San Francisco Giants
+721689|Cincinnati Reds at San Francisco Giants|San Francisco Giants vs Cincinnati Reds [6/29/2012] Tickets at StubHub!|Cincinnati Reds at San Francisco Giants
+721690|Cincinnati Reds at San Francisco Giants|San Francisco Giants vs Cincinnati Reds [6/28/2012] Tickets at StubHub!|Cincinnati Reds at San Francisco Giants
+721691|Texas Rangers at San Francisco Giants|San Francisco Giants vs Texas Rangers [6/9/2012] Tickets at StubHub!|Texas Rangers at San Francisco Giants
+721692|Los Angeles Dodgers at San Francisco Giants|San Francisco Giants vs Los Angeles Dodgers [9/7/2012] Tickets at StubHub!|Los Angeles Dodgers at San Francisco Giants
+721693|Arizona Diamondbacks at San Francisco Giants|San Francisco Giants vs Arizona Diamondbacks [9/5/2012] Tickets at StubHub!|Arizona Diamondbacks at San Francisco Giants
+721694|Houston Astros at San Francisco Giants|San Francisco Giants vs Houston Astros [7/13/2012] Tickets at StubHub!|Houston Astros at San Francisco Giants
+721695|Houston Astros at San Francisco Giants|San Francisco Giants vs Houston Astros [7/15/2012] Tickets at StubHub!|Houston Astros at San Francisco Giants
+721696|Atlanta Braves at San Francisco Giants|San Francisco Giants vs Atlanta Braves [8/23/2012] Tickets at StubHub!|Atlanta Braves at San Francisco Giants
+721697|Arizona Diamondbacks at San Francisco Giants|San Francisco Giants vs Arizona Diamondbacks [9/25/2012] Tickets at StubHub!|Arizona Diamondbacks at San Francisco Giants
+721698|Cincinnati Reds at San Francisco Giants|San Francisco Giants vs Cincinnati Reds [7/1/2012] Tickets at StubHub!|Cincinnati Reds at San Francisco Giants
+721948|Colorado Rockies at Arizona Diamondbacks|Arizona Diamondbacks vs Colorado Rockies [10/3/2012] Tickets at StubHub!|Colorado Rockies at Arizona Diamondbacks
+721956|New York Mets at Atlanta Braves (Saturday September 29, 2012)|Atlanta Braves vs New York Mets [9/29/2012] Tickets at StubHub!|New York Mets at Atlanta Braves
+721957|San Francisco Giants at Atlanta Braves (Wednesday July 18, 2012)|Atlanta Braves vs San Francisco Giants [7/18/2012] Tickets at StubHub!|San Francisco Giants at Atlanta Braves
+721958|Chicago Cubs at Atlanta Braves (Thursday July 5, 2012)|Atlanta Braves vs Chicago Cubs [7/5/2012] Tickets at StubHub!|Chicago Cubs at Atlanta Braves
+721959|Colorado Rockies at Atlanta Braves (Thursday September 6, 2012)|Atlanta Braves vs Colorado Rockies [9/6/2012] Tickets at StubHub!|Colorado Rockies at Atlanta Braves
+721960|Milwaukee Brewers at Atlanta Braves (Sunday April 15, 2012)|Atlanta Braves vs Milwaukee Brewers [4/15/2012] Tickets at StubHub!|Milwaukee Brewers at Atlanta Braves
+721961|Washington Nationals at Atlanta Braves (Friday September 14, 2012)|Atlanta Braves vs Washington Nationals [9/14/2012] Tickets at StubHub!|Washington Nationals at Atlanta Braves
+721962|San Francisco Giants at Atlanta Braves (Thursday July 19, 2012)|Atlanta Braves vs San Francisco Giants [7/19/2012] Tickets at StubHub!|San Francisco Giants at Atlanta Braves
+721963|New York Mets at Atlanta Braves (Tuesday April 17, 2012)|Atlanta Braves vs New York Mets [4/17/2012] Tickets at StubHub!|New York Mets at Atlanta Braves
+721964|Miami Marlins at Atlanta Braves (Thursday August 2, 2012)|Atlanta Braves vs Miami Marlins [8/2/2012] Tickets at StubHub!|Miami Marlins at Atlanta Braves
+721965|Philadelphia Phillies at Atlanta Braves (Sunday September 2, 2012)|Atlanta Braves vs Philadelphia Phillies [9/2/2012] Tickets at StubHub!|Philadelphia Phillies at Atlanta Braves
+721966|Philadelphia Phillies at Atlanta Braves (Friday July 27, 2012)|Atlanta Braves vs Philadelphia Phillies [7/27/2012] Tickets at StubHub!|Philadelphia Phillies at Atlanta Braves
+721967|Philadelphia Phillies at Atlanta Braves (Sunday July 29, 2012)|Atlanta Braves vs Philadelphia Phillies [7/29/2012] Tickets at StubHub!|Philadelphia Phillies at Atlanta Braves
+721968|San Diego Padres at Atlanta Braves (Tuesday August 14, 2012)|Atlanta Braves vs San Diego Padres [8/14/2012] Tickets at StubHub!|San Diego Padres at Atlanta Braves
+721969|Washington Nationals at Atlanta Braves (Friday June 29, 2012)|Atlanta Braves vs Washington Nationals [6/29/2012] Tickets at StubHub!|Washington Nationals at Atlanta Braves
+721970|Toronto Blue Jays at Atlanta Braves (Sunday June 10, 2012)|Atlanta Braves vs Toronto Blue Jays [6/10/2012] Tickets at StubHub!|Toronto Blue Jays at Atlanta Braves
+721971|Los Angeles Dodgers at Atlanta Braves (Sunday August 19, 2012)|Atlanta Braves vs Los Angeles Dodgers [8/19/2012] Tickets at StubHub!|Los Angeles Dodgers at Atlanta Braves
+721972|Miami Marlins at Atlanta Braves (Thursday May 17, 2012)|Atlanta Braves vs Miami Marlins [5/17/2012] Tickets at StubHub!|Miami Marlins at Atlanta Braves
+721973|New York Mets at Atlanta Braves (Sunday July 15, 2012)|Atlanta Braves vs New York Mets [7/15/2012] Tickets at StubHub!|New York Mets at Atlanta Braves
+721974|Toronto Blue Jays at Atlanta Braves (Friday June 8, 2012)|Atlanta Braves vs Toronto Blue Jays [6/8/2012] Tickets at StubHub!|Toronto Blue Jays at Atlanta Braves
+721975|Colorado Rockies at Atlanta Braves (Tuesday September 4, 2012)|Atlanta Braves vs Colorado Rockies [9/4/2012] Tickets at StubHub!|Colorado Rockies at Atlanta Braves
+721976|San Francisco Giants at Atlanta Braves (Tuesday July 17, 2012)|Atlanta Braves vs San Francisco Giants [7/17/2012] Tickets at StubHub!|San Francisco Giants at Atlanta Braves
+721977|Philadelphia Phillies at Atlanta Braves (Wednesday May 2, 2012)|Atlanta Braves vs Philadelphia Phillies [5/2/2012] Tickets at StubHub!|Philadelphia Phillies at Atlanta Braves
+721978|Pittsburgh Pirates at Atlanta Braves (Friday April 27, 2012)|Atlanta Braves vs Pittsburgh Pirates [4/27/2012] Tickets at StubHub!|Pittsburgh Pirates at Atlanta Braves
+721979|Miami Marlins at Atlanta Braves (Wednesday September 26, 2012)|Atlanta Braves vs Miami Marlins [9/26/2012] Tickets at StubHub!|Miami Marlins at Atlanta Braves
+721980|St Louis Cardinals at Atlanta Braves (Tuesday May 29, 2012)|Atlanta Braves vs St Louis Cardinals [5/29/2012] Tickets at StubHub!|St. Louis Cardinals at Atlanta Braves
+721981|New York Mets at Atlanta Braves (Saturday July 14, 2012)|Atlanta Braves vs New York Mets [7/14/2012] Tickets at StubHub!|New York Mets at Atlanta Braves
+721982|Pittsburgh Pirates at Atlanta Braves (Sunday April 29, 2012)|Atlanta Braves vs Pittsburgh Pirates [4/29/2012] Tickets at StubHub!|Pittsburgh Pirates at Atlanta Braves
+721983|New York Yankees at Atlanta Braves (Tuesday June 12, 2012)|Atlanta Braves vs New York Yankees [6/12/2012] Tickets at StubHub!|New York Yankees at Atlanta Braves
+721984|Washington Nationals at Atlanta Braves (Sunday May 27, 2012)|Atlanta Braves vs Washington Nationals [5/27/2012] Tickets at StubHub!|Washington Nationals at Atlanta Braves
+721985|Cincinnati Reds at Atlanta Braves (Monday May 14, 2012)|Atlanta Braves vs Cincinnati Reds [5/14/2012] Tickets at StubHub!|Cincinnati Reds at Atlanta Braves
+721986|Philadelphia Phillies at Atlanta Braves (Friday August 31, 2012)|Atlanta Braves vs Philadelphia Phillies [8/31/2012] Tickets at StubHub!|Philadelphia Phillies at Atlanta Braves
+721987|Washington Nationals at Atlanta Braves (Friday May 25, 2012)|Atlanta Braves vs Washington Nationals [5/25/2012] Tickets at StubHub!|Washington Nationals at Atlanta Braves
+721988|Chicago Cubs at Atlanta Braves (Monday July 2, 2012)|Atlanta Braves vs Chicago Cubs [7/2/2012] Tickets at StubHub!|Chicago Cubs at Atlanta Braves
+721989|San Diego Padres at Atlanta Braves (Thursday August 16, 2012)|Atlanta Braves vs San Diego Padres [8/16/2012] Tickets at StubHub!|San Diego Padres at Atlanta Braves
+721990|Houston Astros at Atlanta Braves (Sunday August 5, 2012)|Atlanta Braves vs Houston Astros [8/5/2012] Tickets at StubHub!|Houston Astros at Atlanta Braves
+721991|Washington Nationals at Atlanta Braves (Saturday September 15, 2012)|Atlanta Braves vs Washington Nationals [9/15/2012] Tickets at StubHub!|Washington Nationals at Atlanta Braves
+721992|New York Mets at Atlanta Braves (Friday September 28, 2012)|Atlanta Braves vs New York Mets [9/28/2012] Tickets at StubHub!|New York Mets at Atlanta Braves
+721993|Chicago Cubs at Atlanta Braves (Wednesday July 4, 2012)|Atlanta Braves vs Chicago Cubs [7/4/2012] Tickets at StubHub!|Chicago Cubs at Atlanta Braves
+721994|Los Angeles Dodgers at Atlanta Braves (Saturday August 18, 2012)|Atlanta Braves vs Los Angeles Dodgers [8/18/2012] Tickets at StubHub!|Los Angeles Dodgers at Atlanta Braves
+721995|Miami Marlins at Atlanta Braves (Tuesday July 31, 2012)|Atlanta Braves vs Miami Marlins [7/31/2012] Tickets at StubHub!|Miami Marlins at Atlanta Braves
+721996|Arizona Diamondbacks at Atlanta Braves (Wednesday June 27, 2012)|Atlanta Braves vs Arizona Diamondbacks [6/27/2012] Tickets at StubHub!|Arizona Diamondbacks at Atlanta Braves
+721997|Washington Nationals at Atlanta Braves (Sunday July 1, 2012)|Atlanta Braves vs Washington Nationals [7/1/2012] Tickets at StubHub!|Washington Nationals at Atlanta Braves
+721998|Miami Marlins at Atlanta Braves (Wednesday August 1, 2012)|Atlanta Braves vs Miami Marlins [8/1/2012] Tickets at StubHub!|Miami Marlins at Atlanta Braves
+721999|Milwaukee Brewers at Atlanta Braves (Saturday April 14, 2012)|Atlanta Braves vs Milwaukee Brewers [4/14/2012] Tickets at StubHub!|Milwaukee Brewers at Atlanta Braves
+722000|Washington Nationals at Atlanta Braves (Sunday September 16, 2012)|Atlanta Braves vs Washington Nationals [9/16/2012] Tickets at StubHub!|Washington Nationals at Atlanta Braves
+722001|Miami Marlins at Atlanta Braves (Monday July 30, 2012)|Atlanta Braves vs Miami Marlins [7/30/2012] Tickets at StubHub!|Miami Marlins at Atlanta Braves
+722002|Los Angeles Dodgers at Atlanta Braves (Friday August 17, 2012)|Atlanta Braves vs Los Angeles Dodgers [8/17/2012] Tickets at StubHub!|Los Angeles Dodgers at Atlanta Braves
+722003|Houston Astros at Atlanta Braves (Friday August 3, 2012)|Atlanta Braves vs Houston Astros [8/3/2012] Tickets at StubHub!|Houston Astros at Atlanta Braves
+722004|New York Mets at Atlanta Braves (Monday April 16, 2012)|Atlanta Braves vs New York Mets [4/16/2012] Tickets at StubHub!|New York Mets at Atlanta Braves
+722005|San Diego Padres at Atlanta Braves (Monday August 13, 2012)|Atlanta Braves vs San Diego Padres [8/13/2012] Tickets at StubHub!|San Diego Padres at Atlanta Braves
+722006|New York Mets at Atlanta Braves (Wednesday April 18, 2012)|Atlanta Braves vs New York Mets [4/18/2012] Tickets at StubHub!|New York Mets at Atlanta Braves
+722007|Arizona Diamondbacks at Atlanta Braves (Tuesday June 26, 2012)|Atlanta Braves vs Arizona Diamondbacks [6/26/2012] Tickets at StubHub!|Arizona Diamondbacks at Atlanta Braves
+722008|Colorado Rockies at Atlanta Braves (Monday September 3, 2012)|Atlanta Braves vs Colorado Rockies [9/3/2012] Tickets at StubHub!|Colorado Rockies at Atlanta Braves
+722009|Philadelphia Phillies at Atlanta Braves (Saturday July 28, 2012)|Atlanta Braves vs Philadelphia Phillies [7/28/2012] Tickets at StubHub!|Philadelphia Phillies at Atlanta Braves
+722010|San Diego Padres at Atlanta Braves (Wednesday August 15, 2012)|Atlanta Braves vs San Diego Padres [8/15/2012] Tickets at StubHub!|San Diego Padres at Atlanta Braves
+722011|Washington Nationals at Atlanta Braves (Saturday June 30, 2012)|Atlanta Braves vs Washington Nationals [6/30/2012] Tickets at StubHub!|Washington Nationals at Atlanta Braves
+722012|New York Yankees at Atlanta Braves (Monday June 11, 2012)|Atlanta Braves vs New York Yankees [6/11/2012] Tickets at StubHub!|New York Yankees at Atlanta Braves
+722013|Philadelphia Phillies at Atlanta Braves (Saturday September 1, 2012)|Atlanta Braves vs Philadelphia Phillies [9/1/2012] Tickets at StubHub!|Philadelphia Phillies at Atlanta Braves
+722014|Miami Marlins at Atlanta Braves (Wednesday May 16, 2012)|Atlanta Braves vs Miami Marlins [5/16/2012] Tickets at StubHub!|Miami Marlins at Atlanta Braves
+722015|Arizona Diamondbacks at Atlanta Braves (Thursday June 28, 2012)|Atlanta Braves vs Arizona Diamondbacks [6/28/2012] Tickets at StubHub!|Arizona Diamondbacks at Atlanta Braves
+722016|Toronto Blue Jays at Atlanta Braves (Saturday June 9, 2012)|Atlanta Braves vs Toronto Blue Jays [6/9/2012] Tickets at StubHub!|Toronto Blue Jays at Atlanta Braves
+722017|St Louis Cardinals at Atlanta Braves (Wednesday May 30, 2012)|Atlanta Braves vs St Louis Cardinals [5/30/2012] Tickets at StubHub!|St. Louis Cardinals at Atlanta Braves
+722018|New York Mets at Atlanta Braves (Sunday September 30, 2012)|Atlanta Braves vs New York Mets [9/30/2012] Tickets at StubHub!|New York Mets at Atlanta Braves
+722019|Baltimore Orioles at Atlanta Braves (Friday June 15, 2012)|Atlanta Braves vs Baltimore Orioles [6/15/2012] Tickets at StubHub!|Baltimore Orioles at Atlanta Braves
+722020|Colorado Rockies at Atlanta Braves (Wednesday September 5, 2012)|Atlanta Braves vs Colorado Rockies [9/5/2012] Tickets at StubHub!|Colorado Rockies at Atlanta Braves
+722021|St Louis Cardinals at Atlanta Braves (Monday May 28, 2012)|Atlanta Braves vs St Louis Cardinals [5/28/2012] Tickets at StubHub!|St. Louis Cardinals at Atlanta Braves
+722022|Philadelphia Phillies at Atlanta Braves (Thursday May 3, 2012)|Atlanta Braves vs Philadelphia Phillies [5/3/2012] Tickets at StubHub!|Philadelphia Phillies at Atlanta Braves
+722023|Baltimore Orioles at Atlanta Braves (Saturday June 16, 2012)|Atlanta Braves vs Baltimore Orioles [6/16/2012] Tickets at StubHub!|Baltimore Orioles at Atlanta Braves
+722024|New York Yankees at Atlanta Braves (Wednesday June 13, 2012)|Atlanta Braves vs New York Yankees [6/13/2012] Tickets at StubHub!|New York Yankees at Atlanta Braves
+722025|Miami Marlins at Atlanta Braves (Thursday September 27, 2012)|Atlanta Braves vs Miami Marlins [9/27/2012] Tickets at StubHub!|Miami Marlins at Atlanta Braves
+722026|Washington Nationals at Atlanta Braves (Saturday May 26, 2012)|Atlanta Braves vs Washington Nationals [5/26/2012] Tickets at StubHub!|Washington Nationals at Atlanta Braves
+722027|Philadelphia Phillies at Atlanta Braves (Tuesday may 1, 2012)|Atlanta Braves vs Philadelphia Phillies [5/1/2012] Tickets at StubHub!|Philadelphia Phillies at Atlanta Braves
+722028|Pittsburgh Pirates at Atlanta Braves (Saturday April 28, 2012)|Atlanta Braves vs Pittsburgh Pirates [4/28/2012] Tickets at StubHub!|Pittsburgh Pirates at Atlanta Braves
+722029|Miami Marlins at Atlanta Braves (Tuesday September 25, 2012)|Atlanta Braves vs Miami Marlins [9/25/2012] Tickets at StubHub!|Miami Marlins at Atlanta Braves
+722030|Cincinnati Reds at Atlanta Braves (Tuesday May 15, 2012)|Atlanta Braves vs Cincinnati Reds [5/15/2012] Tickets at StubHub!|Cincinnati Reds at Atlanta Braves
+722031|Baltimore Orioles at Atlanta Braves (Sunday June 17, 2012)|Atlanta Braves vs Baltimore Orioles [6/17/2012] Tickets at StubHub!|Baltimore Orioles at Atlanta Braves
+722032|Pittsburgh Pirates at Atlanta Braves (Monday April 30, 2012)|Atlanta Braves vs Pittsburgh Pirates [4/30/2012] Tickets at StubHub!|Pittsburgh Pirates at Atlanta Braves
+722033|Chicago Cubs at Atlanta Braves (Tuesday July 3, 2012)|Atlanta Braves vs Chicago Cubs [7/3/2012] Tickets at StubHub!|Chicago Cubs at Atlanta Braves
+722034|New York Mets at Atlanta Braves (Friday July 13, 2012)|Atlanta Braves vs New York Mets [7/13/2012] Tickets at StubHub!|New York Mets at Atlanta Braves
+722035|Houston Astros at Atlanta Braves (Saturday August 4, 2012)|Atlanta Braves vs Houston Astros [8/4/2012] Tickets at StubHub!|Houston Astros at Atlanta Braves
+722036|Milwaukee Brewers at Atlanta Braves (Friday April 13, 2012)|Atlanta Braves vs Milwaukee Brewers [4/13/2012] Tickets at StubHub!|Milwaukee Brewers at Atlanta Braves
+723478|Houston Astros at Cincinnati Reds (Saturday September 8, 2012)|Cincinnati Reds vs Houston Astros [9/8/2012] Tickets at StubHub!|Houston Astros at Cincinnati Reds
+723479|Washington Nationals at Cincinnati Reds (Friday May 11, 2012)|Cincinnati Reds vs Washington Nationals [5/11/2012] Tickets at StubHub!|Washington Nationals at Cincinnati Reds
+723480|Colorado Rockies at Cincinnati Reds (Saturday May 26, 2012)|Cincinnati Reds vs Colorado Rockies [5/26/2012] Tickets at StubHub!|Colorado Rockies at Cincinnati Reds
+723481|Pittsburgh Pirates at Cincinnati Reds (Tuesday June 5, 2012)|Cincinnati Reds vs Pittsburgh Pirates [6/5/2012] Tickets at StubHub!|Pittsburgh Pirates at Cincinnati Reds
+723482|Milwaukee Brewers at Cincinnati Reds (Wednesday June 27, 2012)|Cincinnati Reds vs Milwaukee Brewers [6/27/2012] Tickets at StubHub!|Milwaukee Brewers at Cincinnati Reds
+723483|Pittsburgh Pirates at Cincinnati Reds (Wednesday September 12, 2012)|Cincinnati Reds vs Pittsburgh Pirates [9/12/2012] Tickets at StubHub!|Pittsburgh Pirates at Cincinnati Reds
+723484|Atlanta Braves at Cincinnati Reds (Wednesday May 23, 2012)|Cincinnati Reds vs Atlanta Braves [5/23/2012] Tickets at StubHub!|Atlanta Braves at Cincinnati Reds
+723485|St Louis Cardinals at Cincinnati Reds (Saturday August 25, 2012)|Cincinnati Reds vs St Louis Cardinals [8/25/2012] Tickets at StubHub!|St. Louis Cardinals at Cincinnati Reds
+723486|San Diego Padres at Cincinnati Reds (Thursday August 2, 2012)|Cincinnati Reds vs San Diego Padres [8/2/2012] Tickets at StubHub!|San Diego Padres at Cincinnati Reds
+723487|Milwaukee Brewers at Cincinnati Reds (Monday June 25, 2012)|Cincinnati Reds vs Milwaukee Brewers [6/25/2012] Tickets at StubHub!|Milwaukee Brewers at Cincinnati Reds
+723488|Los Angeles Dodgers at Cincinnati Reds (Sunday September 23, 2012)|Cincinnati Reds vs Los Angeles Dodgers [9/23/2012] Tickets at StubHub!|Los Angeles Dodgers at Cincinnati Reds
+723489|Atlanta Braves at Cincinnati Reds (Monday May 21, 2012)|Cincinnati Reds vs Atlanta Braves [5/21/2012] Tickets at StubHub!|Atlanta Braves at Cincinnati Reds
+723490|Los Angeles Dodgers at Cincinnati Reds (Friday September 21, 2012)|Cincinnati Reds vs Los Angeles Dodgers [9/21/2012] Tickets at StubHub!|Los Angeles Dodgers at Cincinnati Reds
+723491|Houston Astros at Cincinnati Reds (Sunday April 29, 2012)|Cincinnati Reds vs Houston Astros [4/29/2012] Tickets at StubHub!|Houston Astros at Cincinnati Reds
+723492|New York Mets at Cincinnati Reds (Tuesday August 14, 2012)|Cincinnati Reds vs New York Mets [8/14/2012] Tickets at StubHub!|New York Mets at Cincinnati Reds
+723493|Detroit Tigers at Cincinnati Reds (Sunday June 10, 2012)|Cincinnati Reds vs Detroit Tigers [6/10/2012] Tickets at StubHub!|Detroit Tigers at Cincinnati Reds
+723494|San Diego Padres at Cincinnati Reds (Tuesday July 31, 2012)|Cincinnati Reds vs San Diego Padres [7/31/2012] Tickets at StubHub!|San Diego Padres at Cincinnati Reds
+723495|Chicago Cubs at Cincinnati Reds (Tuesday May 1, 2012)|Cincinnati Reds vs Chicago Cubs [5/1/2012] Tickets at StubHub!|Chicago Cubs at Cincinnati Reds
+723496|San Francisco Giants at Cincinnati Reds (Wednesday April 25, 2012)|Cincinnati Reds vs San Francisco Giants [4/25/2012] Tickets at StubHub!|San Francisco Giants at Cincinnati Reds
+723497|Detroit Tigers at Cincinnati Reds (Friday June 8, 2012)|Cincinnati Reds vs Detroit Tigers [6/8/2012] Tickets at StubHub!|Detroit Tigers at Cincinnati Reds
+723498|Philadelphia Phillies at Cincinnati Reds (Tuesday September 4, 2012)|Cincinnati Reds vs Philadelphia Phillies [9/4/2012] Tickets at StubHub!|Philadelphia Phillies at Cincinnati Reds
+723499|Arizona Diamondbacks at Cincinnati Reds (Tuesday July 17, 2012)|Cincinnati Reds vs Arizona Diamondbacks [7/17/2012] Tickets at StubHub!|Arizona Diamondbacks at Cincinnati Reds
+723500|Detroit Tigers at Cincinnati Reds (Saturday June 9, 2012)|Cincinnati Reds vs Detroit Tigers [6/9/2012] Tickets at StubHub!|Detroit Tigers at Cincinnati Reds
+723501|Houston Astros at Cincinnati Reds (Friday April 27, 2012)|Cincinnati Reds vs Houston Astros [4/27/2012] Tickets at StubHub!|Houston Astros at Cincinnati Reds
+723502|Cleveland Indians at Cincinnati Reds (Thursday June 14, 2012)|Cincinnati Reds vs Cleveland Indians [6/14/2012] Tickets at StubHub!|Cleveland Indians at Cincinnati Reds
+723503|Milwaukee Brewers at Cincinnati Reds (Wednesday September 26, 2012)|Cincinnati Reds vs Milwaukee Brewers [9/26/2012] Tickets at StubHub!|Milwaukee Brewers at Cincinnati Reds
+723504|Arizona Diamondbacks at Cincinnati Reds (Thursday July 19, 2012)|Cincinnati Reds vs Arizona Diamondbacks [7/19/2012] Tickets at StubHub!|Arizona Diamondbacks at Cincinnati Reds
+723505|St Louis Cardinals at Cincinnati Reds (Saturday July 14, 2012)|Cincinnati Reds vs St Louis Cardinals [7/14/2012] Tickets at StubHub!|St. Louis Cardinals at Cincinnati Reds
+723506|Minnesota Twins at Cincinnati Reds (Saturday June 23, 2012)|Cincinnati Reds vs Minnesota Twins [6/23/2012] Tickets at StubHub!|Minnesota Twins at Cincinnati Reds
+723507|Cleveland Indians at Cincinnati Reds (Tuesday June 12, 2012)|Cincinnati Reds vs Cleveland Indians [6/12/2012] Tickets at StubHub!|Cleveland Indians at Cincinnati Reds
+723508|Milwaukee Brewers at Cincinnati Reds (Saturday July 21, 2012)|Cincinnati Reds vs Milwaukee Brewers [7/21/2012] Tickets at StubHub!|Milwaukee Brewers at Cincinnati Reds
+723509|Colorado Rockies at Cincinnati Reds (Friday May 25, 2012)|Cincinnati Reds vs Colorado Rockies [5/25/2012] Tickets at StubHub!|Colorado Rockies at Cincinnati Reds
+723510|Washington Nationals at Cincinnati Reds (Saturday May 12, 2012)|Cincinnati Reds vs Washington Nationals [5/12/2012] Tickets at StubHub!|Washington Nationals at Cincinnati Reds
+723511|New York Mets at Cincinnati Reds (Thursday August 16, 2012)|Cincinnati Reds vs New York Mets [8/16/2012] Tickets at StubHub!|New York Mets at Cincinnati Reds
+723512|Pittsburgh Pirates at Cincinnati Reds (Sunday August 5, 2012)|Cincinnati Reds vs Pittsburgh Pirates [8/5/2012] Tickets at StubHub!|Pittsburgh Pirates at Cincinnati Reds
+723513|St Louis Cardinals at Cincinnati Reds (Tuesday April 10, 2012)|Cincinnati Reds vs St Louis Cardinals [4/10/2012] Tickets at StubHub!|St. Louis Cardinals at Cincinnati Reds
+723514|Pittsburgh Pirates at Cincinnati Reds (Tuesday September 11, 2012)|Cincinnati Reds vs Pittsburgh Pirates [9/11/2012] Tickets at StubHub!|Pittsburgh Pirates at Cincinnati Reds
+723515|Atlanta Braves at Cincinnati Reds (Thursday May 24, 2012)|Cincinnati Reds vs Atlanta Braves [5/24/2012] Tickets at StubHub!|Atlanta Braves at Cincinnati Reds
+723516|Chicago Cubs at Cincinnati Reds (Saturday August 18, 2012)|Cincinnati Reds vs Chicago Cubs [8/18/2012] Tickets at StubHub!|Chicago Cubs at Cincinnati Reds
+723517|Pittsburgh Pirates at Cincinnati Reds (Wednesday June 6, 2012)|Cincinnati Reds vs Pittsburgh Pirates [6/6/2012] Tickets at StubHub!|Pittsburgh Pirates at Cincinnati Reds
+723518|Houston Astros at Cincinnati Reds (Sunday September 9, 2012)|Cincinnati Reds vs Houston Astros [9/9/2012] Tickets at StubHub!|Houston Astros at Cincinnati Reds
+723519|San Diego Padres at Cincinnati Reds (Wednesday August 1, 2012)|Cincinnati Reds vs San Diego Padres [8/1/2012] Tickets at StubHub!|San Diego Padres at Cincinnati Reds
+723520|Atlanta Braves at Cincinnati Reds (Tuesday May 22, 2012)|Cincinnati Reds vs Atlanta Braves [5/22/2012] Tickets at StubHub!|Atlanta Braves at Cincinnati Reds
+723521|Pittsburgh Pirates at Cincinnati Reds (Friday August 3, 2012)|Cincinnati Reds vs Pittsburgh Pirates [8/3/2012] Tickets at StubHub!|Pittsburgh Pirates at Cincinnati Reds
+723522|Milwaukee Brewers at Cincinnati Reds (Tuesday June 26, 2012)|Cincinnati Reds vs Milwaukee Brewers [6/26/2012] Tickets at StubHub!|Milwaukee Brewers at Cincinnati Reds
+723523|Los Angeles Dodgers at Cincinnati Reds (Saturday September 22, 2012)|Cincinnati Reds vs Los Angeles Dodgers [9/22/2012] Tickets at StubHub!|Los Angeles Dodgers at Cincinnati Reds
+723524|Chicago Cubs at Cincinnati Reds (Thursday May 3, 2012)|Cincinnati Reds vs Chicago Cubs [5/3/2012] Tickets at StubHub!|Chicago Cubs at Cincinnati Reds
+723525|St Louis Cardinals at Cincinnati Reds (Friday August 24, 2012)|Cincinnati Reds vs St Louis Cardinals [8/24/2012] Tickets at StubHub!|St. Louis Cardinals at Cincinnati Reds
+723526|Minnesota Twins at Cincinnati Reds (Sunday June 24, 2012)|Cincinnati Reds vs Minnesota Twins [6/24/2012] Tickets at StubHub!|Minnesota Twins at Cincinnati Reds
+723527|Philadelphia Phillies at Cincinnati Reds (Monday September 3, 2012)|Cincinnati Reds vs Philadelphia Phillies [9/3/2012] Tickets at StubHub!|Philadelphia Phillies at Cincinnati Reds
+723528|St Louis Cardinals at Cincinnati Reds (Sunday August 26, 2012)|Cincinnati Reds vs St Louis Cardinals [8/26/2012] Tickets at StubHub!|St. Louis Cardinals at Cincinnati Reds
+723529|New York Mets at Cincinnati Reds (Wednesday August 15, 2012)|Cincinnati Reds vs New York Mets [8/15/2012] Tickets at StubHub!|New York Mets at Cincinnati Reds
+723530|San Diego Padres at Cincinnati Reds (Monday July 30, 2012)|Cincinnati Reds vs San Diego Padres [7/30/2012] Tickets at StubHub!|San Diego Padres at Cincinnati Reds
+723531|Houston Astros at Cincinnati Reds (Saturday April 28, 2012)|Cincinnati Reds vs Houston Astros [4/28/2012] Tickets at StubHub!|Houston Astros at Cincinnati Reds
+723532|Houston Astros at Cincinnati Reds (Friday September 7, 2012)|Cincinnati Reds vs Houston Astros [9/7/2012] Tickets at StubHub!|Houston Astros at Cincinnati Reds
+723533|Arizona Diamondbacks at Cincinnati Reds (Monday July 16, 2012)|Cincinnati Reds vs Arizona Diamondbacks [7/16/2012] Tickets at StubHub!|Arizona Diamondbacks at Cincinnati Reds
+723534|San Francisco Giants at Cincinnati Reds (Tuesday April 24, 2012)|Cincinnati Reds vs San Francisco Giants [4/24/2012] Tickets at StubHub!|San Francisco Giants at Cincinnati Reds
+723535|Philadelphia Phillies at Cincinnati Reds (Wednesday September 5, 2012)|Cincinnati Reds vs Philadelphia Phillies [9/5/2012] Tickets at StubHub!|Philadelphia Phillies at Cincinnati Reds
+723536|Arizona Diamondbacks at Cincinnati Reds (Wednesday July 18, 2012)|Cincinnati Reds vs Arizona Diamondbacks [7/18/2012] Tickets at StubHub!|Arizona Diamondbacks at Cincinnati Reds
+723537|St Louis Cardinals at Cincinnati Reds (Friday July 13, 2012)|Cincinnati Reds vs St Louis Cardinals [7/13/2012] Tickets at StubHub!|St. Louis Cardinals at Cincinnati Reds
+723538|Chicago Cubs at Cincinnati Reds (Wednesday May 2, 2012)|Cincinnati Reds vs Chicago Cubs [5/2/2012] Tickets at StubHub!|Chicago Cubs at Cincinnati Reds
+723539|San Francisco Giants at Cincinnati Reds (Thursday April 26, 2012)|Cincinnati Reds vs San Francisco Giants [4/26/2012] Tickets at StubHub!|San Francisco Giants at Cincinnati Reds
+723540|Cleveland Indians at Cincinnati Reds (Wednesday June 13, 2012|Cincinnati Reds vs Cleveland Indians [6/13/2012] Tickets at StubHub!|Cleveland Indians at Cincinnati Reds
+723541|Milwaukee Brewers at Cincinnati Reds (Thursday September 27, 2012)|Cincinnati Reds vs Milwaukee Brewers [9/27/2012] Tickets at StubHub!|Milwaukee Brewers at Cincinnati Reds
+723542|Milwaukee Brewers at Cincinnati Reds (Friday July 20, 2012)|Cincinnati Reds vs Milwaukee Brewers [7/20/2012] Tickets at StubHub!|Milwaukee Brewers at Cincinnati Reds
+723543|St Louis Cardinals at Cincinnati Reds (Sunday July 15, 2012)|Cincinnati Reds vs St Louis Cardinals [7/15/2012] Tickets at StubHub!|St. Louis Cardinals at Cincinnati Reds
+723544|Colorado Rockies at Cincinnati Reds (Sunday may 27, 2012)|Cincinnati Reds vs Colorado Rockies [5/27/2012] Tickets at StubHub!|Colorado Rockies at Cincinnati Reds
+723545|Minnesota Twins at Cincinnati Reds (Friday June 22, 2012)|Cincinnati Reds vs Minnesota Twins [6/22/2012] Tickets at StubHub!|Minnesota Twins at Cincinnati Reds
+723546|St Louis Cardinals at Cincinnati Reds (Monday April 9, 2012)|Cincinnati Reds vs St Louis Cardinals [4/9/2012] Tickets at StubHub!|St. Louis Cardinals at Cincinnati Reds
+723547|Milwaukee Brewers at Cincinnati Reds (Tuesday September 25, 2012)|Cincinnati Reds vs Milwaukee Brewers [9/25/2012] Tickets at StubHub!|Milwaukee Brewers at Cincinnati Reds
+723548|Milwaukee Brewers at Cincinnati Reds (Sunday July 22, 2012)|Cincinnati Reds vs Milwaukee Brewers [7/22/2012] Tickets at StubHub!|Milwaukee Brewers at Cincinnati Reds
+723549|Chicago Cubs at Cincinnati Reds (Friday August 17, 2012)|Cincinnati Reds vs Chicago Cubs [8/17/2012] Tickets at StubHub!|Chicago Cubs at Cincinnati Reds
+723550|St Louis Cardinals at Cincinnati Reds (Wednesday April 11, 2012)|Cincinnati Reds vs St Louis Cardinals [4/11/2012] Tickets at StubHub!|St. Louis Cardinals at Cincinnati Reds
+723551|Pittsburgh Pirates at Cincinnati Reds (Monday September 10, 2012)|Cincinnati Reds vs Pittsburgh Pirates [9/10/2012] Tickets at StubHub!|Pittsburgh Pirates at Cincinnati Reds
+723552|Washington Nationals at Cincinnati Reds (Sunday May 13, 2012)|Cincinnati Reds vs Washington Nationals [5/13/2012] Tickets at StubHub!|Washington Nationals at Cincinnati Reds
+723553|Chicago Cubs at Cincinnati Reds (Sunday August 19, 2012)|Cincinnati Reds vs Chicago Cubs [8/19/2012] Tickets at StubHub!|Chicago Cubs at Cincinnati Reds
+723554|Pittsburgh Pirates at Cincinnati Reds (Saturday August 4, 2012)|Cincinnati Reds vs Pittsburgh Pirates [8/4/2012] Tickets at StubHub!|Pittsburgh Pirates at Cincinnati Reds
+723555|Pittsburgh Pirates at Cincinnati Reds (Thursday June 7, 2012)|Cincinnati Reds vs Pittsburgh Pirates [6/7/2012] Tickets at StubHub!|Pittsburgh Pirates at Cincinnati Reds
+723917|Texas Rangers at Tampa Bay Rays (Sat. 9/8/12)|Tampa Bay Rays vs Texas Rangers [9/8/2012] Tickets at StubHub!|Texas Rangers at Tampa Bay Rays
+723918|Detroit Tigers at Tampa Bay Rays (Thu. 6/28/12)|Tampa Bay Rays vs Detroit Tigers [6/28/2012] Tickets at StubHub!|Detroit Tigers at Tampa Bay Rays
+723919|Boston Red Sox at Tampa Bay Rays (Wed. 9/19/12)|Tampa Bay Rays vs Boston Red Sox [9/19/2012] Tickets at StubHub!|Boston Red Sox at Tampa Bay Rays
+723920|Baltimore Orioles at Tampa Bay Rays (Fri. 6/1/12)|Tampa Bay Rays vs Baltimore Orioles [6/1/2012] Tickets at StubHub!|Baltimore Orioles at Tampa Bay Rays
+723921|Miami Marlins at Tampa Bay Rays (Sat. 6/16/12)|Tampa Bay Rays vs Miami Marlins [6/16/2012] Tickets at StubHub!|Miami Marlins at Tampa Bay Rays
+723922|Atlanta Braves at Tampa Bay Rays (Fri. 5/18/12)|Tampa Bay Rays vs Atlanta Braves [5/18/2012] Tickets at StubHub!|Atlanta Braves at Tampa Bay Rays
+723923|Boston Red Sox at Tampa Bay Rays (Mon. 9/17/12)|Tampa Bay Rays vs Boston Red Sox [9/17/2012] Tickets at StubHub!|Boston Red Sox at Tampa Bay Rays
+723924|Toronto Blue Jays at Tampa Bay Rays (Wed. 5/23/12)|Tampa Bay Rays vs Toronto Blue Jays [5/23/2012] Tickets at StubHub!|Toronto Blue Jays at Tampa Bay Rays
+723925|Oakland Athletics at Tampa Bay Rays (Sat. 8/25/12)|Tampa Bay Rays vs Oakland Athletics [8/25/2012] Tickets at StubHub!|Oakland Athletics at Tampa Bay Rays
+723926|Toronto Blue Jays at Tampa Bay Rays (Sun. 9/23/12)|Tampa Bay Rays vs Toronto Blue Jays [9/23/2012] Tickets at StubHub!|Toronto Blue Jays at Tampa Bay Rays
+723927|Boston Red Sox at Tampa Bay Rays (Tue. 9/18/12)|Tampa Bay Rays vs Boston Red Sox [9/18/2012] Tickets at StubHub!|Boston Red Sox at Tampa Bay Rays
+723928|Toronto Blue Jays at Tampa Bay Rays (Mon. 5/21/12)|Tampa Bay Rays vs Toronto Blue Jays [5/21/2012] Tickets at StubHub!|Toronto Blue Jays at Tampa Bay Rays
+723929|Minnesota Twins at Tampa Bay Rays (Sat. 4/21/12)|Tampa Bay Rays vs Minnesota Twins [4/21/2012] Tickets at StubHub!|Minnesota Twins at Tampa Bay Rays
+723930|Toronto Blue Jays at Tampa Bay Rays (Fri. 9/21/12)|Tampa Bay Rays vs Toronto Blue Jays [9/21/2012] Tickets at StubHub!|Toronto Blue Jays at Tampa Bay Rays
+723931|Atlanta Braves at Tampa Bay Rays (Sat. 5/19/12)|Tampa Bay Rays vs Atlanta Braves [5/19/2012] Tickets at StubHub!|Atlanta Braves at Tampa Bay Rays
+723932|Oakland Athletics at Tampa Bay Rays (Sun. 5/6/12)|Tampa Bay Rays vs Oakland Athletics [5/6/2012] Tickets at StubHub!|Oakland Athletics at Tampa Bay Rays
+723933|Detroit Tigers at Tampa Bay Rays (Sat. 6/30/12)|Tampa Bay Rays vs Detroit Tigers [6/30/2012] Tickets at StubHub!|Detroit Tigers at Tampa Bay Rays
+723934|Boston Red Sox at Tampa Bay Rays (Thu. 5/17/12)|Tampa Bay Rays vs Boston Red Sox [5/17/2012] Tickets at StubHub!|Boston Red Sox at Tampa Bay Rays
+723935|Oakland Athletics at Tampa Bay Rays (Fri. 5/4/12)|Tampa Bay Rays vs Oakland Athletics [5/4/2012] Tickets at StubHub!|Oakland Athletics at Tampa Bay Rays
+723936|Toronto Blue Jays at Tampa Bay Rays (Wed. 8/8/12)|Tampa Bay Rays vs Toronto Blue Jays [8/8/2012] Tickets at StubHub!|Toronto Blue Jays at Tampa Bay Rays
+723937|Los Angeles Angels at Tampa Bay Rays (Wed. 4/25/12)|Tampa Bay Rays vs Los Angeles Angels [4/25/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Tampa Bay Rays
+723938|New York Yankees at Tampa Bay Rays (Tue. 9/4/12)|Tampa Bay Rays vs New York Yankees [9/4/2012] Tickets at StubHub!|New York Yankees at Tampa Bay Rays
+723939|Cleveland Indians at Tampa Bay Rays (Tue. 7/17/12)|Tampa Bay Rays vs Cleveland Indians [7/17/2012] Tickets at StubHub!|Cleveland Indians at Tampa Bay Rays
+723940|Seattle Mariners at Tampa Bay Rays (Wed. 5/2/12)|Tampa Bay Rays vs Seattle Mariners [5/2/2012] Tickets at StubHub!|Seattle Mariners at Tampa Bay Rays
+723941|Miami Marlins at Tampa Bay Rays (Sun. 6/17/12)|Tampa Bay Rays vs Miami Marlins [6/17/2012] Tickets at StubHub!|Miami Marlins at Tampa Bay Rays
+723943|Cleveland Indians at Tampa Bay Rays (Thu. 7/19/12)|Tampa Bay Rays vs Cleveland Indians [7/19/2012] Tickets at StubHub!|Cleveland Indians at Tampa Bay Rays
+723944|Boston Red Sox at Tampa Bay Rays (Sat. 7/14/12)|Tampa Bay Rays vs Boston Red Sox [7/14/2012] Tickets at StubHub!|Boston Red Sox at Tampa Bay Rays
+723945|Kansas City Royals at Tampa Bay Rays (Mon. 8/20/12)|Tampa Bay Rays vs Kansas City Royals [8/20/2012] Tickets at StubHub!|Kansas City Royals at Tampa Bay Rays
+723946|Detroit Tigers at Tampa Bay Rays (Fri. 6/29/12)|Tampa Bay Rays vs Detroit Tigers [6/29/2012] Tickets at StubHub!|Detroit Tigers at Tampa Bay Rays
+723947|New York Yankees at Tampa Bay Rays (Fri. 4/6/12)|Tampa Bay Rays vs New York Yankees [4/6/2012] Tickets at StubHub!|New York Yankees at Tampa Bay Rays
+723948|Seattle Mariners at Tampa Bay Rays (Sat. 7/21/12)|Tampa Bay Rays vs Seattle Mariners [7/21/2012] Tickets at StubHub!|Seattle Mariners at Tampa Bay Rays
+723949|Kansas City Royals at Tampa Bay Rays (Wed. 8/22/12)|Tampa Bay Rays vs Kansas City Royals [8/22/2012] Tickets at StubHub!|Kansas City Royals at Tampa Bay Rays
+723950|New York Yankees at Tampa Bay Rays (Sun. 4/8/12)|Tampa Bay Rays vs New York Yankees [4/8/2012] Tickets at StubHub!|New York Yankees at Tampa Bay Rays
+723951|Chicago White Sox at Tampa Bay Rays (Tue. 5/29/12)|Tampa Bay Rays vs Chicago White Sox [5/29/2012] Tickets at StubHub!|Chicago White Sox at Tampa Bay Rays
+723952|New York Yankees at Tampa Bay Rays (Mon. 7/2/12)|Tampa Bay Rays vs New York Yankees [7/2/2012] Tickets at StubHub!|New York Yankees at Tampa Bay Rays
+723953|Baltimore Orioles at Tampa Bay Rays (Wed. 10/3/12)|Tampa Bay Rays vs Baltimore Orioles [10/3/2012] Tickets at StubHub!|Baltimore Orioles at Tampa Bay Rays
+723954|New York Yankees at Tampa Bay Rays (Wed. 7/4/12)|Tampa Bay Rays vs New York Yankees [7/4/2012] Tickets at StubHub!|New York Yankees at Tampa Bay Rays
+723955|Toronto Blue Jays at Tampa Bay Rays (Tue. 8/7/12)|Tampa Bay Rays vs Toronto Blue Jays [8/7/2012] Tickets at StubHub!|Toronto Blue Jays at Tampa Bay Rays
+723956|New York Mets at Tampa Bay Rays (Tue. 6/12/12)|Tampa Bay Rays vs New York Mets [6/12/2012] Tickets at StubHub!|New York Mets at Tampa Bay Rays
+723957|Texas Rangers at Tampa Bay Rays (Sun. 9/9/12)|Tampa Bay Rays vs Texas Rangers [9/9/2012] Tickets at StubHub!|Texas Rangers at Tampa Bay Rays
+723958|Baltimore Orioles at Tampa Bay Rays (Sat. 6/2/12)|Tampa Bay Rays vs Baltimore Orioles [6/2/2012] Tickets at StubHub!|Baltimore Orioles at Tampa Bay Rays
+723959|Toronto Blue Jays at Tampa Bay Rays (Tue. 5/22/12)|Tampa Bay Rays vs Toronto Blue Jays [5/22/2012] Tickets at StubHub!|Toronto Blue Jays at Tampa Bay Rays
+723960|Baltimore Orioles at Tampa Bay Rays (Tue. 10/2/12)|Tampa Bay Rays vs Baltimore Orioles [10/2/2012] Tickets at StubHub!|Baltimore Orioles at Tampa Bay Rays
+723961|Toronto Blue Jays at Tampa Bay Rays (Sat. 9/22/12)|Tampa Bay Rays vs Toronto Blue Jays [9/22/2012] Tickets at StubHub!|Toronto Blue Jays at Tampa Bay Rays
+723962|Atlanta Braves at Tampa Bay Rays (Sun. 5/20/12)|Tampa Bay Rays vs Atlanta Braves [5/20/2012] Tickets at StubHub!|Atlanta Braves at Tampa Bay Rays
+723963|Oakland Athletics at Tampa Bay Rays (Fri. 8/24/12)|Tampa Bay Rays vs Oakland Athletics [8/24/2012] Tickets at StubHub!|Oakland Athletics at Tampa Bay Rays
+723964|Chicago White Sox at Tampa Bay Rays (Wed. 5/30/12)|Tampa Bay Rays vs Chicago White Sox [5/30/2012] Tickets at StubHub!|Chicago White Sox at Tampa Bay Rays
+723965|Boston Red Sox at Tampa Bay Rays (Thu. 9/20/12)|Tampa Bay Rays vs Boston Red Sox [9/20/2012] Tickets at StubHub!|Boston Red Sox at Tampa Bay Rays
+723966|New York Yankees at Tampa Bay Rays (Mon. 9/3/12)|Tampa Bay Rays vs New York Yankees [9/3/2012] Tickets at StubHub!|New York Yankees at Tampa Bay Rays
+723967|New York Mets at Tampa Bay Rays (Wed. 6/13/12)|Tampa Bay Rays vs New York Mets [6/13/2012] Tickets at StubHub!|New York Mets at Tampa Bay Rays
+723968|Minnesota Twins at Tampa Bay Rays (Fri. 4/20/12)|Tampa Bay Rays vs Minnesota Twins [4/20/2012] Tickets at StubHub!|Minnesota Twins at Tampa Bay Rays
+723969|Baltimore Orioles at Tampa Bay Rays (Sun. 8/5/12)|Tampa Bay Rays vs Baltimore Orioles [8/5/2012] Tickets at StubHub!|Baltimore Orioles at Tampa Bay Rays
+723970|Boston Red Sox at Tampa Bay Rays (Wed. 5/16/12)|Tampa Bay Rays vs Boston Red Sox [5/16/2012] Tickets at StubHub!|Boston Red Sox at Tampa Bay Rays
+723971|Baltimore Orioles at Tampa Bay Rays (Fri. 8/3/12)|Tampa Bay Rays vs Baltimore Orioles [8/3/2012] Tickets at StubHub!|Baltimore Orioles at Tampa Bay Rays
+723972|Toronto Blue Jays at Tampa Bay Rays (Thu. 8/9/12)|Tampa Bay Rays vs Toronto Blue Jays [8/9/2012] Tickets at StubHub!|Toronto Blue Jays at Tampa Bay Rays
+723973|Minnesota Twins at Tampa Bay Rays (Sun. 4/22/12)|Tampa Bay Rays vs Minnesota Twins [4/22/2012] Tickets at StubHub!|Minnesota Twins at Tampa Bay Rays
+723974|Texas Rangers at Tampa Bay Rays (Fri. 9/7/12)|Tampa Bay Rays vs Texas Rangers [9/7/2012] Tickets at StubHub!|Texas Rangers at Tampa Bay Rays
+723975|Cleveland Indians at Tampa Bay Rays (Mon. 7/16/12)|Tampa Bay Rays vs Cleveland Indians [7/16/2012] Tickets at StubHub!|Cleveland Indians at Tampa Bay Rays
+723976|Oakland Athletics at Tampa Bay Rays (Sat. 5/5/12)|Tampa Bay Rays vs Oakland Athletics [5/5/2012] Tickets at StubHub!|Oakland Athletics at Tampa Bay Rays
+723977|Baltimore Orioles at Tampa Bay Rays (Mon. 10/1/12)|Tampa Bay Rays vs Baltimore Orioles [10/1/2012] Tickets at StubHub!|Baltimore Orioles at Tampa Bay Rays
+723978|Los Angeles Angels at Tampa Bay Rays (Tue. 4/24/12)|Tampa Bay Rays vs Los Angeles Angels [4/24/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Tampa Bay Rays
+723979|Miami Marlins at Tampa Bay Rays (Fri. 6/15/12)|Tampa Bay Rays vs Miami Marlins [6/15/2012] Tickets at StubHub!|Miami Marlins at Tampa Bay Rays
+723980|New York Yankees at Tampa Bay Rays (Wed. 9/5/12)|Tampa Bay Rays vs New York Yankees [9/5/2012] Tickets at StubHub!|New York Yankees at Tampa Bay Rays
+723981|Cleveland Indians at Tampa Bay Rays (Wed. 7/18/12)|Tampa Bay Rays vs Cleveland Indians [7/18/2012] Tickets at StubHub!|Cleveland Indians at Tampa Bay Rays
+723982|Seattle Mariners at Tampa Bay Rays (Thu. 5/3/12)|Tampa Bay Rays vs Seattle Mariners [5/3/2012] Tickets at StubHub!|Seattle Mariners at Tampa Bay Rays
+723983|Kansas City Royals at Tampa Bay Rays (Tue. 8/21/12)|Tampa Bay Rays vs Kansas City Royals [8/21/2012] Tickets at StubHub!|Kansas City Royals at Tampa Bay Rays
+723984|Los Angeles Angels at Tampa Bay Rays (Thu. 4/26/12)|Tampa Bay Rays vs Los Angeles Angels [4/26/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Tampa Bay Rays
+723985|New York Yankees at Tampa Bay Rays (Sat. 4/7/12)|Tampa Bay Rays vs New York Yankees [4/7/2012] Tickets at StubHub!|New York Yankees at Tampa Bay Rays
+723986|Seattle Mariners at Tampa Bay Rays (Fri. 7/20/12)|Tampa Bay Rays vs Seattle Mariners [7/20/2012] Tickets at StubHub!|Seattle Mariners at Tampa Bay Rays
+723987|Seattle Mariners at Tampa Bay Rays (Tue. 5/1/12)|Tampa Bay Rays vs Seattle Mariners [5/1/2012] Tickets at StubHub!|Seattle Mariners at Tampa Bay Rays
+723988|Oakland Athletics at Tampa Bay Rays (Thu. 8/23/12)|Tampa Bay Rays vs Oakland Athletics [8/23/2012] Tickets at StubHub!|Oakland Athletics at Tampa Bay Rays
+723989|Baltimore Orioles at Tampa Bay Rays (Sun. 6/3/12)|Tampa Bay Rays vs Baltimore Orioles [6/3/2012] Tickets at StubHub!|Baltimore Orioles at Tampa Bay Rays
+723990|Seattle Mariners at Tampa Bay Rays (Sun. 7/22/12)|Tampa Bay Rays vs Seattle Mariners [7/22/2012] Tickets at StubHub!|Seattle Mariners at Tampa Bay Rays
+723991|Detroit Tigers at Tampa Bay Rays (Sun. 7/1/12)|Tampa Bay Rays vs Detroit Tigers [7/1/2012] Tickets at StubHub!|Detroit Tigers at Tampa Bay Rays
+723992|Chicago White Sox at Tampa Bay Rays (Mon. 5/28/12)|Tampa Bay Rays vs Chicago White Sox [5/28/2012] Tickets at StubHub!|Chicago White Sox at Tampa Bay Rays
+723993|Seattle Mariners at Tampa Bay Rays (Mon. 4/30/12)|Tampa Bay Rays vs Seattle Mariners [4/30/2012] Tickets at StubHub!|Seattle Mariners at Tampa Bay Rays
+723994|Boston Red Sox at Tampa Bay Rays (Sun. 7/15/12)|Tampa Bay Rays vs Boston Red Sox [7/15/2012] Tickets at StubHub!|Boston Red Sox at Tampa Bay Rays
+723995|New York Yankees at Tampa Bay Rays (Tue. 7/3/12)|Tampa Bay Rays vs New York Yankees [7/3/2012] Tickets at StubHub!|New York Yankees at Tampa Bay Rays
+723996|Boston Red Sox at Tampa Bay Rays (Fri. 7/13/12)|Tampa Bay Rays vs Boston Red Sox [7/13/2012] Tickets at StubHub!|Boston Red Sox at Tampa Bay Rays
+723997|Baltimore Orioles at Tampa Bay Rays (Sat. 8/4/12)|Tampa Bay Rays vs Baltimore Orioles [8/4/2012] Tickets at StubHub!|Baltimore Orioles at Tampa Bay Rays
+724426|Atlanta Braves at New York Mets (Saturday September 8, 2012)|New York Mets vs Atlanta Braves [09/08/2012] Tickets at StubHub!|Atlanta Braves at New York Mets
+724427|Chicago Cubs at New York Mets (Sunday July 8, 2012)|New York Mets vs Chicago Cubs [07/08/2012] Tickets at StubHub!|Chicago Cubs at New York Mets
+724428|Chicago Cubs at New York Mets (Saturday July 7, 2012)|New York Mets vs Chicago Cubs [07/07/2012] Tickets at StubHub!|Chicago Cubs at New York Mets
+724429|Cincinnati Reds at New York Mets (Saturday June 16, 2012)|New York Mets vs Cincinnati Reds [06/16/2012] Tickets at StubHub!|Cincinnati Reds at New York Mets
+724430|Washington Nationals at New York Mets (Wednesday July 25, 2012)|New York Mets vs Washington Nationals [07/25/2012] Tickets at StubHub!|Washington Nationals at New York Mets
+724431|Houston Astros at New York Mets (Saturday August 25, 2012)|New York Mets vs Houston Astros [08/25/2012] Tickets at StubHub!|Houston Astros at New York Mets
+724432|Miami Marlins at New York Mets (Sunday September 23, 2012)|New York Mets vs Miami Marlins [09/23/2012] Tickets at StubHub!|Miami Marlins at New York Mets
+724433|Atlanta Braves at New York Mets (Sunday August 12, 2012)|New York Mets vs Atlanta Braves [08/12/2012] Tickets at StubHub!|Atlanta Braves at New York Mets
+724434|San Francisco Giants at New York Mets (Saturday April 21, 2012)|New York Mets vs San Francisco Giants [04/21/2012] Tickets at StubHub!|San Francisco Giants at New York Mets
+724435|Miami Marlins at New York Mets (Friday September 21, 2012)|New York Mets vs Miami Marlins [09/21/2012] Tickets at StubHub!|Miami Marlins at New York Mets
+724436|Los Angeles Dodgers at New York Mets (Friday July 20, 2012)|New York Mets vs Los Angeles Dodgers [07/20/2012] Tickets at StubHub!|Los Angeles Dodgers at New York Mets
+724437|San Francisco Giants at New York Mets (Monday April 23, 2012)|New York Mets vs San Francisco Giants [04/23/2012] Tickets at StubHub!|San Francisco Giants at New York Mets
+724438|Atlanta Braves at New York Mets (Saturday August 11, 2012)|New York Mets vs Atlanta Braves [08/11/2012] Tickets at StubHub!|Atlanta Braves at New York Mets
+724439|Cincinnati Reds at New York Mets (Thursday May 17, 2012)|New York Mets vs Cincinnati Reds [05/17/2012] Tickets at StubHub!|Cincinnati Reds at New York Mets
+724440|Arizona Diamondbacks at New York Mets (Friday May 4, 2012)|New York Mets vs Arizona Diamondbacks [05/04/2012] Tickets at StubHub!|Arizona Diamondbacks at New York Mets
+724441|Miami Marlins at New York Mets (Wednesday August 8, 2012)|New York Mets vs Miami Marlins [08/08/2012] Tickets at StubHub!|Miami Marlins at New York Mets
+724442|Miami Marlins at New York Mets (Wednesday April 25, 2012)|New York Mets vs Miami Marlins [04/25/2012] Tickets at StubHub!|Miami Marlins at New York Mets
+724443|Atlanta Braves at New York Mets (Friday August 10, 2012)|New York Mets vs Atlanta Braves [08/10/2012] Tickets at StubHub!|Atlanta Braves at New York Mets
+724444|Cincinnati Reds at New York Mets (Sunday June 17, 2012)|New York Mets vs Cincinnati Reds [06/17/2012] Tickets at StubHub!|Cincinnati Reds at New York Mets
+724445|Los Angeles Dodgers at New York Mets (Saturday July 21, 2012)|New York Mets vs Los Angeles Dodgers [07/21/2012] Tickets at StubHub!|Los Angeles Dodgers at New York Mets
+724446|Colorado Rockies at New York Mets (Monday August 20, 2012)|New York Mets vs Colorado Rockies [08/20/2012] Tickets at StubHub!|Colorado Rockies at New York Mets
+724447|Pittsburgh Pirates at New York Mets (Monday September 24, 2012)|New York Mets vs Pittsburgh Pirates [09/24/2012] Tickets at StubHub!|Pittsburgh Pirates at New York Mets
+724448|San Diego Padres at New York Mets (Sunday May 27, 2012)|New York Mets vs San Diego Padres [05/27/2012] Tickets at StubHub!|San Diego Padres at New York Mets
+724449|Washington Nationals at New York Mets (Monday April 9, 2012)|New York Mets vs Washington Nationals [04/09/2012] Tickets at StubHub!|Washington Nationals at New York Mets
+724450|Colorado Rockies at New York Mets (Wednesday August 22, 2012)|New York Mets vs Colorado Rockies [08/22/2012] Tickets at StubHub!|Colorado Rockies at New York Mets
+724451|St Louis Cardinals at New York Mets (Saturday June 2, 2012)|New York Mets vs St Louis Cardinals [06/02/2012] Tickets at StubHub!|St. Louis Cardinals at New York Mets
+724452|Atlanta Braves at New York Mets (Sunday April 8, 2012)|New York Mets vs Atlanta Braves [04/08/2012] Tickets at StubHub!|Atlanta Braves at New York Mets
+724453|San Diego Padres at New York Mets (Friday May 25, 2012)|New York Mets vs San Diego Padres [05/25/2012] Tickets at StubHub!|San Diego Padres at New York Mets
+724454|Washington Nationals at New York Mets (Friday April 10, 2012)|New York Mets vs Washington Nationals [04/10/2012] Tickets at StubHub!|Washington Nationals at New York Mets
+724455|Los Angeles Dodgers at New York Mets (Sunday July 22, 2012)|New York Mets vs Los Angeles Dodgers [07/22/2012] Tickets at StubHub!|Los Angeles Dodgers at New York Mets
+724456|Miami Marlins at New York Mets (Tuesday August 7, 2012)|New York Mets vs Miami Marlins [08/07/2012] Tickets at StubHub!|Miami Marlins at New York Mets
+724457|Atlanta Braves at New York Mets (Sunday September 9, 2012)|New York Mets vs Atlanta Braves [09/09/2012] Tickets at StubHub!|Atlanta Braves at New York Mets
+724458|Chicago Cubs at New York Mets (Friday July 6, 2012)|New York Mets vs Chicago Cubs [07/06/2012] Tickets at StubHub!|Chicago Cubs at New York Mets
+724459|St Louis Cardinals at New York Mets (Monday June 4, 2012)|New York Mets vs St Louis Cardinals [06/04/2012] Tickets at StubHub!|St. Louis Cardinals at New York Mets
+724460|Washington Nationals at New York Mets (Tuesday July 24, 2012)|New York Mets vs Washington Nationals [07/24/2012] Tickets at StubHub!|Washington Nationals at New York Mets
+724461|Miami Marlins at New York Mets (Saturday September 22, 2012)|New York Mets vs Miami Marlins [09/22/2012] Tickets at StubHub!|Miami Marlins at New York Mets
+724462|Arizona Diamondbacks at New York Mets (Sunday May 6, 2012)|New York Mets vs Arizona Diamondbacks [05/06/2012] Tickets at StubHub!|Arizona Diamondbacks at New York Mets
+724463|Washington Nationals at New York Mets (Monday July 23, 2012)|New York Mets vs Washington Nationals [07/23/2012] Tickets at StubHub!|Washington Nationals at New York Mets
+724464|Houston Astros at New York Mets (Friday August 24, 2012)|New York Mets vs Houston Astros [08/24/2012] Tickets at StubHub!|Houston Astros at New York Mets
+724465|Baltimore Orioles at New York Mets (Tuesday June 19, 2012)|New York Mets vs Baltimore Orioles [06/19/2012] Tickets at StubHub!|Baltimore Orioles at New York Mets
+724466|Washington Nationals at New York Mets (Wednesday April 11, 2012)|New York Mets vs Washington Nationals [04/11/2012] Tickets at StubHub!|Washington Nationals at New York Mets
+724467|Houston Astros at New York Mets (Sunday August 26, 2012)|New York Mets vs Houston Astros [08/26/2012] Tickets at StubHub!|Houston Astros at New York Mets
+724468|San Francisco Giants at New York Mets (Friday April 20, 2012)|New York Mets vs San Francisco Giants [04/20/2012] Tickets at StubHub!|San Francisco Giants at New York Mets
+724469|Cincinnati Reds at New York Mets (Wednesday May 16, 2012)|New York Mets vs Cincinnati Reds [05/16/2012] Tickets at StubHub!|Cincinnati Reds at New York Mets
+724470|Miami Marlins at New York Mets (Thursday August 9, 2012)|New York Mets vs Miami Marlins [08/09/2012] Tickets at StubHub!|Miami Marlins at New York Mets
+724471|San Francisco Giants at New York Mets (Sunday April 22, 2012)|New York Mets vs San Francisco Giants [04/22/2012] Tickets at StubHub!|San Francisco Giants at New York Mets
+724472|Atlanta Braves at New York Mets (Friday September 7, 2012)|New York Mets vs Atlanta Braves [09/07/2012] Tickets at StubHub!|Atlanta Braves at New York Mets
+724473|Arizona Diamondbacks at New York Mets (Saturday May 5, 2012)|New York Mets vs Arizona Diamondbacks [05/05/2012] Tickets at StubHub!|Arizona Diamondbacks at New York Mets
+724474|Baltimore Orioles at New York Mets (Monday June 18, 2012)|New York Mets vs Baltimore Orioles [06/18/2012] Tickets at StubHub!|Baltimore Orioles at New York Mets
+724475|Miami Marlins at New York Mets (Tuesday April 24, 2012)|New York Mets vs Miami Marlins [04/24/2012] Tickets at StubHub!|Miami Marlins at New York Mets
+724476|Cincinnati Reds at New York Mets (Friday June 15, 2012)|New York Mets vs Cincinnati Reds [06/15/2012] Tickets at StubHub!|Cincinnati Reds at New York Mets
+724477|Colorado Rockies at New York Mets (Tuesday August 21, 2012)|New York Mets vs Colorado Rockies [08/21/2012] Tickets at StubHub!|Colorado Rockies at New York Mets
+724478|Miami Marlins at New York Mets (Thursday April 26, 2012)|New York Mets vs Miami Marlins [04/26/2012] Tickets at StubHub!|Miami Marlins at New York Mets
+724479|Atlanta Braves at New York Mets (Saturday April 7, 2012)|New York Mets vs Atlanta Braves [04/07/2012] Tickets at StubHub!|Atlanta Braves at New York Mets
+724480|San Diego Padres at New York Mets (Saturday May 26, 2012)|New York Mets vs San Diego Padres [05/26/2012] Tickets at StubHub!|San Diego Padres at New York Mets
+724481|Colorado Rockies at New York Mets (Thursday August 23, 2012)|New York Mets vs Colorado Rockies [08/23/2012] Tickets at StubHub!|Colorado Rockies at New York Mets
+724482|St Louis Cardinals at New York Mets (Sunday June 3, 2012)|New York Mets vs St Louis Cardinals [06/03/2012] Tickets at StubHub!|St. Louis Cardinals at New York Mets
+724483|Pittsburgh Pirates at New York Mets (Tuesday September 25, 2012)|New York Mets vs Pittsburgh Pirates [09/25/2012] Tickets at StubHub!|Pittsburgh Pirates at New York Mets
+724484|San Diego Padres at New York Mets (Thursday May 24, 2012)|New York Mets vs San Diego Padres [05/24/2012] Tickets at StubHub!|San Diego Padres at New York Mets
+724485|Milwaukee Brewers at New York Mets (Tuesday May 15, 2012)|New York Mets vs Milwaukee Brewers [05/15/2012] Tickets at StubHub!|Milwaukee Brewers at New York Mets
+724486|Baltimore Orioles at New York Mets (Wednesday June 20, 2012)|New York Mets vs Baltimore Orioles [06/20/2012] Tickets at StubHub!|Baltimore Orioles at New York Mets
+724487|St Louis Cardinals at New York Mets (Friday June 1, 2012)|New York Mets vs St Louis Cardinals [06/01/2012] Tickets at StubHub!|St. Louis Cardinals at New York Mets
+724488|Washington Nationals at New York Mets (Monday September 10, 2012)|New York Mets vs Washington Nationals [09/10/2012] Tickets at StubHub!|Washington Nationals at New York Mets
+724489|Milwaukee Brewers at New York Mets (Monday May 14, 2012)|New York Mets vs Milwaukee Brewers [05/14/2012] Tickets at StubHub!|Milwaukee Brewers at New York Mets
+725053|Miami Marlins at Cincinnati Reds (Sunday April 8, 2012)|Cincinnati Reds vs Miami Marlins [4/8/2012] Tickets at StubHub!|Miami Marlins at Cincinnati Reds
+725054|Miami Marlins at Cincinnati Reds (Saturday April 7, 2012)|Cincinnati Reds vs Miami Marlins [4/7/2012] Tickets at StubHub!|Miami Marlins at Cincinnati Reds
+726282|San Francisco Giants at San Diego Padres (Saturday September 29, 2012)|San Diego Padres vs San Francisco Giants [09/29/2012] Tickets at StubHub!|San Francisco Giants at San Diego Padres
+726283|Arizona Diamondbacks at San Diego Padres (Saturday September 8, 2012)|San Diego Padres vs Arizona Diamondbacks [09/08/2012] Tickets at StubHub!|Arizona Diamondbacks at San Diego Padres
+726284|Cincinnati Reds at San Diego Padres (Thursday July 5, 2012)|San Diego Padres vs Cincinnati Reds [07/05/2012] Tickets at StubHub!|Cincinnati Reds at San Diego Padres
+726285|Atlanta Braves at San Diego Padres (Wednesday August 29, 2012)|San Diego Padres vs Atlanta Braves [08/29/2012] Tickets at StubHub!|Atlanta Braves at San Diego Padres
+726286|Cincinnati Reds at San Diego Padres (Sunday July 8, 2012)|San Diego Padres vs Cincinnati Reds [07/08/2012] Tickets at StubHub!|Cincinnati Reds at San Diego Padres
+726287|San Francisco Giants at San Diego Padres (Tuesday June 5, 2012)|San Diego Padres vs San Francisco Giants [06/05/2012] Tickets at StubHub!|San Francisco Giants at San Diego Padres
+726288|Arizona Diamondbacks at San Diego Padres (Friday June 1, 2012)|San Diego Padres vs Arizona Diamondbacks [06/01/2012] Tickets at StubHub!|Arizona Diamondbacks at San Diego Padres
+726289|Colorado Rockies at San Diego Padres (Wednesday May 9, 2012)|San Diego Padres vs Colorado Rockies [05/09/2012] Tickets at StubHub!|Colorado Rockies at San Diego Padres
+726290|Arizona Diamondbacks at San Diego Padres (Saturday June 2, 2012)|San Diego Padres vs Arizona Diamondbacks [06/02/2012] Tickets at StubHub!|Arizona Diamondbacks at San Diego Padres
+726291|San Francisco Giants at San Diego Padres (Wednesday June 6, 2012)|San Diego Padres vs San Francisco Giants [06/06/2012] Tickets at StubHub!|San Francisco Giants at San Diego Padres
+726292|Philadelphia Phillies at San Diego Padres (Thursday April 19, 2012)|San Diego Padres vs Philadelphia Phillies [04/19/2012] Tickets at StubHub!|Philadelphia Phillies at San Diego Padres
+726293|Atlanta Braves at San Diego Padres (Monday August 27, 2012)|San Diego Padres vs Atlanta Braves [08/27/2012] Tickets at StubHub!|Atlanta Braves at San Diego Padres
+726294|Philadelphia Phillies at San Diego Padres (Saturday April 21, 2012)|San Diego Padres vs Philadelphia Phillies [04/21/2012] Tickets at StubHub!|Philadelphia Phillies at San Diego Padres
+726295|Chicago Cubs at San Diego Padres (Monday August 6, 2012)|San Diego Padres vs Chicago Cubs [08/06/2012] Tickets at StubHub!|Chicago Cubs at San Diego Padres
+726297|Miami Marlins at San Diego Padres (Sunday May 6, 2012)|San Diego Padres vs Miami Marlins [05/06/2012] Tickets at StubHub!|Miami Marlins at San Diego Padres
+726298|Cincinnati Reds at San Diego Padres (Friday July 6, 2012)|San Diego Padres vs Cincinnati Reds [07/06/2012] Tickets at StubHub!|Cincinnati Reds at San Diego Padres
+726299|Los Angeles Dodgers at San Diego Padres (Thursday May 17, 2012)|San Diego Padres vs Los Angeles Dodgers [05/17/2012] Tickets at StubHub!|Los Angeles Dodgers at San Diego Padres
+726300|Miami Marlins at San Diego Padres (Friday May 4, 2012)|San Diego Padres vs Miami Marlins [05/04/2012] Tickets at StubHub!|Miami Marlins at San Diego Padres
+726301|Chicago Cubs at San Diego Padres (Wednesday August 8, 2012)|San Diego Padres vs Chicago Cubs [08/08/2012] Tickets at StubHub!|Chicago Cubs at San Diego Padres
+726302|Washington Nationals at San Diego Padres (Wednesday April 25, 2012)|San Diego Padres vs Washington Nationals [04/25/2012] Tickets at StubHub!|Washington Nationals at San Diego Padres
+726303|Houston Astros at San Diego Padres (Tuesday July 17, 2012)|San Diego Padres vs Houston Astros [07/17/2012] Tickets at StubHub!|Houston Astros at San Diego Padres
+726304|Milwaukee Brewers at San Diego Padres (Wednesday May 2, 2012)|San Diego Padres vs Milwaukee Brewers [05/02/2012] Tickets at StubHub!|Milwaukee Brewers at San Diego Padres
+726305|Colorado Rockies at San Diego Padres (Friday September 14, 2012)|San Diego Padres vs Colorado Rockies [09/14/2012] Tickets at StubHub!|Colorado Rockies at San Diego Padres
+726306|Houston Astros at San Diego Padres (Thursday July 19, 2012)|San Diego Padres vs Houston Astros [07/19/2012] Tickets at StubHub!|Houston Astros at San Diego Padres
+726307|Pittsburgh Pirates at San Diego Padres (Monday August 20, 2012)|San Diego Padres vs Pittsburgh Pirates [08/20/2012] Tickets at StubHub!|Pittsburgh Pirates at San Diego Padres
+726308|Seattle Mariners at San Diego Padres (Saturday June 23, 2012)|San Diego Padres vs Seattle Mariners [06/23/2012] Tickets at StubHub!|Seattle Mariners at San Diego Padres
+726309|Los Angeles Dodgers at San Diego Padres (Friday April 6, 2012)|San Diego Padres vs Los Angeles Dodgers [04/06/2012] Tickets at StubHub!|Los Angeles Dodgers at San Diego Padres
+726310|Cincinnati Reds at San Diego Padres (Saturday July 7, 2012)|San Diego Padres vs Cincinnati Reds [07/07/2012] Tickets at StubHub!|Cincinnati Reds at San Diego Padres
+726311|Colorado Rockies at San Diego Padres (Saturday July 21, 2012)|San Diego Padres vs Colorado Rockies [07/21/2012] Tickets at StubHub!|Colorado Rockies at San Diego Padres
+726312|Pittsburgh Pirates at San Diego Padres (Wednesday August 22, 2012)|San Diego Padres vs Pittsburgh Pirates [08/22/2012] Tickets at StubHub!|Pittsburgh Pirates at San Diego Padres
+726313|Los Angeles Dodgers at San Diego Padres (Wednesday September 26, 2012)|San Diego Padres vs Los Angeles Dodgers [09/26/2012] Tickets at StubHub!|Los Angeles Dodgers at San Diego Padres
+726314|Los Angeles Dodgers at San Diego Padres (Sunday April 8, 2012)|San Diego Padres vs Los Angeles Dodgers [04/08/2012] Tickets at StubHub!|Los Angeles Dodgers at San Diego Padres
+726315|San Francisco Giants at San Diego Padres (Sunday September 30, 2012)|San Diego Padres vs San Francisco Giants [09/30/2012] Tickets at StubHub!|San Francisco Giants at San Diego Padres
+726316|New York Mets at San Diego Padres (Saturday August 5, 2012)|San Diego Padres vs New York Mets [08/05/2012] Tickets at StubHub!|New York Mets at San Diego Padres
+726317|Arizona Diamondbacks at San Diego Padres (Tuesday April 10, 2012)|San Diego Padres vs Arizona Diamondbacks [04/10/2012] Tickets at StubHub!|Arizona Diamondbacks at San Diego Padres
+726318|San Francisco Giants at San Diego Padres (Friday September 28, 2012)|San Diego Padres vs San Francisco Giants [09/28/2012] Tickets at StubHub!|San Francisco Giants at San Diego Padres
+726319|St Louis Cardinals at San Diego Padres (Tuesday September 11, 2012)|San Diego Padres vs St Louis Cardinals [09/11/2012] Tickets at StubHub!|St. Louis Cardinals at San Diego Padres
+726320|San Francisco Giants at San Diego Padres (Saturday August 18, 2012)|San Diego Padres vs San Francisco Giants [08/18/2012] Tickets at StubHub!|San Francisco Giants at San Diego Padres
+726321|Chicago Cubs at San Diego Padres (Tuesday August 7, 2012)|San Diego Padres vs Chicago Cubs [08/07/2012] Tickets at StubHub!|Chicago Cubs at San Diego Padres
+726322|Arizona Diamondbacks at San Diego Padres (Thursday April 12, 2012)|San Diego Padres vs Arizona Diamondbacks [04/12/2012] Tickets at StubHub!|Arizona Diamondbacks at San Diego Padres
+726323|Arizona Diamondbacks at San Diego Padres (Sunday September 9, 2012)|San Diego Padres vs Arizona Diamondbacks [09/09/2012] Tickets at StubHub!|Arizona Diamondbacks at San Diego Padres
+726324|Colorado Rockies at San Diego Padres (Tuesday May 8, 2012)|San Diego Padres vs Colorado Rockies [05/08/2012] Tickets at StubHub!|Colorado Rockies at San Diego Padres
+726325|Atlanta Braves at San Diego Padres (Tuesday August 28, 2012)|San Diego Padres vs Atlanta Braves [08/28/2012] Tickets at StubHub!|Atlanta Braves at San Diego Padres
+726326|Colorado Rockies at San Diego Padres (Sunday September 16, 2012)|San Diego Padres vs Colorado Rockies [09/16/2012] Tickets at StubHub!|Colorado Rockies at San Diego Padres
+726327|Colorado Rockies at San Diego Padres (Saturday September 15, 2012)|San Diego Padres vs Colorado Rockies [09/15/2012] Tickets at StubHub!|Colorado Rockies at San Diego Padres
+726328|New York Mets at San Diego Padres (Friday August 3, 2012)|San Diego Padres vs New York Mets [08/03/2012] Tickets at StubHub!|New York Mets at San Diego Padres
+726329|St Louis Cardinals at San Diego Padres (Wednesday September 12, 2012)|San Diego Padres vs St Louis Cardinals [09/12/2012] Tickets at StubHub!|St. Louis Cardinals at San Diego Padres
+726331|Texas Rangers at San Diego Padres (Tuesday June 19, 2012)|San Diego Padres vs Texas Rangers [06/19/2012] Tickets at StubHub!|Texas Rangers at San Diego Padres
+726332|Seattle Mariners at San Diego Padres (Sunday June 24, 2012)|San Diego Padres vs Seattle Mariners [06/24/2012] Tickets at StubHub!|Seattle Mariners at San Diego Padres
+726334|Philadelphia Phillies at San Diego Padres (Friday April 20, 2012)|San Diego Padres vs Philadelphia Phillies [04/20/2012] Tickets at StubHub!|Philadelphia Phillies at San Diego Padres
+726335|Los Angeles Dodgers at San Diego Padres (Wednesday May 16, 2012)|San Diego Padres vs Los Angeles Dodgers [05/16/2012] Tickets at StubHub!|Los Angeles Dodgers at San Diego Padres
+726336|Colorado Rockies at San Diego Padres (Monday May 7, 2012)|San Diego Padres vs Colorado Rockies [05/07/2012] Tickets at StubHub!|Colorado Rockies at San Diego Padres
+726337|Philadelphia Phillies at San Diego Padres (Sunday April 22, 2012)|San Diego Padres vs Philadelphia Phillies [04/22/2012] Tickets at StubHub!|Philadelphia Phillies at San Diego Padres
+726338|Arizona Diamondbacks at San Diego Padres (Friday September 7, 2012)|San Diego Padres vs Arizona Diamondbacks [09/07/2012] Tickets at StubHub!|Arizona Diamondbacks at San Diego Padres
+726339|Houston Astros at San Diego Padres (Monday July 16, 2012)|San Diego Padres vs Houston Astros [07/16/2012] Tickets at StubHub!|Houston Astros at San Diego Padres
+726340|Miami Marlins at San Diego Padres (Saturday May 5, 2012)|San Diego Padres vs Miami Marlins [05/05/2012] Tickets at StubHub!|Miami Marlins at San Diego Padres
+726341|Texas Rangers at San Diego Padres (Monday June 18, 2012)|San Diego Padres vs Texas Rangers [06/18/2012] Tickets at StubHub!|Texas Rangers at San Diego Padres
+726342|Washington Nationals at San Diego Padres (Tuesday April 24, 2012)|San Diego Padres vs Washington Nationals [04/24/2012] Tickets at StubHub!|Washington Nationals at San Diego Padres
+726343|Texas Rangers at San Diego Padres (Wednesday June 20, 2012)|San Diego Padres vs Texas Rangers [06/20/2012] Tickets at StubHub!|Texas Rangers at San Diego Padres
+726344|Houston Astros at San Diego Padres (Wednesday July 18, 2012)|San Diego Padres vs Houston Astros [07/18/2012] Tickets at StubHub!|Houston Astros at San Diego Padres
+726345|Pittsburgh Pirates at San Diego Padres (Tuesday August 21, 2012)|San Diego Padres vs Pittsburgh Pirates [08/21/2012] Tickets at StubHub!|Pittsburgh Pirates at San Diego Padres
+726346|Washington Nationals at San Diego Padres (Thursday April 26, 2012)|San Diego Padres vs Washington Nationals [04/26/2012] Tickets at StubHub!|Washington Nationals at San Diego Padres
+726347|Los Angeles Dodgers at San Diego Padres (Saturday April 7, 2012)|San Diego Padres vs Los Angeles Dodgers [04/07/2012] Tickets at StubHub!|Los Angeles Dodgers at San Diego Padres
+726348|Los Angeles Dodgers at San Diego Padres (Thursday September 27, 2012)|San Diego Padres vs Los Angeles Dodgers [09/27/2012] Tickets at StubHub!|Los Angeles Dodgers at San Diego Padres
+726349|Colorado Rockies at San Diego Padres (Friday July 20, 2012)|San Diego Padres vs Colorado Rockies [07/20/2012] Tickets at StubHub!|Colorado Rockies at San Diego Padres
+726350|Milwaukee Brewers at San Diego Padres (Tuesday May 1, 2012)|San Diego Padres vs Milwaukee Brewers [05/01/2012] Tickets at StubHub!|Milwaukee Brewers at San Diego Padres
+726351|Seattle Mariners at San Diego Padres (Friday June 22, 2012)|San Diego Padres vs Seattle Mariners [06/22/2012] Tickets at StubHub!|Seattle Mariners at San Diego Padres
+726352|Arizona Diamondbacks at San Diego Padres (Sunday June 3, 2012)|San Diego Padres vs Arizona Diamondbacks [06/03/2012] Tickets at StubHub!|Arizona Diamondbacks at San Diego Padres
+726353|Los Angeles Dodgers at San Diego Padres (Tuesday September 25, 2012)|San Diego Padres vs Los Angeles Dodgers [09/25/2012] Tickets at StubHub!|Los Angeles Dodgers at San Diego Padres
+726354|Colorado Rockies at San Diego Padres (Sunday July 22, 2012)|San Diego Padres vs Colorado Rockies [07/22/2012] Tickets at StubHub!|Colorado Rockies at San Diego Padres
+726355|San Francisco Giants at San Diego Padres (Friday August 17, 2012)|San Diego Padres vs San Francisco Giants [08/17/2012] Tickets at StubHub!|San Francisco Giants at San Diego Padres
+726356|Milwaukee Brewers at San Diego Padres (Monday April 30, 2012)|San Diego Padres vs Milwaukee Brewers [04/30/2012] Tickets at StubHub!|Milwaukee Brewers at San Diego Padres
+726357|Arizona Diamondbacks at San Diego Padres (Wednesday April 11, 2012)|San Diego Padres vs Arizona Diamondbacks [04/11/2012] Tickets at StubHub!|Arizona Diamondbacks at San Diego Padres
+726358|St Louis Cardinals at San Diego Padres (Monday September 10, 2012)|San Diego Padres vs St Louis Cardinals [09/10/2012] Tickets at StubHub!|St. Louis Cardinals at San Diego Padres
+726359|San Francisco Giants at San Diego Padres (Sunday August 19, 2012)|San Diego Padres vs San Francisco Giants [08/19/2012] Tickets at StubHub!|San Francisco Giants at San Diego Padres
+726360|New York Mets at San Diego Padres (Saturday August 4, 2012)|San Diego Padres vs New York Mets [08/04/2012] Tickets at StubHub!|New York Mets at San Diego Padres
+726361|San Francisco Giants at San Diego Padres (Thursday June 7, 2012)|San Diego Padres vs San Francisco Giants [06/07/2012] Tickets at StubHub!|San Francisco Giants at San Diego Padres
+726407|Tampa Bay Rays at Cleveland Indians (Thursday July 5, 2012)|Cleveland Indians vs Tampa Bay Rays [7/5/2012] Tickets at StubHub!|Tampa Bay Rays at Cleveland Indians
+726408|Chicago White Sox at Cleveland Indians (Wednesday May 9, 2012)|Cleveland Indians vs Chicago White Sox [5/9/2012] Tickets at StubHub!|Chicago White Sox at Cleveland Indians
+726409|New York Yankees at Cleveland Indians (Saturday August 25, 2012)|Cleveland Indians vs New York Yankees [8/25/2012] Tickets at StubHub!|New York Yankees at Cleveland Indians
+726410|Texas Rangers at Cleveland Indians (Sunday May 6, 2012)|Cleveland Indians vs Texas Rangers [5/6/2012] Tickets at StubHub!|Texas Rangers at Cleveland Indians
+726411|Seattle Mariners at Cleveland Indians (Thursday May 17, 2012)|Cleveland Indians vs Seattle Mariners [5/17/2012] Tickets at StubHub!|Seattle Mariners at Cleveland Indians
+726412|Minnesota Twins at Cleveland Indians (Wednesday August 8, 2012)|Cleveland Indians vs Minnesota Twins [8/8/2012] Tickets at StubHub!|Minnesota Twins at Cleveland Indians
+726413|Cincinnati Reds at Cleveland Indians (Tuesday June 19, 2012)|Cleveland Indians vs Cincinnati Reds [6/19/2012] Tickets at StubHub!|Cincinnati Reds at Cleveland Indians
+726415|Baltimore Orioles at Cleveland Indians (Saturday July 21, 2012)|Cleveland Indians vs Baltimore Orioles [7/21/2012] Tickets at StubHub!|Baltimore Orioles at Cleveland Indians
+726416|Minnesota Twins at Cleveland Indians (Saturday June 2, 2012)|Cleveland Indians vs Minnesota Twins [6/2/2012] Tickets at StubHub!|Minnesota Twins at Cleveland Indians
+726417|Chicago White Sox at Cleveland Indians (Tuesday April 10, 2012)|Cleveland Indians vs Chicago White Sox [4/10/2012] Tickets at StubHub!|Chicago White Sox at Cleveland Indians
+726418|Kansas City Royals at Cleveland Indians (Friday September 28, 2012)|Cleveland Indians vs Kansas City Royals [9/28/2012] Tickets at StubHub!|Kansas City Royals at Cleveland Indians
+726419|Tampa Bay Rays at Cleveland Indians (Friday July 6, 2012)|Cleveland Indians vs Tampa Bay Rays [7/6/2012] Tickets at StubHub!|Tampa Bay Rays at Cleveland Indians
+726420|Detroit Tigers at Cleveland Indians (Tuesday May 22, 2012)|Cleveland Indians vs Detroit Tigers [5/22/2012] Tickets at StubHub!|Detroit Tigers at Cleveland Indians
+726421|New York Yankees at Cleveland Indians (Friday August 24, 2012)|Cleveland Indians vs New York Yankees [8/24/2012] Tickets at StubHub!|New York Yankees at Cleveland Indians
+726422|Minnesota Twins at Cleveland Indians (Thursday September 20, 2012)|Cleveland Indians vs Minnesota Twins [9/20/2012] Tickets at StubHub!|Minnesota Twins at Cleveland Indians
+726423|Chicago White Sox at Cleveland Indians (Monday May 7, 2012)|Cleveland Indians vs Chicago White Sox [5/7/2012] Tickets at StubHub!|Chicago White Sox at Cleveland Indians
+726424|Chicago White Sox at Cleveland Indians (Wednesday October 3, 2012)|Cleveland Indians vs Chicago White Sox [10/3/2012] Tickets at StubHub!|Chicago White Sox at Cleveland Indians
+726425|Kansas City Royals at Cleveland Indians (Wednesday May 30, 2012)|Cleveland Indians vs Kansas City Royals [5/30/2012] Tickets at StubHub!|Kansas City Royals at Cleveland Indians
+726426|Boston Red Sox at Cleveland Indians (Saturday August 11, 2012)|Cleveland Indians vs Boston Red Sox [8/11/2012] Tickets at StubHub!|Boston Red Sox at Cleveland Indians
+726427|Cincinnati Reds at Cleveland Indians (Monday June 18, 2012)|Cleveland Indians vs Cincinnati Reds [6/18/2012] Tickets at StubHub!|Cincinnati Reds at Cleveland Indians
+726428|Toronto Blue Jays at Cleveland Indians (Thursday April 5, 2012)|Cleveland Indians vs Toronto Blue Jays [4/5/2012] Tickets at StubHub!|Toronto Blue Jays at Cleveland Indians
+726429|Kansas City Royals at Cleveland Indians (Thursday April 26, 2012)|Cleveland Indians vs Kansas City Royals [4/26/2012] Tickets at StubHub!|Kansas City Royals at Cleveland Indians
+726430|Baltimore Orioles at Cleveland Indians (Sunday July 22, 2012)|Cleveland Indians vs Baltimore Orioles [7/22/2012] Tickets at StubHub!|Baltimore Orioles at Cleveland Indians
+726431|Minnesota Twins at Cleveland Indians (Friday June 1, 2012)|Cleveland Indians vs Minnesota Twins [6/1/2012] Tickets at StubHub!|Minnesota Twins at Cleveland Indians
+726432|Kansas City Royals at Cleveland Indians (Saturday September 29, 2012)|Cleveland Indians vs Kansas City Royals [9/29/2012] Tickets at StubHub!|Kansas City Royals at Cleveland Indians
+726433|Tampa Bay Rays at Cleveland Indians (Saturday July 7, 2012)|Cleveland Indians vs Tampa Bay Rays [7/7/2012] Tickets at StubHub!|Tampa Bay Rays at Cleveland Indians
+726434|Detroit Tigers at Cleveland Indians (Wednesday May 23, 2012)|Cleveland Indians vs Detroit Tigers [5/23/2012] Tickets at StubHub!|Detroit Tigers at Cleveland Indians
+726435|Texas Rangers at Cleveland Indians (Sunday September 2, 2012)|Cleveland Indians vs Texas Rangers [9/2/2012] Tickets at StubHub!|Texas Rangers at Cleveland Indians
+726436|Oakland Athletics at Cleveland Indians (Monday August 27, 2012)|Cleveland Indians vs Oakland Athletics [8/27/2012] Tickets at StubHub!|Oakland Athletics at Cleveland Indians
+726437|Tampa Bay Rays at Cleveland Indians (Sunday July 8, 2012)|Cleveland Indians vs Tampa Bay Rays [7/8/2012] Tickets at StubHub!|Tampa Bay Rays at Cleveland Indians
+726438|Texas Rangers at Cleveland Indians (Friday May 4, 2012)|Cleveland Indians vs Texas Rangers [5/4/2012] Tickets at StubHub!|Texas Rangers at Cleveland Indians
+726439|Chicago White Sox at Cleveland Indians (Tuesday October 2, 2012)|Cleveland Indians vs Chicago White Sox [10/2/2012] Tickets at StubHub!|Chicago White Sox at Cleveland Indians
+726440|Boston Red Sox at Cleveland Indians (Friday August 10, 2012)|Cleveland Indians vs Boston Red Sox [8/10/2012] Tickets at StubHub!|Boston Red Sox at Cleveland Indians
+726441|Pittsburgh Pirates at Cleveland Indians (Sunday June 17, 2012)|Cleveland Indians vs Pittsburgh Pirates [6/17/2012] Tickets at StubHub!|Pittsburgh Pirates at Cleveland Indians
+726443|Baltimore Orioles at Cleveland Indians (Monday July 23, 2012)|Cleveland Indians vs Baltimore Orioles [7/23/2012] Tickets at StubHub!|Baltimore Orioles at Cleveland Indians
+726444|Minnesota Twins at Cleveland Indians (Tuesday September 18, 2012)|Cleveland Indians vs Minnesota Twins [9/18/2012] Tickets at StubHub!|Minnesota Twins at Cleveland Indians
+726445|Detroit Tigers at Cleveland Indians (Tuesday July 24, 2012)|Cleveland Indians vs Detroit Tigers [7/24/2012] Tickets at StubHub!|Detroit Tigers at Cleveland Indians
+726446|Miami Marlins at Cleveland Indians (Sunday May 20, 2012)|Cleveland Indians vs Florida Marlins [5/20/2012] Tickets at StubHub!|Miami Marlins at Cleveland Indians
+726447|New York Yankees at Cleveland Indians (Sunday August 26, 2012)|Cleveland Indians vs New York Yankees [8/26/2012] Tickets at StubHub!|New York Yankees at Cleveland Indians
+726448|Texas Rangers at Cleveland Indians (Saturday May 5, 2012)|Cleveland Indians vs Texas Rangers [5/5/2012] Tickets at StubHub!|Texas Rangers at Cleveland Indians
+726449|Chicago White Sox at Cleveland Indians (Monday October 1, 2012)|Cleveland Indians vs Chicago White Sox [10/1/2012] Tickets at StubHub!|Chicago White Sox at Cleveland Indians
+726450|Pittsburgh Pirates at Cleveland Indians (Friday June 15, 2012)|Cleveland Indians vs Pittsburgh Pirates [6/15/2012] Tickets at StubHub!|Pittsburgh Pirates at Cleveland Indians
+726451|Kansas City Royals at Cleveland Indians (Monday May 28, 2012)|Cleveland Indians vs Kansas City Royals [5/28/2012] Tickets at StubHub!|Kansas City Royals at Cleveland Indians
+726452|Pittsburgh Pirates at Cleveland Indians (Saturday June 16, 2012)|Cleveland Indians vs Pittsburgh Pirates [6/16/2012] Tickets at StubHub!|Pittsburgh Pirates at Cleveland Indians
+726453|Toronto Blue Jays at Cleveland Indians (Saturday April 7, 2012)|Cleveland Indians vs Toronto Blue Jays [4/7/2012] Tickets at StubHub!|Toronto Blue Jays at Cleveland Indians
+726455|Oakland Athletics at Cleveland Indians (Wednesday August 29, 2012)|Cleveland Indians vs Oakland Athletics [8/29/2012] Tickets at StubHub!|Oakland Athletics at Cleveland Indians
+726456|Minnesota Twins at Cleveland Indians (Wednesday September 19, 2012)|Cleveland Indians vs Minnesota Twins [9/19/2012] Tickets at StubHub!|Minnesota Twins at Cleveland Indians
+726457|Detroit Tigers at Cleveland Indians (Wednesday July 25, 2012)|Cleveland Indians vs Detroit Tigers [7/25/2012] Tickets at StubHub!|Detroit Tigers at Cleveland Indians
+726458|Boston Red Sox at Cleveland Indians (Sunday August 12, 2012)|Cleveland Indians vs Boston Red Sox [8/12/2012] Tickets at StubHub!|Boston Red Sox at Cleveland Indians
+726459|Kansas City Royals at Cleveland Indians (Tuesday May 29, 2012)|Cleveland Indians vs Kansas City Royals [5/29/2012] Tickets at StubHub!|Kansas City Royals at Cleveland Indians
+726461|Minnesota Twins at Cleveland Indians (Tuesday August 7, 2012)|Cleveland Indians vs Minnesota Twins [8/7/2012] Tickets at StubHub!|Minnesota Twins at Cleveland Indians
+726462|Oakland Athletics at Cleveland Indians (Tuesday August 28, 2012)|Cleveland Indians vs Oakland Athletics [8/28/2012] Tickets at StubHub!|Oakland Athletics at Cleveland Indians
+726463|Detroit Tigers at Cleveland Indians (Sunday September 16, 2012)|Cleveland Indians vs Detroit Tigers [9/16/2012] Tickets at StubHub!|Detroit Tigers at Cleveland Indians
+726464|Detroit Tigers at Cleveland Indians (Thursday July 26, 2012)|Cleveland Indians vs Detroit Tigers [7/26/2012] Tickets at StubHub!|Detroit Tigers at Cleveland Indians
+726465|Miami Marlins at Cleveland Indians (Friday May 18, 2012)|Cleveland Indians vs Miami Marlins [5/18/2012] Tickets at StubHub!|Miami Marlins at Cleveland Indians
+726466|Texas Rangers at Cleveland Indians (Saturday September 1, 2012)|Cleveland Indians vs Texas Rangers [9/1/2012] Tickets at StubHub!|Texas Rangers at Cleveland Indians
+726467|Chicago White Sox at Cleveland Indians (Monday April 9, 2012)|Cleveland Indians vs Chicago White Sox [4/9/2012] Tickets at StubHub!|Chicago White Sox at Cleveland Indians
+726469|Minnesota Twins at Cleveland Indians (Monday August 6, 2012)|Cleveland Indians vs Minnesota Twins [8/6/2012] Tickets at StubHub!|Minnesota Twins at Cleveland Indians
+726470|Detroit Tigers at Cleveland Indians (Friday September 14, 2012)|Cleveland Indians vs Detroit Tigers [9/14/2012] Tickets at StubHub!|Detroit Tigers at Cleveland Indians
+726471|Texas Rangers at Cleveland Indians (Friday August 31, 2012)|Cleveland Indians vs Texas Rangers [8/31/2012] Tickets at StubHub!|Texas Rangers at Cleveland Indians
+726472|Miami Marlins at Cleveland Indians (Saturday May 19, 2012)|Cleveland Indians vs Miami Marlins [5/19/2012] Tickets at StubHub!|Miami Marlins at Cleveland Indians
+726473|Kansas City Royals at Cleveland Indians (Wednesday April 25, 2012)|Cleveland Indians vs Kansas City Royals [4/25/2012] Tickets at StubHub!|Kansas City Royals at Cleveland Indians
+726474|Toronto Blue Jays at Cleveland Indians (Sunday April 8, 2012)|Cleveland Indians vs Toronto Blue Jays [4/8/2012] Tickets at StubHub!|Toronto Blue Jays at Cleveland Indians
+726475|Kansas City Royals at Cleveland Indians (Sunday September 30, 2012)|Cleveland Indians vs Kansas City Royals [9/30/2012] Tickets at StubHub!|Kansas City Royals at Cleveland Indians
+726477|Chicago White Sox at Cleveland Indians (Tuesday May 8, 2012)|Cleveland Indians vs Chicago White Sox [5/8/2012] Tickets at StubHub!|Chicago White Sox at Cleveland Indians
+726478|Detroit Tigers at Cleveland Indians (Saturday September 15, 2012)|Cleveland Indians vs Detroit Tigers [9/15/2012] Tickets at StubHub!|Detroit Tigers at Cleveland Indians
+726479|Oakland Athletics at Cleveland Indians (Thursday August 30, 2012)|Cleveland Indians vs Oakland Athletics [8/30/2012] Tickets at StubHub!|Oakland Athletics at Cleveland Indians
+726480|Seattle Mariners at Cleveland Indians (Wednesday May 16, 2012)|Cleveland Indians vs Seattle Mariners [5/16/2012] Tickets at StubHub!|Seattle Mariners at Cleveland Indians
+726481|Boston Red Sox at Cleveland Indians (Thursday August 9, 2012)|Cleveland Indians vs Boston Red Sox [8/9/2012] Tickets at StubHub!|Boston Red Sox at Cleveland Indians
+726482|Kansas City Royals at Cleveland Indians (Tuesday April 24, 2012)|Cleveland Indians vs Kansas City Royals [4/24/2012] Tickets at StubHub!|Kansas City Royals at Cleveland Indians
+726483|Baltimore Orioles at Cleveland Indians (Friday July 20, 2012)|Cleveland Indians vs Baltimore Orioles [7/20/2012] Tickets at StubHub!|Baltimore Orioles at Cleveland Indians
+726484|Minnesota Twins at Cleveland Indians (Sunday June 3, 2012)|Cleveland Indians vs Minnesota Twins [6/3/2012] Tickets at StubHub!|Minnesota Twins at Cleveland Indians
+726485|Detroit Tigers at Cleveland Indians (Thursday May 24, 2012)|Cleveland Indians vs Detroit Tigers [5/24/2012] Tickets at StubHub!|Detroit Tigers at Cleveland Indians
+726486|Cincinnati Reds at Cleveland Indians (Wednesday June 20, 2012)|Cleveland Indians vs Cincinnati Reds [6/20/2012] Tickets at StubHub!|Cincinnati Reds at Cleveland Indians
+726487|Chicago White Sox at Cleveland Indians (Wednesday April 11, 2012)|Cleveland Indians vs Chicago White Sox [4/11/2012] Tickets at StubHub!|Chicago White Sox at Cleveland Indians
+726540|New York Yankees at Philadelphia Phillies Spring Training|New York Yankees vs Philadelphia Phillies 3/3/2012 Spring Training Tickets at StubHub!|Spring Training - New York Yankees at Philadelphia Phillies
+726541|Baltimore Orioles at Philadelphia Phillies Spring Training (SS)|Baltimore Orioles vs Philadelphia Phillies 25/3/2012 Spring Training Tickets at StubHub!|Spring Training - Baltimore Orioles at Philadelphia Phillies (Split Squad)
+726542|New York Yankees at Philadelphia Phillies Spring Training|New York Yankees vs Philadelphia Phillies 23/3/2012 Spring Training Tickets at StubHub!|Spring Training - New York Yankees at Philadelphia Phillies
+726543|Boston Red Sox at Philadelphia Phillies Spring Training|Boston Red Sox vs Philadelphia Phillies 26/3/2012 Spring Training Tickets at StubHub!|Spring Training - Boston Red Sox at Philadelphia Phillies
+726544|Pittsburgh Pirates at Philadelphia Phillies Spring Training|Pittsburgh Pirates vs Philadelphia Phillies 27/3/2012 Spring Training Tickets at StubHub!|Spring Training - Pittsburgh Pirates at Philadelphia Phillies
+726545|Minnesota Twins at Philadelphia Phillies Spring Training|Minnesota Twins vs Philadelphia Phillies 14/3/2012 Spring Training Tickets at StubHub!|Spring Training - Minnesota Twins at Philadelphia Phillies
+726546|Toronto Blue Jays at Philadelphia Phillies Spring Training|Toronto Blue Jays vs Philadelphia Phillies 17/3/2012 Spring Training Tickets at StubHub!|Spring Training - Toronto Blue Jays at Philadelphia Phillies
+726547|Atlanta Braves at Philadelphia Phillies Spring Training (SS)|Atlanta Braves vs Philadelphia Phillies 15/3/2012 Spring Training Tickets at StubHub!|Spring Training - Atlanta Braves at Philadelphia Phillies (Split Squad)
+726548|New York Yankees at Philadelphia Phillies Spring Training|New York Yankees vs Philadelphia Phillies 5/3/2012 Spring Training Tickets at StubHub!|Spring Training - New York Yankees at Philadelphia Phillies
+726549|Pittsburgh Pirates at Philadelphia Phillies Spring Training|Pittsburgh Pirates vs Philadelphia Phillies 8/3/2012 Spring Training Tickets at StubHub!|Spring Training - Pittsburgh Pirates at Philadelphia Phillies
+726550|Detroit Tigers at Philadelphia Phillies Spring Training|Detroit Tigers vs Philadelphia Phillies 19/3/2012 Spring Training Tickets at StubHub!|Spring Training - Detroit Tigers at Philadelphia Phillies
+726551|Houston Astros at Philadelphia Phillies Spring Training|Houston Astros vs Philadelphia Phillies 7/3/2012 Spring Training Tickets at StubHub!|Spring Training - Houston Astros at Philadelphia Phillies
+726552|Baltimore Orioles at Philadelphia Phillies Spring Training|Baltimore Orioles vs Philadelphia Phillies 10/3/2012 Spring Training Tickets at StubHub!|Spring Training - Baltimore Orioles at Philadelphia Phillies
+726553|Tampa Bay Rays at Philadelphia Phillies Spring Training|Tampa Bay Rays vs Philadelphia Phillies 29/3/2012 Spring Training Tickets at StubHub!|Spring Training - Tampa Bay Rays at Philadelphia Phillies
+726554|Detroit Tigers at Philadelphia Phillies Spring Training (SS)|Detroit Tigers vs Philadelphia Phillies 11/3/2012 Spring Training Tickets at StubHub!|Spring Training - Detroit Tigers at Philadelphia Phillies (Split Squad)
+726555|Florida State Seminoles at Philadelphia Phillies Spring Training|Florida State Seminoles vs Philadelphia Phillies [02/29/2012] Spring Training Tickets at StubHub!|Spring Training - Florida State Seminoles at Philadelphia Phillies
+726556|Toronto Blue Jays at Philadelphia Phillies Spring Training|Toronto Blue Jays vs Philadelphia Phillies 31/3/2012 Spring Training Tickets at StubHub!|Spring Training - Toronto Blue Jays at Philadelphia Phillies
+726743|Los Angeles Angels at San Diego Padres (Saturday May 19, 2012)|San Diego Padres vs Los Angeles Angels [05/19/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at San Diego Padres
+726744|Los Angeles Dodgers at San Diego Padres (Thursday April 5, 2012)|San Diego Padres vs Los Angeles Dodgers [04/05/2012] Tickets at StubHub!|Los Angeles Dodgers at San Diego Padres
+726745|Los Angeles Angels at San Diego Padres (Friday May 18, 2012)|San Diego Padres vs Los Angeles Angels [05/18/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at San Diego Padres
+726748|Los Angeles Angels at San Diego Padres (Sunday May 20, 2012)|San Diego Padres vs Los Angeles Angels [05/20/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at San Diego Padres
+727485|Los Angeles Angels at Cleveland Indians (Friday April 27, 2012)|Cleveland Indians vs Los Angeles Angels [4/27/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Cleveland Indians
+727486|Los Angeles Angels at Cleveland Indians (Sunday April 29, 2012)|Cleveland Indians vs Los Angeles Angels [4/29/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Cleveland Indians
+727487|Los Angeles Angels at Cleveland Indians (Saturday April 28, 2012)|Cleveland Indians vs Los Angeles Angels [4/28/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Cleveland Indians
+727488|Los Angeles Angels at Cleveland Indians (Monday July 2, 2012)|Cleveland Indians vs Los Angeles Angels [7/2/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Cleveland Indians
+727489|Los Angeles Angels at Cleveland Indians (Tuesday July 3, 2012)|Cleveland Indians vs Los Angeles Angels [7/3/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Cleveland Indians
+727490|Los Angeles Angels at Cleveland Indians (Wednesday July 4, 2012(|Cleveland Indians vs Los Angeles Angels [7/4/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Cleveland Indians
+727506|Los Angeles Angels at Detroit Tigers (Saturday August 25, 2012)|Detroit Tigers vs Los Angeles Angels [8/25/2012] Tickets at StubHub!|
+727507|Los Angeles Angels at Detroit Tigers (Friday August 24, 2012)|Detroit Tigers vs Los Angeles Angels [8/24/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Detroit Tigers
+727508|Los Angeles Angels at Detroit Tigers (Sunday August 26, 2012)|Detroit Tigers vs Los Angeles Angels [8/26/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Detroit Tigers
+727509|Los Angeles Angels at Detroit Tigers (Monday July 16, 2012)|Detroit Tigers vs Los Angeles Angels [7/16/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Detroit Tigers
+727510|Los Angeles Angels at Detroit Tigers (Tuesday July 17, 2012)|Detroit Tigers vs Los Angeles Angels [7/17/2012] Tickets at StubHub!|
+727511|Los Angeles Angels at Detroit Tigers (Wednesday July 18, 2012)|Detroit Tigers vs Los Angeles Angels [7/18/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Detroit Tigers
+727512|Los Angeles Angels at Detroit Tigers (Thursday July 19, 2012)|Detroit Tigers vs Los Angeles Angels [7/19/2012] Tickets at StubHub!|
+727546|Kansas City Royals at Detroit Tigers (Wednesday May 2, 2012)|Detroit Tigers vs Kansas City Royals [5/2/2012] Tickets at StubHub!|Kansas City Royals at Detroit Tigers
+727547|Kansas City Royals at Detroit Tigers (Tuesday May 1, 2012)|Detroit Tigers vs Kansas City Royals [5/1/2012] Tickets at StubHub!|Kansas City Royals at Detroit Tigers
+727548|Kansas City Royals at Detroit Tigers (Monday April 30, 2012)|Detroit Tigers vs Kansas City Royals [4/30/2012] Tickets at StubHub!|Kansas City Royals at Detroit Tigers
+728658|Tampa Bay Rays at Chicago White Sox (Saturday September 29, 2012)|Chicago White Sox vs Tampa Bay Rays [9/29/2012] Tickets at StubHub!|Tampa Bay Rays at Chicago White Sox
+728659|Kansas City Royals at Chicago White Sox (Saturday September 8, 2012)|Chicago White Sox vs Kansas City Royals [9/8/2012] Tickets at StubHub!|Kansas City Royals at Chicago White Sox
+728660|Kansas City Royals at Chicago White Sox (Friday May 11, 2012)|Chicago White Sox vs Kansas City Royals [5/11/2012] Tickets at StubHub!|Kansas City Royals at Chicago White Sox
+728661|Toronto Blue Jays at Chicago White Sox (Sunday July 8, 2012)|Chicago White Sox vs Toronto Blue Jays [7/8/2012] Tickets at StubHub!|Toronto Blue Jays at Chicago White Sox
+728662|Detroit Tigers at Chicago White Sox (Sunday April 15, 2012)|Chicago White Sox vs Detroit Tigers [4/15/2012] Tickets at StubHub!|Detroit Tigers at Chicago White Sox
+728663|Toronto Blue Jays at Chicago White Sox (Saturday July 7, 2012)|Chicago White Sox vs Toronto Blue Jays [7/7/2012] Tickets at StubHub!|Toronto Blue Jays at Chicago White Sox
+728664|Baltimore Orioles at Chicago White Sox (Tuesday April 17, 2012)|Chicago White Sox vs Baltimore Orioles [4/17/2012] Tickets at StubHub!|Baltimore Orioles at Chicago White Sox
+728665|Texas Rangers at Chicago White Sox (Thursday July 5, 2012)|Chicago White Sox vs Texas Rangers [7/5/2012] Tickets at StubHub!|Texas Rangers at Chicago White Sox
+728666|Minnesota Twins at Chicago White Sox (Wednesday May 23, 2012)|Chicago White Sox vs Minnesota Twins [5/23/2012] Tickets at StubHub!|Minnesota Twins at Chicago White Sox
+728667|Seattle Mariners at Chicago White Sox (Saturday August 25, 20120|Chicago White Sox vs Seattle Mariners [8/25/2012] Tickets at StubHub!|Seattle Mariners at Chicago White Sox
+728668|Baltimore Orioles at Chicago White Sox (Thursday April 19, 2012)|Chicago White Sox vs Baltimore Orioles [4/19/2012] Tickets at StubHub!|Baltimore Orioles at Chicago White Sox
+728669|Oakland Athletics at Chicago White Sox (Sunday August 12, 2012)|Chicago White Sox vs Oakland Athletics [8/12/2012] Tickets at StubHub!|Oakland Athletics at Chicago White Sox
+728670|Kansas City Royals at Chicago White Sox (Monday August 6, 2012)|Chicago White Sox vs Kansas City Royals [8/6/2012] Tickets at StubHub!|Kansas City Royals at Chicago White Sox
+728671|Milwaukee Brewers at Chicago White Sox (Saturday June 23, 2012)|Chicago White Sox vs Milwaukee Brewers [6/23/2012] Tickets at StubHub!|Milwaukee Brewers at Chicago White Sox
+728672|Houston Astros at Chicago White Sox (Sunday June 10, 2012)|Chicago White Sox vs Houston Astros [6/10/2012] Tickets at StubHub!|Houston Astros at Chicago White Sox
+728673|Toronto Blue Jays at Chicago White Sox (Tuesday June 5, 2012)|Chicago White Sox vs Toronto Blue Jays [6/5/2012] Tickets at StubHub!|Toronto Blue Jays at Chicago White Sox
+728674|Kansas City Royals at Chicago White Sox (Wednesday August 8, 2012)|Chicago White Sox vs Kansas City Royals [8/8/2012] Tickets at StubHub!|Kansas City Royals at Chicago White Sox
+728675|Chicago Cubs at Chicago White Sox (Tuesday June 19, 2012)|Chicago White Sox vs Chicago Cubs [6/19/2012] Tickets at StubHub!|Chicago Cubs at Chicago White Sox
+728676|Houston Astros at Chicago White Sox (Friday June 8, 2012)|Chicago White Sox vs Houston Astros [6/8/2012] Tickets at StubHub!|Houston Astros at Chicago White Sox
+728677|Minnesota Twins at Chicago White Sox (Tuesday September 4, 2012)|Chicago White Sox vs Minnesota Twins [9/4/2012] Tickets at StubHub!|Minnesota Twins at Chicago White Sox
+728678|Cleveland Indians at Chicago White Sox (Wednesday May 2, 2012)|Chicago White Sox vs Cleveland Indians [5/2/2012] Tickets at StubHub!|Cleveland Indians at Chicago White Sox
+728679|Oakland Athletics at Chicago White Sox (Friday August 10, 2012)|Chicago White Sox vs Oakland Athletics [8/10/2012] Tickets at StubHub!|Oakland Athletics at Chicago White Sox
+728680|Boston Red Sox at Chicago White Sox (Friday April 27, 2012)|Chicago White Sox vs Boston Red Sox [4/27/2012] Tickets at StubHub!|Boston Red Sox at Chicago White Sox
+728681|Cleveland Indians at Chicago White Sox (Wednesday September 26, 2012)|Chicago White Sox vs Cleveland Indians [9/26/2012] Tickets at StubHub!|Cleveland Indians at Chicago White Sox
+728682|Milwaukee Brewers at Chicago White Sox (Friday June 22, 2012)|Chicago White Sox vs Milwaukee Brewers [6/22/2012] Tickets at StubHub!|Milwaukee Brewers at Chicago White Sox
+728683|New York Yankees at Chicago White Sox (Monday August 20, 2012)|Chicago White Sox vs New York Yankees [8/20/2012] Tickets at StubHub!|New York Yankees at Chicago White Sox
+728684|Boston Red Sox at Chicago White Sox (Sunday April 29, 2012)|Chicago White Sox vs Boston Red Sox [4/29/2012] Tickets at StubHub!|Boston Red Sox at Chicago White Sox
+728685|Cleveland Indians at Chicago White Sox (Monday September 24, 2012)|Chicago White Sox vs Cleveland Indians [9/24/2012] Tickets at StubHub!|Cleveland Indians at Chicago White Sox
+728686|Cleveland Indians at Chicago White Sox (Sunday May 27, 2012)|Chicago White Sox vs Cleveland Indians [5/27/2012] Tickets at StubHub!|Cleveland Indians at Chicago White Sox
+728687|Detroit Tigers at Chicago White Sox (Monday May 14, 2012)|Chicago White Sox vs Detroit Tigers [5/14/2012] Tickets at StubHub!|Detroit Tigers at Chicago White Sox
+728688|New York Yankees at Chicago White Sox (Wednesday August 22, 2012)|Chicago White Sox vs New York Yankees [8/22/2012] Tickets at StubHub!|New York Yankees at Chicago White Sox
+728689|Seattle Mariners at Chicago White Sox (Saturday June 2, 2012)|Chicago White Sox vs Seattle Mariners [6/2/2012] Tickets at StubHub!|Seattle Mariners at Chicago White Sox
+728690|Tampa Bay Rays at Chicago White Sox (Sunday September 30, 2012)|Chicago White Sox vs Tampa Bay Rays [9/30/2012] Tickets at StubHub!|Tampa Bay Rays at Chicago White Sox
+728691|Cleveland Indians at Chicago White Sox (Friday May 25, 2012)|Chicago White Sox vs Cleveland Indians [5/25/2012] Tickets at StubHub!|Cleveland Indians at Chicago White Sox
+728692|Kansas City Royals at Chicago White Sox (Saturday May 12, 2012)|Chicago White Sox vs Kansas City Royals [5/12/2012] Tickets at StubHub!|Kansas City Royals at Chicago White Sox
+728693|Los Angeles Angels at Chicago White Sox (Sunday August 5, 2012)|Chicago White Sox vs Los Angeles Angels [8/5/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Chicago White Sox
+728694|Tampa Bay Rays at Chicago White Sox (Friday September 28, 2012)|Chicago White Sox vs Tampa Bay Rays [9/28/2012] Tickets at StubHub!|Tampa Bay Rays at Chicago White Sox
+728695|Detroit Tigers at Chicago White Sox (Tuesday September 11, 2012)|Chicago White Sox vs Detroit Tigers [9/11/2012] Tickets at StubHub!|Detroit Tigers at Chicago White Sox
+728696|Texas Rangers at Chicago White Sox (Wednesday July 4, 2012)|Chicago White Sox vs Texas Rangers [7/4/2012] Tickets at StubHub!|Texas Rangers at Chicago White Sox
+728697|Kansas City Royals at Chicago White Sox (Tuesday August 7, 2012)|Chicago White Sox vs Kansas City Royals [8/7/2012] Tickets at StubHub!|Kansas City Royals at Chicago White Sox
+728698|Toronto Blue Jays at Chicago White Sox (Wednesday June 6, 2012)|Chicago White Sox vs Toronto Blue Jays [6/6/2012] Tickets at StubHub!|Toronto Blue Jays at Chicago White Sox
+728699|Minnesota Twins at Chicago White Sox (Tuesday July 24, 2012)|Chicago White Sox vs Minnesota Twins [7/24/2012] Tickets at StubHub!|Minnesota Twins at Chicago White Sox
+728700|Kansas City Royals at Chicago White Sox (Sunday September 9, 2012)|Chicago White Sox vs Kansas City Royals [9/9/2012] Tickets at StubHub!|Kansas City Royals at Chicago White Sox
+728701|Toronto Blue Jays at Chicago White Sox (Friday July 6, 2012)|Chicago White Sox vs Toronto Blue Jays [7/6/2012] Tickets at StubHub!|Toronto Blue Jays at Chicago White Sox
+728702|Detroit Tigers at Chicago White Sox (Saturday April 14, 2012)|Chicago White Sox vs Detroit Tigers [4/14/2012] Tickets at StubHub!|Detroit Tigers at Chicago White Sox
+728703|Minnesota Twins at Chicago White Sox (Tuesday May 22, 2012)|Chicago White Sox vs Minnesota Twins [5/22/2012] Tickets at StubHub!|Minnesota Twins at Chicago White Sox
+728704|Milwaukee Brewers at Chicago White Sox (Sunday June 24, 2012)|Chicago White Sox vs Milwaukee Brewers [6/24/2012] Tickets at StubHub!|Milwaukee Brewers at Chicago White Sox
+728705|Los Angeles Angels at Chicago White Sox (Friday August 3, 2012)|Chicago White Sox vs Los Angeles Angels [8/3/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Chicago White Sox
+728706|Baltimore Orioles at Chicago White Sox (Monday April 16, 2012)|Chicago White Sox vs Baltimore Orioles [4/16/2012] Tickets at StubHub!|Baltimore Orioles at Chicago White Sox
+728707|Detroit Tigers at Chicago White Sox (Wednesday September 12, 2012)|Chicago White Sox vs Detroit Tigers [9/12/2012] Tickets at StubHub!|Detroit Tigers at Chicago White Sox
+728708|Detroit Tigers at Chicago White Sox (Thursday September 13, 2012)|Chicago White Sox vs Detroit Tigers [9/13/2012] Tickets at StubHub!|Detroit Tigers at Chicago White Sox
+728709|Minnesota Twins at Chicago White Sox (Monday July 23, 2012)|Chicago White Sox vs Minnesota Twins [7/23/2012] Tickets at StubHub!|Minnesota Twins at Chicago White Sox
+728710|Seattle Mariners at Chicago White Sox (Friday August 24, 2012)|Chicago White Sox vs Seattle Mariners [8/24/2012] Tickets at StubHub!|Seattle Mariners at Chicago White Sox
+728711|Baltimore Orioles at Chicago White Sox (Wednesday April 18, 2012)|Chicago White Sox vs Baltimore Orioles [4/18/2012] Tickets at StubHub!|Baltimore Orioles at Chicago White Sox
+728712|Minnesota Twins at Chicago White Sox (Wednesday July 25, 2012)|Chicago White Sox vs Minnesota Twins [7/25/2012] Tickets at StubHub!|Minnesota Twins at Chicago White Sox
+728713|Minnesota Twins at Chicago White Sox (Monday September 3, 2012)|Chicago White Sox vs Minnesota Twins [9/3/2012] Tickets at StubHub!|Minnesota Twins at Chicago White Sox
+728714|Seattle Mariners at Chicago White Sox (Sunday August 26, 2012)|Chicago White Sox vs Seattle Mariners [8/26/2012] Tickets at StubHub!|Seattle Mariners at Chicago White Sox
+728715|Houston Astros at Chicago White Sox (Saturday June 9, 2012)|Chicago White Sox vs Houston Astros [6/9/2012] Tickets at StubHub!|Houston Astros at Chicago White Sox
+728716|Kansas City Royals at Chicago White Sox (Friday September 7, 2012)|Chicago White Sox vs Kansas City Royals [9/7/2012] Tickets at StubHub!|Kansas City Royals at Chicago White Sox
+728717|Detroit Tigers at Chicago White Sox (Monday September 10, 2012)|Chicago White Sox vs Detroit Tigers [9/10/2012] Tickets at StubHub!|Detroit Tigers at Chicago White Sox
+728718|Oakland Athletics at Chicago White Sox (Saturday August 11, 2012)|Chicago White Sox vs Oakland Athletics [8/11/2012] Tickets at StubHub!|Oakland Athletics at Chicago White Sox
+728719|Chicago Cubs at Chicago White Sox (Monday June 18, 2012)|Chicago White Sox vs Chicago Cubs [6/18/2012] Tickets at StubHub!|Chicago Cubs at Chicago White Sox
+728720|Minnesota Twins at Chicago White Sox (Wednesday September 5, 2012)|Chicago White Sox vs Minnesota Twins [9/5/2012] Tickets at StubHub!|Minnesota Twins at Chicago White Sox
+728721|Texas Rangers at Chicago White Sox (Tuesday July 3, 2012)|Chicago White Sox vs Texas Rangers [7/3/2012] Tickets at StubHub!|Texas Rangers at Chicago White Sox
+728722|Cleveland Indians at Chicago White Sox (Thursday May 3, 2012)|Chicago White Sox vs Cleveland Indians [5/3/2012] Tickets at StubHub!|Cleveland Indians at Chicago White Sox
+728723|New York Yankees at Chicago White Sox (Tuesday August 21, 2012)|Chicago White Sox vs New York Yankees [8/21/2012] Tickets at StubHub!|New York Yankees at Chicago White Sox
+728724|Boston Red Sox at Chicago White Sox (Thursday April 26, 2012)|Chicago White Sox vs Boston Red Sox [4/26/2012] Tickets at StubHub!|Boston Red Sox at Chicago White Sox
+728725|Tampa Bay Rays at Chicago White Sox (Thursday September 27, 2012)|Chicago White Sox vs Tampa Bay Rays [9/27/2012] Tickets at StubHub!|Tampa Bay Rays at Chicago White Sox
+728726|Cleveland Indians at Chicago White Sox (Saturday May 26, 2012)|Chicago White Sox vs Cleveland Indians [5/26/2012] Tickets at StubHub!|Cleveland Indians at Chicago White Sox
+728727|Cleveland Indians at Chicago White Sox (Tuesday May 1, 2012)|Chicago White Sox vs Cleveland Indians [5/1/2012] Tickets at StubHub!|Cleveland Indians at Chicago White Sox
+728728|Boston Red Sox at Chicago White Sox (Saturday April 28, 2012)|Chicago White Sox vs Boston Red Sox [4/28/2012] Tickets at StubHub!|Boston Red Sox at Chicago White Sox
+728729|Seattle Mariners at Chicago White Sox (Sunday June 3, 2012)|Chicago White Sox vs Seattle Mariners [6/3/2012] Tickets at StubHub!|Seattle Mariners at Chicago White Sox
+728730|Cleveland Indians at Chicago White Sox (Tuesday September 25, 2012)|Chicago White Sox vs Cleveland Indians [9/25/2012] Tickets at StubHub!|Cleveland Indians at Chicago White Sox
+728731|Minnesota Twins at Chicago White Sox (Thursday May 24, 2012)|Chicago White Sox vs Minnesota Twins [5/24/2012] Tickets at StubHub!|Minnesota Twins at Chicago White Sox
+728732|Detroit Tigers at Chicago White Sox (Tuesday May 15, 2012)|Chicago White Sox vs Detroit Tigers [5/15/2012] Tickets at StubHub!|Detroit Tigers at Chicago White Sox
+728733|Chicago Cubs at Chicago White Sox (Wednesday June 20, 2012)|Chicago White Sox vs Chicago Cubs [6/20/2012] Tickets at StubHub!|Chicago Cubs at Chicago White Sox
+728734|Seattle Mariners at Chicago White Sox (Friday June 1, 2012)|Chicago White Sox vs Seattle Mariners [6/1/2012] Tickets at StubHub!|Seattle Mariners at Chicago White Sox
+728735|Toronto Blue Jays at Chicago White Sox (Thursday June 7, 2012)|Chicago White Sox vs Toronto Blue Jays [6/7/2012] Tickets at StubHub!|Toronto Blue Jays at Chicago White Sox
+728736|Kansas City Royals at Chicago White Sox (Sunday May 13, 2012)|Chicago White Sox vs Kansas City Royals [5/13/2012] Tickets at StubHub!|Kansas City Royals at Chicago White Sox
+728737|Los Angeles Angels at Chicago White Sox (Saturday August 4, 2012)|Chicago White Sox vs Los Angeles Angels [8/4/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Chicago White Sox
+728738|Detroit Tigers at Chicago White Sox (Friday April 13, 2012)|Chicago White Sox vs Detroit Tigers [4/13/2012] Tickets at StubHub!|Detroit Tigers at Chicago White Sox
+728869|Colorado Rockies at Los Angeles Dodgers (Saturday September 29, 2012)|Los Angeles Dodgers vs Colorado Rockies [9/29/2012] Tickets at StubHub!|Colorado Rockies at Los Angeles Dodgers
+728870|Colorado Rockies at Los Angeles Dodgers (Friday May 11, 2012)|Los Angeles Dodgers vs Colorado Rockies [5/11/2012] Tickets at StubHub!|Colorado Rockies at Los Angeles Dodgers
+728871|Colorado Rockies at Los Angeles Dodgers (Monday August 6, 2012)|Los Angeles Dodgers vs Colorado Rockies [8/6/2012] Tickets at StubHub!|Colorado Rockies at Los Angeles Dodgers
+728872|St Louis Cardinals at Los Angeles Dodgers (Friday September 14, 2012)|Los Angeles Dodgers vs St Louis Cardinals [9/14/2012] Tickets at StubHub!|St. Louis Cardinals at Los Angeles Dodgers
+728873|San Francisco Giants at Los Angeles Dodgers (Wednesday May 9, 2012)|Los Angeles Dodgers vs San Francisco Giants [5/9/2012] Tickets at StubHub!|San Francisco Giants at Los Angeles Dodgers
+728874|Chicago White Sox at Los Angeles Dodgers (Saturday June 16, 2012)|Los Angeles Dodgers vs Chicago White Sox [6/16/2012] Tickets at StubHub!|Chicago White Sox at Los Angeles Dodgers
+728875|Miami Marlins at Los Angeles Dodgers (Saturday August 25, 2012)|Los Angeles Dodgers vs Miami Marlins [8/25/2012] Tickets at StubHub!|Miami Marlins at Los Angeles Dodgers
+728876|Arizona Diamondbacks at Los Angeles Dodgers (Sunday September 2, 2012)|Los Angeles Dodgers vs Arizona Diamondbacks [9/2/2012] Tickets at StubHub!|Arizona Diamondbacks at Los Angeles Dodgers
+728877|St Louis Cardinals at Los Angeles Dodgers (Saturday May 19, 2012)|Los Angeles Dodgers vs St Louis Cardinals [5/19/2012] Tickets at StubHub!|St. Louis Cardinals at Los Angeles Dodgers
+728878|New York Mets at Los Angeles Dodgers (Friday June 29, 2012)|Los Angeles Dodgers vs New York Mets [6/29/2012] Tickets at StubHub!|New York Mets at Los Angeles Dodgers
+728879|Arizona Diamondbacks at Los Angeles Dodgers (Tuesday July 31, 2012)|Los Angeles Dodgers vs Arizona Diamondbacks [7/31/2012] Tickets at StubHub!|Arizona Diamondbacks at Los Angeles Dodgers
+728880|Cincinnati Reds at Los Angeles Dodgers (Tuesday July 3, 2012)|Los Angeles Dodgers vs Cincinnati Reds [7/3/2012] Tickets at StubHub!|Cincinnati Reds at Los Angeles Dodgers
+728881|San Francisco Giants at Los Angeles Dodgers (Tuesday October 2, 2012)|Los Angeles Dodgers vs San Francisco Giants [10/2/2012] Tickets at StubHub!|San Francisco Giants at Los Angeles Dodgers
+728882|Atlanta Braves at Los Angeles Dodgers (Wednesday April 25, 2012)|Los Angeles Dodgers vs Atlanta Braves [4/25/2012] Tickets at StubHub!|Atlanta Braves at Los Angeles Dodgers
+728883|San Diego Padres at Los Angeles Dodgers (Tuesday September 4, 2012)|Los Angeles Dodgers vs San Diego Padres [9/4/2012] Tickets at StubHub!|San Diego Padres at Los Angeles Dodgers
+728884|Philadelphia Phillies at Los Angeles Dodgers (Tuesday July 17, 2012)|Los Angeles Dodgers vs Philadelphia Phillies [7/17/2012] Tickets at StubHub!|Philadelphia Phillies at Los Angeles Dodgers
+728885|Washington Nationals at Los Angeles Dodgers (Firday April 27, 2012)|Los Angeles Dodgers vs Washington Nationals [4/27/2012] Tickets at StubHub!|Washington Nationals at Los Angeles Dodgers
+728886|Milwaukee Brewers at Los Angeles Dodgers (Tuesday May 29, 2012)|Los Angeles Dodgers vs Milwaukee Brewers [5/29/2012] Tickets at StubHub!|Milwaukee Brewers at Los Angeles Dodgers
+728887|San Diego Padres at Los Angeles Dodgers (Saturday July 14, 2012)|Los Angeles Dodgers vs San Diego Padres [7/14/2012] Tickets at StubHub!|San Diego Padres at Los Angeles Dodgers
+728888|San Francisco Giants at Los Angeles Dodgers (Monday August 20, 2012)|Los Angeles Dodgers vs San Francisco Giants [8/20/2012] Tickets at StubHub!|San Francisco Giants at Los Angeles Dodgers
+728889|Washington Nationals at Los Angeles Dodgers (Sunday April 29, 2012)|Los Angeles Dodgers vs Washington Nationals [4/29/2012] Tickets at StubHub!|Washington Nationals at Los Angeles Dodgers
+728890|Los Angeles Angels at Los Angeles Dodgers (Tuesday June 12, 2012)|Los Angeles Dodgers vs Los Angeles Angels [6/12/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Los Angeles Dodgers
+728891|Arizona Diamondbacks at Los Angeles Dodgers (Tuesday May 15, 2012)|Los Angeles Dodgers vs Arizona Diamondbacks [5/15/2012] Tickets at StubHub!|Arizona Diamondbacks at Los Angeles Dodgers
+728892|Houston Astros at Los Angeles Dodgers (Sunday May 27, 2012)|Los Angeles Dodgers vs Houston Astros [5/27/2012] Tickets at StubHub!|Houston Astros at Los Angeles Dodgers
+728893|Arizona Diamondbacks at Los Angeles Dodgers (Monday May 14, 2012)|Los Angeles Dodgers vs Arizona Diamondbacks [5/14/2012] Tickets at StubHub!|Arizona Diamondbacks at Los Angeles Dodgers
+728894|San Francisco Giants at Los Angeles Dodgers (Wednesday August 22, 2012)|Los Angeles Dodgers vs San Francisco Giants [8/22/2012] Tickets at StubHub!|San Francisco Giants at Los Angeles Dodgers
+728895|Colorado Rockies at Los Angeles Dodgers (Sunday September 30, 2012)|Los Angeles Dodgers vs Colorado Rockies [9/30/2012] Tickets at StubHub!|Colorado Rockies at Los Angeles Dodgers
+728896|Houston Astros at Los Angeles Dodgers (Friday May 25, 2012)|Los Angeles Dodgers vs Houston Astros [5/25/2012] Tickets at StubHub!|Houston Astros at Los Angeles Dodgers
+728897|Colorado Rockies at Los Angeles Dodgers (Saturday May 12, 2012)|Los Angeles Dodgers vs Colorado Rockies [5/12/2012] Tickets at StubHub!|Colorado Rockies at Los Angeles Dodgers
+728898|Arizona Diamondbacks at Los Angeles Dodgers (Friday August 31, 2012)|Los Angeles Dodgers vs Arizona Diamondbacks [8/31/2012] Tickets at StubHub!|Arizona Diamondbacks at Los Angeles Dodgers
+728899|Chicago Cubs at Los Angeles Dodgers (Sunday August 5, 2012)|Los Angeles Dodgers vs Chicago Cubs [8/5/2012] Tickets at StubHub!|Chicago Cubs at Los Angeles Dodgers
+728900|Colorado Rockies at Los Angeles Dodgers (Friday September 28, 2012)|Los Angeles Dodgers vs Colorado Rockies [9/28/2012] Tickets at StubHub!|Colorado Rockies at Los Angeles Dodgers
+728901|Milwaukee Brewers at Los Angeles Dodgers (Thursday May 31, 2012)|Los Angeles Dodgers vs Milwaukee Brewers [5/31/2012] Tickets at StubHub!|Milwaukee Brewers at Los Angeles Dodgers
+728902|Colorado Rockies at Los Angeles Dodgers (Tuesday August 7, 2012)|Los Angeles Dodgers vs Colorado Rockies [8/7/2012] Tickets at StubHub!|Colorado Rockies at Los Angeles Dodgers
+728903|San Francisco Giants at Los Angeles Dodgers (Tuesday May 8, 2012)|Los Angeles Dodgers vs San Francisco Giants [5/8/2012] Tickets at StubHub!|San Francisco Giants at Los Angeles Dodgers
+728904|Arizona Diamondbacks at Los Angeles Dodgers (Wednesday August 1, 2012)|Los Angeles Dodgers vs Arizona Diamondbacks [8/1/2012] Tickets at StubHub!|Arizona Diamondbacks at Los Angeles Dodgers
+728905|St Louis Cardinals at Los Angeles Dodgers (Sunday September 16, 2012)|Los Angeles Dodgers vs St Louis Cardinals [9/16/2012] Tickets at StubHub!|St. Louis Cardinals at Los Angeles Dodgers
+728906|St Louis Cardinals at Los Angeles Dodgers (Saturday September 15, 2012)|Los Angeles Dodgers vs St Louis Cardinals [9/15/2012] Tickets at StubHub!|St. Louis Cardinals at Los Angeles Dodgers
+728907|Arizona Diamondbacks at Los Angeles Dodgers (Thursday August 30, 2012)|Los Angeles Dodgers vs Arizona Diamondbacks [8/30/2012] Tickets at StubHub!|Arizona Diamondbacks at Los Angeles Dodgers
+728908|Colorado Rockies at Los Angeles Dodgers (Wednesday August 8, 2012)|Los Angeles Dodgers vs Colorado Rockies [8/8/2012] Tickets at StubHub!|Colorado Rockies at Los Angeles Dodgers
+728909|Atlanta Braves at Los Angeles Dodgers (Tuesday April 24, 2012)|Los Angeles Dodgers vs Atlanta Braves [4/24/2012] Tickets at StubHub!|Atlanta Braves at Los Angeles Dodgers
+728910|Chicago Cubs at Los Angeles Dodgers (Friday August 3, 2012)|Los Angeles Dodgers vs Chicago Cubs [8/3/2012] Tickets at StubHub!|Chicago Cubs at Los Angeles Dodgers
+728911|St Louis Cardinals at Los Angeles Dodgers (Thursday September 13, 2012)|Los Angeles Dodgers vs St Louis Cardinals [9/13/2012] Tickets at StubHub!|St. Louis Cardinals at Los Angeles Dodgers
+728912|St Louis Cardinals at Los Angeles Dodgers (Sunday May 20, 2012)|Los Angeles Dodgers vs St Louis Cardinals [5/20/2012] Tickets at StubHub!|St. Louis Cardinals at Los Angeles Dodgers
+728913|Miami Marlins at Los Angeles Dodgers (Friday August 24, 2012)|Los Angeles Dodgers vs Miami Marlins [8/24/2012] Tickets at StubHub!|Miami Marlins at Los Angeles Dodgers
+728914|Milwaukee Brewers at Los Angeles Dodgers (Wednesday May 30, 2012)|Los Angeles Dodgers vs Milwaukee Brewers [5/30/2012] Tickets at StubHub!|Milwaukee Brewers at Los Angeles Dodgers
+728915|San Diego Padres at Los Angeles Dodgers (Monday September 3, 2012)|Los Angeles Dodgers vs San Diego Padres [9/3/2012] Tickets at StubHub!|San Diego Padres at Los Angeles Dodgers
+728916|St Louis Cardinals at Los Angeles Dodgers (Friday May 18, 2012)|Los Angeles Dodgers vs St Louis Cardinals [5/18/2012] Tickets at StubHub!|St. Louis Cardinals at Los Angeles Dodgers
+728917|Miami Marlins at Los Angeles Dodgers (Sunday August 26, 2012)|Los Angeles Dodgers vs Miami Marlins [8/26/2012] Tickets at StubHub!|Miami Marlins at Los Angeles Dodgers
+728918|New York Mets at Los Angeles Dodgers (Saturday June 30, 2012)|Los Angeles Dodgers vs New York Mets [6/30/2012] Tickets at StubHub!|New York Mets at Los Angeles Dodgers
+728919|Los Angeles Angels at Los Angeles Dodgers (Monday June 11, 2012)|Los Angeles Dodgers vs Los Angeles Angels [6/11/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Los Angeles Dodgers
+728920|Arizona Diamondbacks at Los Angeles Dodgers (Saturday September 1, 2012)|Los Angeles Dodgers vs Arizona Diamondbacks [9/1/2012] Tickets at StubHub!|Arizona Diamondbacks at Los Angeles Dodgers
+728921|Arizona Diamondbacks at Los Angeles Dodgers (Monday July 30, 2012)|Los Angeles Dodgers vs Arizona Diamondbacks [7/30/2012] Tickets at StubHub!|Arizona Diamondbacks at Los Angeles Dodgers
+728922|San Francisco Giants at Los Angeles Dodgers (Monday May 7, 2012)|Los Angeles Dodgers vs San Francisco Giants [5/7/2012] Tickets at StubHub!|San Francisco Giants at Los Angeles Dodgers
+728923|San Francisco Giants at Los Angeles Dodgers (Wednesday October 3, 2012)|Los Angeles Dodgers vs San Francisco Giants [10/3/2012] Tickets at StubHub!|San Francisco Giants at Los Angeles Dodgers
+728924|New York Mets at Los Angeles Dodgers (Thursday June 28, 2012)|Los Angeles Dodgers vs New York Mets [6/28/2012] Tickets at StubHub!|New York Mets at Los Angeles Dodgers
+728925|Philadelphia Phillies at Los Angeles Dodgers (Monday July 16, 2012)|Los Angeles Dodgers vs Philadelphia Phillies [7/16/2012] Tickets at StubHub!|Philadelphia Phillies at Los Angeles Dodgers
+728926|Atlanta Braves at Los Angeles Dodgers (Monday April 23, 2012)|Los Angeles Dodgers vs Atlanta Braves [4/23/2012] Tickets at StubHub!|Atlanta Braves at Los Angeles Dodgers
+728927|San Francisco Giants at Los Angeles Dodgers (Monday October 1, 2012)|Los Angeles Dodgers vs San Francisco Giants [10/1/2012] Tickets at StubHub!|San Francisco Giants at Los Angeles Dodgers
+728928|Cincinnati Reds at Los Angeles Dodgers (Monday July 2, 2012)|Los Angeles Dodgers vs Cincinnati Reds [7/2/2012] Tickets at StubHub!|Cincinnati Reds at Los Angeles Dodgers
+728929|Chicago White Sox at Los Angeles Dodgers (Friday June 15, 2012)|Los Angeles Dodgers vs Chicago White Sox [6/15/2012] Tickets at StubHub!|Chicago White Sox at Los Angeles Dodgers
+728930|San Diego Padres at Los Angeles Dodgers (Wednesday September 5, 2012)|Los Angeles Dodgers vs San Diego Padres [9/5/2012] Tickets at StubHub!|San Diego Padres at Los Angeles Dodgers
+728931|Philadelphia Phillies at Los Angeles Dodgers (Wednesday July 18, 2012)|Los Angeles Dodgers vs Philadelphia Phillies [7/18/2012] Tickets at StubHub!|Philadelphia Phillies at Los Angeles Dodgers
+728932|San Diego Padres at Los Angeles Dodgers (Friday July 13, 2012)|Los Angeles Dodgers vs San Diego Padres [7/13/2012] Tickets at StubHub!|San Diego Padres at Los Angeles Dodgers
+728933|San Francisco Giants at Los Angeles Dodgers (Tuesday August 21, 2012)|Los Angeles Dodgers vs San Francisco Giants [8/21/2012] Tickets at StubHub!|San Francisco Giants at Los Angeles Dodgers
+728934|Chicago White Sox at Los Angeles Dodgers (Sunday June 17, 2012)|Los Angeles Dodgers vs Chicago White Sox [6/17/2012] Tickets at StubHub!|Chicago White Sox at Los Angeles Dodgers
+728935|Los Angeles Angels at Los Angeles Dodgers (Wednesday June 13, 2012)|Los Angeles Dodgers vs Los Angeles Angels [6/13/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Los Angeles Dodgers
+728936|Houston Astros at Los Angeles Dodgers (Saturday May 26, 2012)|Los Angeles Dodgers vs Houston Astros [5/26/2012] Tickets at StubHub!|Houston Astros at Los Angeles Dodgers
+728937|San Diego Padres at Los Angeles Dodgers (Sunday July 15, 2012)|Los Angeles Dodgers vs San Diego Padres [7/15/2012] Tickets at StubHub!|San Diego Padres at Los Angeles Dodgers
+728938|Washington Nationals at Los Angeles Dodgers (Saturday April 28, 2012)|Los Angeles Dodgers vs Washington Nationals [4/28/2012] Tickets at StubHub!|Washington Nationals at Los Angeles Dodgers
+728939|New York Mets at Los Angeles Dodgers (Sunday July 1, 2012)|Los Angeles Dodgers vs New York Mets [7/1/2012] Tickets at StubHub!|New York Mets at Los Angeles Dodgers
+728940|Milwaukee Brewers at Los Angeles Dodgers (Monday May 28, 2012)|Los Angeles Dodgers vs Milwaukee Brewers [5/28/2012] Tickets at StubHub!|Milwaukee Brewers at Los Angeles Dodgers
+728941|Cincinnati Reds at Los Angeles Dodgers (Wednesday July 4, 2012)|Los Angeles Dodgers vs Cincinnati Reds [7/4/2012] Tickets at StubHub!|Cincinnati Reds at Los Angeles Dodgers
+728942|Colorado Rockies at Los Angeles Dodgers (Sunday May 13, 2012)|Los Angeles Dodgers vs Colorado Rockies [5/13/2012] Tickets at StubHub!|Colorado Rockies at Los Angeles Dodgers
+728943|Chicago Cubs at Los Angeles Dodgers (Saturday August 4, 2012)|Los Angeles Dodgers vs Chicago Cubs [8/4/2012] Tickets at StubHub!|Chicago Cubs at Los Angeles Dodgers
+728966|Los Angeles Dodgers at Colorado Rockies (Wednesday August 29, 2012)|Colorado Rockies vs Los Angeles Dodgers [8/29/2012] Tickets at StubHub!|Los Angeles Dodgers at Colorado Rockies
+728967|Arizona Diamondbacks at Colorado Rockies (Sunday April 15, 2012)|Colorado Rockies vs Arizona Diamondbacks [4/15/2012] Tickets at StubHub!|Arizona Diamondbacks at Colorado Rockies
+728968|San Diego Padres at Colorado Rockies (Friday August 31, 2012)|Colorado Rockies vs San Diego Padres [8/31/2012] Tickets at StubHub!|San Diego Padres at Colorado Rockies
+728969|Washington Nationals at Colorado Rockies (Wednesday June 27, 2012)|Colorado Rockies vs Washington Nationals [6/27/2012] Tickets at StubHub!|Washington Nationals at Colorado Rockies
+728970|San Francisco Giants at Colorado Rockies (Wednesday September 12, 2012)|Colorado Rockies vs San Francisco Giants [9/12/2012] Tickets at StubHub!|San Francisco Giants at Colorado Rockies
+728971|St. Louis Cardinals at Colorado Rockies (Thursday August 2, 2012)|Colorado Rockies vs St. Louis Cardinals [8/2/2012] Tickets at StubHub!|St. Louis Cardinals at Colorado Rockies
+728972|Washington Nationals at Colorado Rockies (Monday June 25, 2012)|Colorado Rockies vs Washington Nationals [6/25/2012] Tickets at StubHub!|Washington Nationals at Colorado Rockies
+728973|San Diego Padres at Colorado Rockies (Sunday September 2, 2012)|Colorado Rockies vs San Diego Padres [9/2/2012] Tickets at StubHub!|San Diego Padres at Colorado Rockies
+728974|Cincinnati Reds at Colorado Rockies (Friday July 27, 2012)|Colorado Rockies vs Cincinnati Reds [7/27/2012] Tickets at StubHub!|Cincinnati Reds at Colorado Rockies
+728975|Los Angeles Dodgers at Colorado Rockies (Monday August 27, 2012)|Colorado Rockies vs Los Angeles Dodgers [8/27/2012] Tickets at StubHub!|Los Angeles Dodgers at Colorado Rockies
+728976|Arizona Diamondbacks at Colorado Rockies (Friday September 21, 2012)|Colorado Rockies vs Arizona Diamondbacks [9/21/2012] Tickets at StubHub!|Arizona Diamondbacks at Colorado Rockies
+728977|Seattle Mariners at Colorado Rockies (Saturday May 19, 2012)|Colorado Rockies vs Seattle Mariners [5/19/2012] Tickets at StubHub!|Seattle Mariners at Colorado Rockies
+728978|Atlanta Braves at Colorado Rockies (Sunday May 6, 2012)|Colorado Rockies vs Atlanta Braves [5/6/2012] Tickets at StubHub!|Atlanta Braves at Colorado Rockies
+728979|Milwaukee Brewers at Colorado Rockies (Tuesday August 14, 2012)|Colorado Rockies vs Milwaukee Brewers [8/14/2012] Tickets at StubHub!|Milwaukee Brewers at Colorado Rockies
+728980|San Diego Padres at Colorado Rockies (Friday June 29, 2012)|Colorado Rockies vs San Diego Padres [6/29/2012] Tickets at StubHub!|San Diego Padres at Colorado Rockies
+728981|Los Angeles Angels at Colorado Rockies (Sunday June 10, 2012)|Colorado Rockies vs Los Angeles Angels [6/10/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Colorado Rockies
+728982|St. Louis Cardinals at Colorado Rockies (Tuesday July 31, 2012)|Colorado Rockies vs St. Louis Cardinals [7/31/2012] Tickets at StubHub!|St. Louis Cardinals at Colorado Rockies
+728983|Los Angeles Dodgers at Colorado Rockies (Tuesday May 1, 2012)|Colorado Rockies vs Los Angeles Dodgers [5/1/2012] Tickets at StubHub!|Los Angeles Dodgers at Colorado Rockies
+728984|Los Angeles Angels at Colorado Rockies (Friday June 8, 2012)|Colorado Rockies vs Los Angeles Angels [6/8/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Colorado Rockies
+728985|Pittsburgh Pirates at Colorado Rockies (Tuesday July 17, 2012)|Colorado Rockies vs Pittsburgh Pirates [7/17/2012] Tickets at StubHub!|Pittsburgh Pirates at Colorado Rockies
+728986|Los Angeles Dodgers at Colorado Rockies (Wednesday May 2, 2012)|Colorado Rockies vs Los Angeles Dodgers [5/2/2012] Tickets at StubHub!|Los Angeles Dodgers at Colorado Rockies
+728987|New York Mets at Colorado Rockies (Friday April 27, 2012)|Colorado Rockies vs New York Mets [4/27/2012] Tickets at StubHub!|New York Mets at Colorado Rockies
+728988|Oakland Athletics at Colorado Rockies (Thursday June 14, 2012)|Colorado Rockies vs Oakland Athletics [6/14/2012] Tickets at StubHub!|Oakland Athletics at Colorado Rockies
+728989|Chicago Cubs at Colorado Rockies (Wednesday September 26, 2012)|Colorado Rockies vs Chicago Cubs [9/26/2012] Tickets at StubHub!|Chicago Cubs at Colorado Rockies
+728990|Houston Astros at Colorado Rockies (Tuesday May 29, 2012)|Colorado Rockies vs Houston Astros [5/29/2012] Tickets at StubHub!|Houston Astros at Colorado Rockies
+728991|Philadelphia Phillies at Colorado Rockies (Saturday July 14, 2012)|Colorado Rockies vs Philadelphia Phillies [7/14/2012] Tickets at StubHub!|Philadelphia Phillies at Colorado Rockies
+728992|Atlanta Braves at Colorado Rockies (Friday May 4, 2012)|Colorado Rockies vs Atlanta Braves [5/4/2012] Tickets at StubHub!|Atlanta Braves at Colorado Rockies
+728993|New York Mets at Colorado Rockies (Sunday April 29, 2012)|Colorado Rockies vs New York Mets [4/29/2012] Tickets at StubHub!|New York Mets at Colorado Rockies
+728994|Oakland Athletics at Colorado Rockies (Tuesday June 12, 2012)|Colorado Rockies vs Oakland Athletics [6/12/2012] Tickets at StubHub!|Oakland Athletics at Colorado Rockies
+728995|Arizona Diamondbacks at Colorado Rockies (Monday September 24, 2012)|Colorado Rockies vs Arizona Diamondbacks [9/24/2012] Tickets at StubHub!|Arizona Diamondbacks at Colorado Rockies
+728996|Los Angeles Dodgers at Colorado Rockies (Saturday June 2, 2012)|Colorado Rockies vs Los Angeles Dodgers [6/2/2012] Tickets at StubHub!|Los Angeles Dodgers at Colorado Rockies
+728997|Miami Marlins at Colorado Rockies (Thursday August 16, 2012)|Colorado Rockies vs Miami Marlins [8/16/2012] Tickets at StubHub!|Miami Marlins at Colorado Rockies
+728998|San Francisco Giants at Colorado Rockies (Sunday August 5, 2012)|Colorado Rockies vs San Francisco Giants [8/5/2012] Tickets at StubHub!|San Francisco Giants at Colorado Rockies
+728999|San Francisco Giants at Colorado Rockies (Tuesday September 11, 2012)|Colorado Rockies vs San Francisco Giants [9/11/2012] Tickets at StubHub!|San Francisco Giants at Colorado Rockies
+729000|Miami Marlins at Colorado Rockies (Saturday August 18, 2012)|Colorado Rockies vs Miami Marlins [8/18/2012] Tickets at StubHub!|Miami Marlins at Colorado Rockies
+729001|Arizona Diamondbacks at Colorado Rockies (Thursday May 17, 2012)|Colorado Rockies vs Arizona Diamondbacks [5/17/2012] Tickets at StubHub!|Arizona Diamondbacks at Colorado Rockies
+729002|San Diego Padres at Colorado Rockies (Tuesday April 17, 2012)|Colorado Rockies vs San Diego Padres [4/17/2012] Tickets at StubHub!|San Diego Padres at Colorado Rockies
+729003|Los Angeles Dodgers at Colorado Rockies (Tuesday August 28, 2012)|Colorado Rockies vs Los Angeles Dodgers [8/28/2012] Tickets at StubHub!|Los Angeles Dodgers at Colorado Rockies
+729004|St. Louis Cardinals at Colorado Rockies (Wednesday August 1, 2012)|Colorado Rockies vs St. Louis Cardinals [8/1/2012] Tickets at StubHub!|St. Louis Cardinals at Colorado Rockies
+729005|Arizona Diamondbacks at Colorado Rockies (Saturday April 14, 2012)|Colorado Rockies vs Arizona Diamondbacks [4/14/2012] Tickets at StubHub!|Arizona Diamondbacks at Colorado Rockies
+729006|Miami Marlins at Colorado Rockies (Friday August 17, 2012)|Colorado Rockies vs Miami Marlins [8/17/2012] Tickets at StubHub!|Miami Marlins at Colorado Rockies
+729007|San Francisco Giants at Colorado Rockies (Friday August 3, 2012)|Colorado Rockies vs San Francisco Giants [8/3/2012] Tickets at StubHub!|San Francisco Giants at Colorado Rockies
+729008|Washington Nationals at Colorado Rockies (Tuesday June 26, 2012)|Colorado Rockies vs Washington Nationals [6/26/2012] Tickets at StubHub!|Washington Nationals at Colorado Rockies
+729009|Arizona Diamondbacks at Colorado Rockies (Saturday September 22, 2012)|Colorado Rockies vs Arizona Diamondbacks [9/22/2012] Tickets at StubHub!|Arizona Diamondbacks at Colorado Rockies
+729010|Seattle Mariners at Colorado Rockies (Sunday May 20, 2012)|Colorado Rockies vs Seattle Mariners [5/20/2012] Tickets at StubHub!|Seattle Mariners at Colorado Rockies
+729011|Houston Astros at Colorado Rockies (Wednesday May 30, 2012)|Colorado Rockies vs Houston Astros [5/30/2012] Tickets at StubHub!|Houston Astros at Colorado Rockies
+729012|Milwaukee Brewers at Colorado Rockies (Monday August 13, 2012)|Colorado Rockies vs Milwaukee Brewers [8/13/2012] Tickets at StubHub!|Milwaukee Brewers at Colorado Rockies
+729013|San Diego Padres at Colorado Rockies (Wednesday April 18, 2012)|Colorado Rockies vs San Diego Padres [4/18/2012] Tickets at StubHub!|San Diego Padres at Colorado Rockies
+729014|San Diego Padres at Colorado Rockies (Monday April 16, 2012)|Colorado Rockies vs San Diego Padres [4/16/2012] Tickets at StubHub!|San Diego Padres at Colorado Rockies
+729015|Seattle Mariners at Colorado Rockies (Friday May 18, 2012)|Colorado Rockies vs Seattle Mariners [5/18/2012] Tickets at StubHub!|Seattle Mariners at Colorado Rockies
+729016|Milwaukee Brewers at Colorado Rockies (Wednesday August 15, 2012)|Colorado Rockies vs Milwaukee Brewers [8/15/2012] Tickets at StubHub!|Milwaukee Brewers at Colorado Rockies
+729017|San Diego Padres at Colorado Rockies (Saturday June 30, 2012)|Colorado Rockies vs San Diego Padres [6/30/2012] Tickets at StubHub!|San Diego Padres at Colorado Rockies
+729018|San Diego Padres at Colorado Rockies (Saturday September 1, 2012)|Colorado Rockies vs San Diego Padres [9/1/2012] Tickets at StubHub!|San Diego Padres at Colorado Rockies
+729019|Arizona Diamondbacks at Colorado Rockies (Wednesday May 16, 2012)|Colorado Rockies vs Arizona Diamondbacks [5/16/2012] Tickets at StubHub!|Arizona Diamondbacks at Colorado Rockies
+729020|Washington Nationals at Colorado Rockies (Thursday June 28, 2012)|Colorado Rockies vs Washington Nationals [6/28/2012] Tickets at StubHub!|Washington Nationals at Colorado Rockies
+729021|Los Angeles Angels at Colorado Rockies (Saturday June 9, 2012)|Colorado Rockies vs Los Angeles Angels [6/9/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Colorado Rockies
+729022|Cincinnati Reds at Colorado Rockies (Sunday July 29, 2012)|Colorado Rockies vs Cincinnati Reds [7/29/2012] Tickets at StubHub!|Cincinnati Reds at Colorado Rockies
+729023|Pittsburgh Pirates at Colorado Rockies (Monday July 16, 2012)|Colorado Rockies vs Pittsburgh Pirates [7/16/2012] Tickets at StubHub!|Pittsburgh Pirates at Colorado Rockies
+729024|Atlanta Braves at Colorado Rockies (Saturday May 5, 2012)|Colorado Rockies vs Atlanta Braves [5/5/2012] Tickets at StubHub!|Atlanta Braves at Colorado Rockies
+729025|Houston Astros at Colorado Rockies (Thursday May 31, 2012)|Colorado Rockies vs Houston Astros [5/31/2012] Tickets at StubHub!|Houston Astros at Colorado Rockies
+729026|Cincinnati Reds at Colorado Rockies (Saturday July 28, 2012)|Colorado Rockies vs Cincinnati Reds [7/28/2012] Tickets at StubHub!|Cincinnati Reds at Colorado Rockies
+729027|Pittsburgh Pirates at Colorado Rockies (Wednesday July 18, 2012)|Colorado Rockies vs Pittsburgh Pirates [7/18/2012] Tickets at StubHub!|Pittsburgh Pirates at Colorado Rockies
+729028|Philadelphia Phillies at Colorado Rockies (Friday July 13, 2012)|Colorado Rockies vs Philadelphia Phillies [7/13/2012] Tickets at StubHub!|Philadelphia Phillies at Colorado Rockies
+729029|Oakland Athletics at Colorado Rockies (Wednesday June 13, 2012)|Colorado Rockies vs Oakland Athletics [6/13/2012] Tickets at StubHub!|Oakland Athletics at Colorado Rockies
+729030|Chicago Cubs at Colorado Rockies (Thursday September 27, 2012)|Colorado Rockies vs Chicago Cubs [9/27/2012] Tickets at StubHub!|Chicago Cubs at Colorado Rockies
+729031|Philadelphia Phillies at Colorado Rockies (Sunday July 15, 2012)|Colorado Rockies vs Philadelphia Phillies [7/15/2012] Tickets at StubHub!|Philadelphia Phillies at Colorado Rockies
+729032|New York Mets at Colorado Rockies (Saturday April 28, 2012)|Colorado Rockies vs New York Mets [4/28/2012] Tickets at StubHub!|New York Mets at Colorado Rockies
+729033|Los Angeles Dodgers at Colorado Rockies (Sunday June 3, 2012)|Colorado Rockies vs Los Angeles Dodgers [6/3/2012] Tickets at StubHub!|Los Angeles Dodgers at Colorado Rockies
+729034|Chicago Cubs at Colorado Rockies (Tuesday September 25, 2012)|Colorado Rockies vs Chicago Cubs [9/25/2012] Tickets at StubHub!|Chicago Cubs at Colorado Rockies
+729035|San Diego Padres at Colorado Rockies (Sunday July 1, 2012)|Colorado Rockies vs San Diego Padres [7/1/2012] Tickets at StubHub!|San Diego Padres at Colorado Rockies
+729036|Houston Astros at Colorado Rockies (Monday May 28, 2012)|Colorado Rockies vs Houston Astros [5/28/2012] Tickets at StubHub!|Houston Astros at Colorado Rockies
+729038|Los Angeles Dodgers at Colorado Rockies (Friday June 1, 2012)|Colorado Rockies vs Los Angeles Dodgers [6/1/2012] Tickets at StubHub!|Los Angeles Dodgers at Colorado Rockies
+729039|San Francisco Giants at Colorado Rockies (Monday September 10, 2012)|Colorado Rockies vs San Francisco Giants [9/10/2012] Tickets at StubHub!|San Francisco Giants at Colorado Rockies
+729040|Miami Marlins at Colorado Rockies (Sunday August 19, 2012)|Colorado Rockies vs Miami Marlins [8/19/2012] Tickets at StubHub!|Miami Marlins at Colorado Rockies
+729041|San Francisco Giants at Colorado Rockies (Saturday August 4, 2012)|Colorado Rockies vs San Francisco Giants [8/4/2012] Tickets at StubHub!|San Francisco Giants at Colorado Rockies
+729042|Arizona Diamondbacks at Colorado Rockies (Friday April 13, 2012)|Colorado Rockies vs Arizona Diamondbacks [4/13/2012] Tickets at StubHub!|Arizona Diamondbacks at Colorado Rockies
+729046|San Francisco Giants at Houston Astros (Wednesday August 29, 2012)|Houston Astros vs San Francisco Giants [8/29/2012] Tickets at StubHub!|San Francisco Giants at Houston Astros
+729047|Washington Nationals at Houston Astros (Monday August 6, 2012)|Houston Astros vs Washington Nationals [8/6/2012] Tickets at StubHub!|Washington Nationals at Houston Astros
+729048|St. Louis Cardinals at Houston Astros (Tuesday June 5. 2012)|Houston Astros vs St. Louis Cardinals [6/5/2012] Tickets at StubHub!|St. Louis Cardinals at Houston Astros
+729049|Philadelphia Phillies at Houston Astros (Friday September 14, 2012)|Houston Astros vs Philadelphia Phillies [9/14/2012] Tickets at StubHub!|Philadelphia Phillies at Houston Astros
+729050|Milwaukee Brewers at Houston Astros (Saturday July 7, 2012)|Houston Astros vs Milwaukee Brewers [7/7/2012] Tickets at StubHub!|Milwaukee Brewers at Houston Astros
+729052|San Diego Padres at Houston Astros (Wednesday June 27, 2012)|Houston Astros vs San Diego Padres [6/27/2012] Tickets at StubHub!|San Diego Padres at Houston Astros
+729053|Chicago Cubs at Houston Astros (Wednesday September 12, 2012)|Houston Astros vs Chicago Cubs [9/12/2012] Tickets at StubHub!|Chicago Cubs at Houston Astros
+729054|Cincinnati Reds at Houston Astros (Wednesday July 25, 2012)|Houston Astros vs Cincinnati Reds [7/25/2012] Tickets at StubHub!|Cincinnati Reds at Houston Astros
+729055|San Diego Padres at Houston Astros (Monday June 25, 2012)|Houston Astros vs San Diego Padres [6/25/2012] Tickets at StubHub!|San Diego Padres at Houston Astros
+729056|Pittsburgh Pirates at Houston Astros (Sunday September 23, 2012)|Houston Astros vs Pittsburgh Pirates [9/23/2012] Tickets at StubHub!|Pittsburgh Pirates at Houston Astros
+729057|Cincinnati Reds at Houston Astros (Sunday September 2, 2012)|Houston Astros vs Cincinnati Reds [9/2/2012] Tickets at StubHub!|Cincinnati Reds at Houston Astros
+729058|Pittsburgh Pirates at Houston Astros (Friday July 27, 2012)|Houston Astros vs Pittsburgh Pirates [7/27/2012] Tickets at StubHub!|Pittsburgh Pirates at Houston Astros
+729059|Milwaukee Brewers at Houston Astros (Sunday August 12, 2012)|Houston Astros vs Milwaukee Brewers [8/12/2012] Tickets at StubHub!|Milwaukee Brewers at Houston Astros
+729060|Los Angeles Dodgers at Houston Astros (Saturday April 21, 2012)|Houston Astros vs Los Angeles Dodgers [4/21/2012] Tickets at StubHub!|Los Angeles Dodgers at Houston Astros
+729061|Pittsburgh Pirates at Houston Astros (Friday September 21, 2012)|Houston Astros vs Pittsburgh Pirates [9/21/2012] Tickets at StubHub!|Pittsburgh Pirates at Houston Astros
+729062|Texas Rangers at Houston Astros (Saturday May 19, 2012)|Houston Astros vs Texas Rangers [5/19/2012] Tickets at StubHub!|Texas Rangers at Houston Astros
+729063|St. Louis Cardinals at Houston Astros (Sunday May 6, 2012)|Houston Astros vs St. Louis Cardinals [5/6/2012] Tickets at StubHub!|St. Louis Cardinals at Houston Astros
+729064|Pittsburgh Pirates at Houston Astros (Sunday July 29, 2012)|Houston Astros vs Pittsburgh Pirates [7/29/2012] Tickets at StubHub!|Pittsburgh Pirates at Houston Astros
+729065|Miami Marlins at Houston Astros (Tuesday May 8, 2012)|Houston Astros vs Miami Marlins [5/8/2012] Tickets at StubHub!|Miami Marlins at Houston Astros
+729066|Milwaukee Brewers at Houston Astros (Thursday May 17, 2012)|Houston Astros vs Milwaukee Brewers [5/17/2012] Tickets at StubHub!|Milwaukee Brewers at Houston Astros
+729067|St. Louis Cardinals at Houston Astros (Friday May 4, 2012)|Houston Astros vs St. Louis Cardinals [5/4/2012] Tickets at StubHub!|St. Louis Cardinals at Houston Astros
+729068|Washington Nationals at Houston Astros (Wednesday August 8, 2012)|Houston Astros vs Washington Nationals [8/8/2012] Tickets at StubHub!|Washington Nationals at Houston Astros
+729069|Milwaukee Brewers at Houston Astros (Sunday July 8, 2012)|Houston Astros vs Milwaukee Brewers [7/8/2012] Tickets at StubHub!|Milwaukee Brewers at Houston Astros
+729070|Miami Marlins at Houston Astros (Wednesday May 9, 2012)|Houston Astros vs Miami Marlins [5/9/2012] Tickets at StubHub!|Miami Marlins at Houston Astros
+729071|New York Mets at Houston Astros (Wednesday May 2, 2012)|Houston Astros vs New York Mets [5/2/2012] Tickets at StubHub!|New York Mets at Houston Astros
+729072|Milwaukee Brewers at Houston Astros (Friday August 10, 2012)|Houston Astros vs Milwaukee Brewers [8/10/2012] Tickets at StubHub!|Milwaukee Brewers at Houston Astros
+729073|St. Louis Cardinals at Houston Astros (Wednesday September 26, 2012)|Houston Astros vs St. Louis Cardinals [9/26/2012] Tickets at StubHub!|St. Louis Cardinals at Houston Astros
+729074|Cleveland Indians at Houston Astros (Saturday June 23, 2012)|Houston Astros vs Cleveland Indians [6/23/2012] Tickets at StubHub!|Cleveland Indians at Houston Astros
+729075|St. Louis Cardinals at Houston Astros (Monday September 24, 2012)|Houston Astros vs St. Louis Cardinals [9/24/2012] Tickets at StubHub!|St. Louis Cardinals at Houston Astros
+729076|Cincinnati Reds at Houston Astros (Sunday June 3, 2012)|Houston Astros vs Cincinnati Reds [6/3/2012] Tickets at StubHub!|Cincinnati Reds at Houston Astros
+729077|Cincinnati Reds at Houston Astros (Saturday June 2, 2012)|Houston Astros vs Cincinnati Reds [6/2/2012] Tickets at StubHub!|Cincinnati Reds at Houston Astros
+729078|Cincinnati Reds at Houston Astros (Monday July 23, 2012)|Houston Astros vs Cincinnati Reds [7/23/2012] Tickets at StubHub!|Cincinnati Reds at Houston Astros
+729079|Chicago Cubs at Houston Astros (Tuesday September 11, 2012)|Houston Astros vs Chicago Cubs [9/11/2012] Tickets at StubHub!|Chicago Cubs at Houston Astros
+729080|Arizona Diamondbacks at Houston Astros (Saturday August 18, 2012)|Houston Astros vs Arizona Diamondbacks [8/18/2012] Tickets at StubHub!|Arizona Diamondbacks at Houston Astros
+729081|Washington Nationals at Houston Astros (Tuesday August 7, 2012)|Houston Astros vs Washington Nationals [8/7/2012] Tickets at StubHub!|Washington Nationals at Houston Astros
+729082|St. Louis Cardinals at Houston Astros (Wednesday June 6, 2012)|Houston Astros vs St. Louis Cardinals [6/6/2012] Tickets at StubHub!|St. Louis Cardinals at Houston Astros
+729083|Chicago Cubs at Houston Astros (Tuesday May 22, 2012)|Houston Astros vs Chicago Cubs [5/22/2012] Tickets at StubHub!|Chicago Cubs at Houston Astros
+729084|Milwaukee Brewers at Houston Astros (Friday July 6, 2012)|Houston Astros vs Milwaukee Brewers [7/6/2012] Tickets at StubHub!|Milwaukee Brewers at Houston Astros
+729085|San Francisco Giants at Houston Astros (Tuesday August 28, 2012)|Houston Astros vs San Francisco Giants [8/28/2012] Tickets at StubHub!|San Francisco Giants at Houston Astros
+729086|Philadelphia Phillies at Houston Astros (Sunday September 16, 2012)|Houston Astros vs Philadelphia Phillies [9/16/2012] Tickets at StubHub!|Philadelphia Phillies at Houston Astros
+729087|Philadelphia Phillies at Houston Astros (Saturday September 15, 2012)|Houston Astros vs Philadelphia Phillies [9/15/2012] Tickets at StubHub!|Philadelphia Phillies at Houston Astros
+729088|Cincinnati Reds at Houston Astros (Tuesday July 24, 2012)|Houston Astros vs Cincinnati Reds [7/24/2012] Tickets at StubHub!|Cincinnati Reds at Houston Astros
+729089|San Francisco Giants at Houston Astros (Thursday August 30, 2012)|Houston Astros vs San Francisco Giants [8/30/2012] Tickets at StubHub!|San Francisco Giants at Houston Astros
+729090|San Diego Padres at Houston Astros (Tuesday June 26, 2012)|Houston Astros vs San Diego Padres [6/26/2012] Tickets at StubHub!|San Diego Padres at Houston Astros
+729091|Pittsburgh Pirates at Houston Astros (Saturday September 22, 2012)|Houston Astros vs Pittsburgh Pirates [9/22/2012] Tickets at StubHub!|Pittsburgh Pirates at Houston Astros
+729092|Philadelphia Phillies at Houston Astros (Thursday September 13, 2012)|Houston Astros vs Philadelphia Phillies [9/13/2012] Tickets at StubHub!|Philadelphia Phillies at Houston Astros
+729093|Texas Rangers at Houston Astros (Sunday May 20, 2012)|Houston Astros vs Texas Rangers [5/20/2012] Tickets at StubHub!|Texas Rangers at Houston Astros
+729094|Kansas City Royals at Houston Astros (Tuesday June 19, 2012)|Houston Astros vs Kansas City Royals [6/19/2012] Tickets at StubHub!|Kansas City Royals at Houston Astros
+729095|Cleveland Indians at Houston Astros (Sunday June 24, 2012)|Houston Astros vs Cleveland Indians [6/24/2012] Tickets at StubHub!|Cleveland Indians at Houston Astros
+729096|Chicago Cubs at Houston Astros (Wednesday May 23, 2012)|Houston Astros vs Chicago Cubs [5/23/2012] Tickets at StubHub!|Chicago Cubs at Houston Astros
+729097|Chicago Cubs at Houston Astros (Monday May 21, 2012)|Houston Astros vs Chicago Cubs [5/21/2012] Tickets at StubHub!|Chicago Cubs at Houston Astros
+729098|Texas Rangers at Houston Astros (Friday May 18, 2012)|Houston Astros vs Texas Rangers [5/18/2012] Tickets at StubHub!|Texas Rangers at Houston Astros
+729099|Los Angeles Dodgers at Houston Astros (Friday April 20, 2012)|Houston Astros vs Los Angeles Dodgers [4/20/2012] Tickets at StubHub!|Los Angeles Dodgers at Houston Astros
+729100|Cincinnati Reds at Houston Astros (Saturday September 1, 2012)|Houston Astros vs Cincinnati Reds [9/1/2012] Tickets at StubHub!|Cincinnati Reds at Houston Astros
+729101|Milwaukee Brewers at Houston Astros (Wednesday May 16, 2012)|Houston Astros vs Milwaukee Brewers [5/16/2012] Tickets at StubHub!|Milwaukee Brewers at Houston Astros
+729102|Miami Marlins at Houston Astros (Monday May 7, 2012)|Houston Astros vs Miami Marlins [5/7/2012] Tickets at StubHub!|Miami Marlins at Houston Astros
+729103|Washington Nationals at Houston Astros (Thursday August 9, 2012)|Houston Astros vs Washington Nationals [8/9/2012] Tickets at StubHub!|Washington Nationals at Houston Astros
+729104|San Diego Padres at Houston Astros (Thursday June 28, 2012)|Houston Astros vs San Diego Padres [6/28/2012] Tickets at StubHub!|San Diego Padres at Houston Astros
+729105|St. Louis Cardinals at Houston Astros (Saturday May 5. 2012)|Houston Astros vs St. Louis Cardinals [5/5/2012] Tickets at StubHub!|St. Louis Cardinals at Houston Astros
+729106|Milwaukee Brewers at Houston Astros (Saturday August 11, 2012)|Houston Astros vs Milwaukee Brewers [8/11/2012] Tickets at StubHub!|Milwaukee Brewers at Houston Astros
+729107|Kansas City Royals at Houston Astros (Monday June 18, 2012)|Houston Astros vs Kansas City Royals [6/18/2012] Tickets at StubHub!|Kansas City Royals at Houston Astros
+729108|Pittsburgh Pirates at Houston Astros (Thursday July 26, 2012)|Houston Astros vs Pittsburgh Pirates [7/26/2012] Tickets at StubHub!|Pittsburgh Pirates at Houston Astros
+729109|Kansas City Royals at Houston Astros (Wednesday June 20, 2012)|Houston Astros vs Kansas City Royals [6/20/2012] Tickets at StubHub!|Kansas City Royals at Houston Astros
+729110|New York Mets at Houston Astros (Tuesday May 1, 2012)|Houston Astros vs New York Mets [5/1/2012] Tickets at StubHub!|New York Mets at Houston Astros
+729111|Cleveland Indians at Houston Astros (Friday June 22, 2012)|Houston Astros vs Cleveland Indians [6/22/2012] Tickets at StubHub!|Cleveland Indians at Houston Astros
+729112|Los Angeles Dodgers at Houston Astros (Sunday April 22, 2012)|Houston Astros vs Los Angeles Dodgers [4/22/2012] Tickets at StubHub!|Los Angeles Dodgers at Houston Astros
+729113|St. Louis Cardinals at Houston Astros (Tuesday September 25, 2012)|Houston Astros vs St. Louis Cardinals [9/25/2012] Tickets at StubHub!|St. Louis Cardinals at Houston Astros
+729114|Pittsburgh Pirates at Houston Astros (Saturday July 28, 2012)|Houston Astros vs Pittsburgh Pirates [7/28/2012] Tickets at StubHub!|Pittsburgh Pirates at Houston Astros
+729115|Arizona Diamondbacks at Houston Astros (Friday August 17, 2012)|Houston Astros vs Arizona Diamondbacks [8/17/2012] Tickets at StubHub!|Arizona Diamondbacks at Houston Astros
+729116|New York Mets at Houston Astros (Monday April 30, 2012)|Houston Astros vs New York Mets [4/30/2012] Tickets at StubHub!|New York Mets at Houston Astros
+729117|Cincinnati Reds at Houston Astros (Friday June 1, 2012)|Houston Astros vs Cincinnati Reds [6/1/2012] Tickets at StubHub!|Cincinnati Reds at Houston Astros
+729118|Chicago Cubs at Houston Astros (Monday September 10, 2012)|Houston Astros vs Chicago Cubs [9/10/2012] Tickets at StubHub!|Chicago Cubs at Houston Astros
+729119|Arizona Diamondbacks at Houston Astros (Sunday August 19, 2012)|Houston Astros vs Arizona Diamondbacks [8/19/2012] Tickets at StubHub!|Arizona Diamondbacks at Houston Astros
+729120|St. Louis Cardinals at Houston Astros (Thursday June 7, 2012)|Houston Astros vs St. Louis Cardinals [6/7/2012] Tickets at StubHub!|St. Louis Cardinals at Houston Astros
+729124|Seattle Mariners at Oakland Athletics (Saturday September 29, 2012)|Oakland Athletics vs Seattle Mariners [09/29/2012] Tickets at StubHub!|Seattle Mariners at Oakland Athletics
+729125|Seattle Mariners at Oakland Athletics (Thursday July 5, 2012)|Oakland Athletics vs Seattle Mariners [07/05/2012] Tickets at StubHub!|
+729126|Los Angeles Angels at Oakland Athletics (Monday August 6, 2012)|Oakland Athletics vs Los Angeles Angels [08/06/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Oakland Athletics
+729127|Texas Rangers at Oakland Athletics (Tuesday June 5, 2012)|Oakland Athletics vs Texas Rangers [06/05/2012] Tickets at StubHub!|Texas Rangers at Oakland Athletics
+729128|Baltimore Orioles at Oakland Athletics (Friday September 14, 2012)|Oakland Athletics vs Baltimore Orioles [09/14/2012] Tickets at StubHub!|Baltimore Orioles at Oakland Athletics
+729129|Toronto Blue Jays at Oakland Athletics (Wednesday May 9, 2012)|Oakland Athletics vs Toronto Blue Jays [05/09/2012] Tickets at StubHub!|Toronto Blue Jays at Oakland Athletics
+729130|Boston Red Sox at Oakland Athletics (Friday August 31, 2012)|Oakland Athletics vs Boston Red Sox [08/31/2012] Tickets at StubHub!|Boston Red Sox at Oakland Athletics
+729131|Detroit Tigers at Oakland Athletics (Friday May 11, 2012)|Oakland Athletics vs Detroit Tigers [05/11/2012] Tickets at StubHub!|Detroit Tigers at Oakland Athletics
+729132|Los Angeles Angels at Oakland Athletics (Wednesday May 23, 2012)|Oakland Athletics vs Los Angeles Angels [05/23/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Oakland Athletics
+729133|Chicago White Sox at Oakland Athletics (Wednesday April 25, 2012)|Oakland Athletics vs Chicago White Sox [04/25/2012] Tickets at StubHub!|Chicago White Sox at Oakland Athletics
+729134|Toronto Blue Jays at Oakland Athletics (Thursday August 2, 2012)|Oakland Athletics vs Toronto Blue Jays [08/02/2012] Tickets at StubHub!|Toronto Blue Jays at Oakland Athletics
+729135|Boston Red Sox at Oakland Athletics (Sunday September 2, 2012)|Oakland Athletics vs Boston Red Sox [09/02/2012] Tickets at StubHub!|Boston Red Sox at Oakland Athletics
+729136|Los Angeles Angels at Oakland Athletics (Monday May 21, 2012)|Oakland Athletics vs Los Angeles Angels [05/21/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Oakland Athletics
+729137|Cleveland Indians at Oakland Athletics (Saturday April 21, 2012)|Oakland Athletics vs Cleveland Indians [04/21/2012] Tickets at StubHub!|Cleveland Indians at Oakland Athletics
+729138|Boston Red Sox at Oakland Athletics (Tuesday July 3, 2012)|Oakland Athletics vs Boston Red Sox [07/03/2012] Tickets at StubHub!|Boston Red Sox at Oakland Athletics
+729139|Seattle Mariners at Oakland Athletics (Sunday July 8, 2012)|Oakland Athletics vs Seattle Mariners [07/08/2012] Tickets at StubHub!|Seattle Mariners at Oakland Athletics
+729140|Chicago White Sox at Oakland Athletics (Monday Apil 23, 2012)|Oakland Athletics vs Chicago White Sox [04/23/2012] Tickets at StubHub!|Chicago White Sox at Oakland Athletics
+729141|Seattle Mariners at Oakland Athletics (Friday July 6, 2012)|Oakland Athletics vs Seattle Mariners [07/06/2012] Tickets at StubHub!|Seattle Mariners at Oakland Athletics
+729142|Tampa Bay Rays at Oakland Athletics (Tuesday July 31, 2012)|Oakland Athletics vs Tampa Bay Rays [07/31/2012] Tickets at StubHub!|Tampa Bay Rays at Oakland Athletics
+729143|Texas Rangers at Oakland Athletics (Tuesday October 2, 2012)|Oakland Athletics vs Texas Rangers [10/02/2012] Tickets at StubHub!|Texas Rangers at Oakland Athletics
+729144|Los Angeles Dodgers at Oakland Athletics (Tuesday June 19, 2012)|Oakland Athletics vs Los Angeles Dodgers [06/19/2012] Tickets at StubHub!|Los Angeles Dodgers at Oakland Athletics
+729145|Los Angeles Angels at Oakland Athletics (Tuesday September 4, 2012)|Oakland Athletics vs Los Angeles Angels [09/04/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Oakland Athletics
+729146|Texas Rangers at Oakland Athletics (Tuesday July 17, 2012)|Oakland Athletics vs Texas Rangers [07/17/2012] Tickets at StubHub!|Texas Rangers at Oakland Athletics
+729147|San Diego Padres at Oakland Athletics (Sunday June 17, 2012)|Oakland Athletics vs San Diego Padres [06/17/2012] Tickets at StubHub!|San Diego Padres at Oakland Athletics
+729148|Boston Red Sox at Oakland Athletics (Monday July 2, 2012)|Oakland Athletics vs Boston Red Sox [07/02/2012] Tickets at StubHub!|Boston Red Sox at Oakland Athletics
+729149|New York Yankees at Oakland Athletics (Thursday July 19, 2012)|Oakland Athletics vs New York Yankees [07/19/2012] Tickets at StubHub!|New York Yankees at Oakland Athletics
+729150|New York Yankees at Oakland Athletics (Saturday July 21, 2012)|Oakland Athletics vs New York Yankees [07/21/2012] Tickets at StubHub!|New York Yankees at Oakland Athletics
+729151|Minnesota Twins at Oakland Athletics (Monday August 20, 2012)|Oakland Athletics vs Minnesota Twins [08/20/2012] Tickets at StubHub!|Minnesota Twins at Oakland Athletics
+729152|San Francisco Giants at Oakland Athletics (Saturday June 23, 2012)|Oakland Athletics vs San Francisco Giants [06/23/2012] Tickets at StubHub!|San Francisco Giants at Oakland Athletics
+729153|Seattle Mariners at Oakland Athletics (Saturday July 7, 2012)|Oakland Athletics vs Seattle Mariners [07/07/2012] Tickets at StubHub!|Seattle Mariners at Oakland Athletics
+729154|New York Yankees at Oakland Athletics (Sunday May 27, 2012)|Oakland Athletics vs New York Yankees [05/27/2012] Tickets at StubHub!|New York Yankees at Oakland Athletics
+729155|Minnesota Twins at Oakland Athletics (Wednesday August 22, 2012)|Oakland Athletics vs Minnesota Twins [08/22/2012] Tickets at StubHub!|Minnesota Twins at Oakland Athletics
+729156|Los Angeles Dodgers at Oakland Athletics (Thursday June 21, 2012)|Oakland Athletics vs Los Angeles Dodgers [06/21/2012] Tickets at StubHub!|Los Angeles Dodgers at Oakland Athletics
+729157|Seattle Mariners at Oakland Athletics (Sunday September 30, 2012)|Oakland Athletics vs Seattle Mariners [09/30/2012] Tickets at StubHub!|Seattle Mariners at Oakland Athletics
+729158|New York Yankees at Oakland Athletics (Friday May 25, 2012)|Oakland Athletics vs New York Yankees [05/25/2012] Tickets at StubHub!|New York Yankees at Oakland Athletics
+729159|Detroit Tigers at Oakland Athletics (Saturday May 12, 2012)|Oakland Athletics vs Detroit Tigers [05/12/2012] Tickets at StubHub!|Detroit Tigers at Oakland Athletics
+729160|Toronto Blue Jays at Oakland Athletics (Sunday August 5, 2012)|Oakland Athletics vs Toronto Blue Jays [08/05/2012] Tickets at StubHub!|Toronto Blue Jays at Oakland Athletics
+729161|Kansas City Royals at Oakland Athletics (Tuesday April 10, 2012)|Oakland Athletics vs Kansas City Royals [04/10/2012] Tickets at StubHub!|Kansas City Royals at Oakland Athletics
+729162|Seattle Mariners at Oakland Athletics (Friday September 28, 2012)|Oakland Athletics vs Seattle Mariners [09/28/2012] Tickets at StubHub!|Seattle Mariners at Oakland Athletics
+729163|Detroit Tigers at Oakland Athletics (Thursday May 10, 2012)|Oakland Athletics vs Detroit Tigers [05/10/2012] Tickets at StubHub!|Detroit Tigers at Oakland Athletics
+729164|Cleveland Indians at Oakland Athletics (Saturday August 18, 2012)|Oakland Athletics vs Cleveland Indians [08/18/2012] Tickets at StubHub!|Cleveland Indians at Oakland Athletics
+729165|Los Angeles Angels at Oakland Athletics (Tuesday August 7, 2012)|Oakland Athletics vs Los Angeles Angels [08/07/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Oakland Athletics
+729166|Texas Rangers at Oakland Athletics (Wednesday June 6, 2012)|Oakland Athletics vs Texas Rangers [06/06/2012] Tickets at StubHub!|Texas Rangers at Oakland Athletics
+729167|Toronto Blue Jays at Oakland Athletics (Tuesday May 8, 2012)|Oakland Athletics vs Toronto Blue Jays [05/08/2012] Tickets at StubHub!|Toronto Blue Jays at Oakland Athletics
+729168|Tampa Bay Rays at Oakland Athletics (Wednesday August 1, 2012)|Oakland Athletics vs Tampa Bay Rays [08/01/2012] Tickets at StubHub!|Tampa Bay Rays at Oakland Athletics
+729169|Baltimore Orioles at Oakland Athletics (Sunday September 16, 2012)|Oakland Athletics vs Baltimore Orioles [09/16/2012] Tickets at StubHub!|Baltimore Orioles at Oakland Athletics
+729170|Baltimore Orioles at Oakland Athletics (Saturday September 15, 2012)|Oakland Athletics vs Baltimore Orioles [09/15/2012] Tickets at StubHub!|Baltimore Orioles at Oakland Athletics
+729171|Los Angeles Angels at Oakland Athletics (Tuesday May 22, 2012)|Oakland Athletics vs Los Angeles Angels [05/22/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Oakland Athletics
+729172|Toronto Blue Jays at Oakland Athletics (Friday August 3, 2012)|Oakland Athletics vs Toronto Blue Jays [08/03/2012] Tickets at StubHub!|Toronto Blue Jays at Oakland Athletics
+729173|Los Angeles Angels at Oakland Athletics (Wednesday August 8, 2012)|Oakland Athletics vs Los Angeles Angels [08/08/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Oakland Athletics
+729174|San Francisco Giants at Oakland Athletics (Sunday June 24, 2012)|Oakland Athletics vs San Francisco Giants [06/24/2012] Tickets at StubHub!|San Francisco Giants at Oakland Athletics
+729175|Los Angeles Angels at Oakland Athletics (Monday September 3, 2012)|Oakland Athletics vs Los Angeles Angels [09/03/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Oakland Athletics
+729176|New York Yankees at Oakland Athletics (Friday July 20, 2012)|Oakland Athletics vs New York Yankees [07/20/2012] Tickets at StubHub!|New York Yankees at Oakland Athletics
+729177|Cleveland Indians at Oakland Athletics (Firday April 20, 2012)|Oakland Athletics vs Cleveland Indians [04/20/2012] Tickets at StubHub!|Cleveland Indians at Oakland Athletics
+729178|Boston Red Sox at Oakland Athletics (Saturday September 1, 2012)|Oakland Athletics vs Boston Red Sox [09/01/2012] Tickets at StubHub!|Boston Red Sox at Oakland Athletics
+729179|Tampa Bay Rays at Oakland Athletics (Monday July 30, 2012)|Oakland Athletics vs Tampa Bay Rays [07/30/2012] Tickets at StubHub!|Tampa Bay Rays at Oakland Athletics
+729180|Texas Rangers at Oakland Athletics (Wednesday October 3, 2012)|Oakland Athletics vs Texas Rangers [10/03/2012] Tickets at StubHub!|Texas Rangers at Oakland Athletics
+729181|Cleveland Indians at Oakland Athletics (Sunday April 22, 2012)|Oakland Athletics vs Cleveland Indians [04/22/2012] Tickets at StubHub!|Cleveland Indians at Oakland Athletics
+729182|Texas Rangers at Oakland Athletics (Monday July 16, 2012)|Oakland Athletics vs Texas Rangers [07/16/2012] Tickets at StubHub!|Texas Rangers at Oakland Athletics
+729183|Texas Rangers at Oakland Athletics (Monday October 1, 2012)|Oakland Athletics vs Texas Rangers [10/01/2012] Tickets at StubHub!|Texas Rangers at Oakland Athletics
+729184|Chicago White Sox at Oakland Athletics (Tuesday April 24, 2012)|Oakland Athletics vs Chicago White Sox [04/24/2012] Tickets at StubHub!|Chicago White Sox at Oakland Athletics
+729185|San Diego Padres at Oakland Athletics (Friday June 15, 2012)|Oakland Athletics vs San Diego Padres [06/15/2012] Tickets at StubHub!|San Diego Padres at Oakland Athletics
+729186|Los Angeles Angels at Oakland Athletics (Wednesday September 5, 2012)|Oakland Athletics vs Los Angeles Angels [09/05/2012] Tickets at StubHub!|Los Angeles Angels of Anaheim at Oakland Athletics
+729187|Texas Rangers at Oakland Athletics (Wednesday July 18, 2012)|Oakland Athletics vs Texas Rangers [07/18/2012] Tickets at StubHub!|Texas Rangers at Oakland Athletics
+729188|Minnesota Twins at Oakland Athletics (Tuesday August 21, 2012)|Oakland Athletics vs Minnesota Twins [08/21/2012] Tickets at StubHub!|Minnesota Twins at Oakland Athletics
+729189|San Diego Padres at Oakland Athletics (Saturday June 16, 2012)|Oakland Athletics vs San Diego Padres [06/16/2012] Tickets at StubHub!|San Diego Padres at Oakland Athletics
+729190|New York Yankees at Oakland Athletics (Saturday May 26, 2012)|Oakland Athletics vs New York Yankees [05/26/2012] Tickets at StubHub!|New York Yankees at Oakland Athletics
+729191|San Francisco Giants at Oakland Athletics (Friday June 22, 2012)|Oakland Athletics vs San Francisco Giants [06/22/2012] Tickets at StubHub!|San Francisco Giants at Oakland Athletics
+729192|Kansas City Royals at Oakland Athletics (Monday April 9, 2012)|Oakland Athletics vs Kansas City Royals [04/09/2012] Tickets at StubHub!|Kansas City Royals at Oakland Athletics
+729193|New York Yankees at Oakland Athletics (Sunday July 22, 2012)|Oakland Athletics vs New York Yankees [07/22/2012] Tickets at StubHub!|New York Yankees at Oakland Athletics
+729194|Los Angeles Dodgers at Oakland Athletics (Wednesday June 20, 2012)|Oakland Athletics vs Los Angeles Dodgers [06/20/2012] Tickets at StubHub!|Los Angeles Dodgers at Oakland Athletics
+729195|Kansas City Royals at Oakland Athletics (Wednesday April 11, 2012)|Oakland Athletics vs Kansas City Royals [04/11/2012] Tickets at StubHub!|Kansas City Royals at Oakland Athletics
+729196|Boston Red Sox at Oakland Athletics (Wednesday July 4, 2012)|Oakland Athletics vs Boston Red Sox [07/04/2012] Tickets at StubHub!|Boston Red Sox at Oakland Athletics
+729197|Detroit Tigers at Oakland Athletics (Sunday May 13, 2012)|Oakland Athletics vs Detroit Tigers [05/13/2012] Tickets at StubHub!|Detroit Tigers at Oakland Athletics
+729198|Cleveland Indians at Oakland Athletics (Sunday August 19, 2012)|Oakland Athletics vs Cleveland Indians [08/19/2012] Tickets at StubHub!|Cleveland Indians at Oakland Athletics
+729199|Toronto Blue Jays at Oakland Athletics (Saturday August 4, 2012)|Oakland Athletics vs Toronto Blue Jays [08/04/2012] Tickets at StubHub!|Toronto Blue Jays at Oakland Athletics
+729200|Texas Rangers at Oakland Athletics (Thursday June 7, 2012)|Oakland Athletics vs Texas Rangers [06/07/2012] Tickets at StubHub!|Texas Rangers at Oakland Athletics
+729462|Washington Nationals at New York Mets (Wednesday September 12, 2012)|New York Mets vs Washington Nationals [09/12/2012] Tickets at StubHub!|Washington Nationals at New York Mets
+729463|Washington Nationals at New York Mets (Tuesday September 11, 2012)|New York Mets vs Washington Nationals [09/11/2012] Tickets at StubHub!|Washington Nationals at New York Mets
+730427|New York Mets at Tampa Bay Rays (Thu. 6/14/12)|Tampa Bay Rays vs New York Mets [6/14/2012] Tickets at StubHub!|New York Mets at Tampa Bay Rays
+732529|Chicago Cubs at Cincinnati Reds Spring Training|Chicago Cubs vs Cincinnati Reds 27/3/2012 Spring Training Tickets at StubHub!|Spring Training - Chicago Cubs at Cincinnati Reds
+732530|Cleveland Indians at Cincinnati Reds Spring Training|Cleveland Indians vs Cincinnati Reds 5/3/2012 Spring Training Tickets at StubHub!|Spring Training - Cleveland Indians at Cincinnati Reds
+732531|San Diego Padres at Cincinnati Reds Spring Training|San Diego Padres vs Cincinnati Reds 7/3/2012 Spring Training Tickets at StubHub!|Spring Training - San Diego Padres at Cincinnati Reds
+732532|Seattle Mariners at Cincinnati Reds Spring Training|Seattle Mariners vs Cincinnati Reds 20/3/2012 Spring Training Tickets at StubHub!|Spring Training - Seattle Mariners at Cincinnati Reds
+732533|Texas Rangers at Cincinnati Reds Spring Training|Texas Rangers vs Cincinnati Reds 22/3/2012 Spring Training Tickets at StubHub!|Spring Training - Texas Rangers at Cincinnati Reds
+732535|Colorado Rockies at Cincinnati Reds Spring Training|Colorado Rockies vs Cincinnati Reds 16/3/2012 Spring Training Tickets at StubHub!|Spring Training - Colorado Rockies at Cincinnati Reds
+732537|Arizona Diamondbacks at Cincinnati Reds Spring Training|Arizona Diamondbacks vs Cincinnati Reds 18/3/2012 Spring Training Tickets at StubHub!|Spring Training - Arizona Diamondbacks at Cincinnati Reds
+732538|Kansas City Royals at Cincinnati Reds Spring Training|Kansas City Royals vs Cincinnati Reds 9/3/2012 Spring Training Tickets at StubHub!|Spring Training - Kansas City Royals at Cincinnati Reds
+732539|Los Angeles Angels at Cincinnati Reds Spring Training|Los Angeles Angels vs Cincinnati Reds 28/3/2012 Spring Training Tickets at StubHub!|Spring Training - Los Angeles Angels of Anaheim at Cincinnati Reds
+732540|Los Angeles Angels at Cincinnati Reds Spring Training|Los Angeles Angels vs Cincinnati Reds 11/3/2012 Spring Training Tickets at StubHub!|Spring Training - Los Angeles Angels of Anaheim at Cincinnati Reds
+732541|Cleveland Indians at Cincinnati Reds Spring Training|Cleveland Indians vs Cincinnati Reds 30/3/2012 Spring Training Tickets at StubHub!|Spring Training - Cleveland Indians at Cincinnati Reds
+732542|San Francisco Giants at Cincinnati Reds Spring Training|San Francisco Giants vs Cincinnati Reds 24/3/2012 Spring Training Tickets at StubHub!|Spring Training - San Francisco Giants at Cincinnati Reds
+732546|Chicago White Sox at Cincinnati Reds Spring Training|Chicago White Sox vs Cincinnati Reds 1/4/2012 Spring Training Tickets at StubHub!|Spring Training - Chicago White Sox at Cincinnati Reds
+732550|San Diego Padres at Cincinnati Reds Spring Training|San Diego Padres vs Cincinnati Reds 14/3/2012 Spring Training Tickets at StubHub!|Spring Training - Los Angeles Dodgers at Cincinnati Reds (Split Squad)
+734171|Pittsburgh Pirates at Philadelphia Phillies Spring Training|Philadelphia Phillies vs Pittsburgh Pirates [04/03/2012] Tickets at StubHub!|Exhibition - Pittsburgh Pirates at Philadelphia Phillies
+734172|Pittsburgh Pirates at Philadelphia Phillies Spring Training|Philadelphia Phillies vs Pittsburgh Pirates [04/02/2012] Tickets at StubHub!|Exhibition - Pittsburgh Pirates at Philadelphia Phillies
+734619|Colorado Rockies at Houston Astros (Friday April 6, 2012)|Houston Astros vs Colorado Rockies [4/6/2012] Tickets at StubHub!|Colorado Rockies at Houston Astros
+734626|Seattle Mariners at Oakland Athletics (Saturday April 7, 2012)|Oakland Athletics vs Seattle Mariners [04/07/2012] Tickets at StubHub!|Seattle Mariners at Oakland Athletics
+734627|Seattle Mariners at Oakland Athletics (Friday April 6, 2012)|Oakland Athletics vs Seattle Mariners [04/06/2012] Tickets at StubHub!|Seattle Mariners at Oakland Athletics
+734628|Seattle Mariners at Oakland Athletics (Sunday April 8, 2012)||
+735790|Cleveland Indians at Oakland Athletics (Friday August 17, 2012)|Oakland Athletics vs Cleveland Indians [08/17/2012] Tickets at StubHub!|Cleveland Indians at Oakland Athletics
+738957|San Francisco Giants at Chicago White Sox Spring Training|San Francisco Giants vs Chicago White Sox [03/25/2012] Spring Training Tickets at StubHub!|Spring Training - San Francisco Giants at Chicago White Sox
+738958|Cleveland Indians at Chicago White Sox Spring Training|Cleveland Indians vs Chicago White Sox [03/27/2012] Spring Training Tickets at StubHub!|Spring Training - Cleveland Indians at Chicago White Sox
+738959|Los Angeles Dodgers at Chicago White Sox Spring Training|Los Angeles Dodgers vs Chicago White Sox [03/05/2012] Spring Training Tickets at StubHub!|Spring Training - Los Angeles Dodgers at Chicago White Sox
+738960|Milwaukee Brewers at Chicago White Sox Spring Training|Milwaukee Brewers vs Chicago White Sox [03/07/2012] Spring Training Tickets at StubHub!|Spring Training - Milwaukee Brewers at Chicago White Sox
+738961|Milwaukee Brewers at Los Angeles Dodgers Spring Training|Milwaukee Brewers vs Los Angeles Dodgers [03/20/2012] Spring Training Tickets at StubHub!|Spring Training - Milwaukee Brewers at Los Angeles Dodgers
+738962|Kansas City Royals at Chicago White Sox Spring Training|Kansas City Royals vs Chicago White Sox [03/22/2012] Spring Training Tickets at StubHub!|Spring Training - Kansas City Royals at Chicago White Sox
+738963|Milwaukee Brewers at Chicago White Sox Spring Training|Milwaukee Brewers vs Chicago White Sox [04/02/2012] Spring Training Tickets at StubHub!|Spring Training - Milwaukee Brewers at Chicago White Sox
+738964|Colorado Rockies at Los Angeles Dodgers Spring Training|Colorado Rockies vs Los Angeles Dodgers [03/13/2012] Spring Training Tickets at StubHub!|Spring Training - Colorado Rockies at Los Angeles Dodgers
+738965|Texas Rangers at Los Angeles Dodgers Spring Training|Texas Rangers vs Los Angeles Dodgers [03/16/2012] Spring Training Tickets at StubHub!|Spring Training - Texas Rangers at Los Angeles Dodgers
+738966|Los Angeles Angels at Los Angeles Dodgers Spring Training|Los Angeles Angels vs Los Angeles Dodgers [03/18/2012] Spring Training Tickets at StubHub!|Los Angeles Angels of Anaheim at Los Angeles Dodgers
+738967|Chicago Cubs at Chicago White Sox Spring Training|Chicago Cubs vs Chicago White Sox [03/09/2012] Spring Training Tickets at StubHub!|Spring Training - Chicago Cubs at Chicago White Sox
+738968|San Diego Padres at Chicago White Sox Spring Training|San Diego Padres vs Chicago White Sox [03/28/2012] Spring Training Tickets at StubHub!|Spring Training - San Diego Padres at Chicago White Sox
+738969|Chicago Cubs at Los Angeles Dodgers Spring Training|Chicago Cubs vs Los Angeles Dodgers [03/11/2012] Spring Training Tickets at StubHub!|Spring Training - Chicago Cubs at Los Angeles Dodgers
+738970|Milwaukee Brewers at Los Angeles Dodgers Spring Training|Milwaukee Brewers vs Los Angeles Dodgers [03/30/2012] Spring Training Tickets at StubHub!|Spring Training - Milwaukee Brewers at Los Angeles Dodgers
+738971|Cleveland Indians at Los Angeles Dodgers Spring Training|Cleveland Indians vs Los Angeles Dodgers [03/24/2012] Spring Training Tickets at StubHub!|Spring Training - Cleveland Indians at Los Angeles Dodgers
+738972|Chicago White Sox at Los Angeles Dodgers Spring Training|Chicago White Sox vs Los Angeles Dodgers [03/26/2012] Spring Training Tickets at StubHub!|Spring Training - Chicago White Sox at Los Angeles Dodgers
+738973|San Francisco Giants at Los Angeles Dodgers Spring Training|San Francisco Giants vs Los Angeles Dodgers [03/06/2012] Spring Training Tickets at StubHub!|Spring Training - San Francisco Giants at Los Angeles Dodgers
+738974|Arizona Diamondbacks at Los Angeles Dodgers Spring Training|Arizona Diamondbacks vs Los Angeles Dodgers [04/01/2012] Spring Training Tickets at StubHub!|Spring Training - Arizona Diamondbacks at Los Angeles Dodgers
+738975|San Diego Padres at Los Angeles Dodgers Spring Training|San Diego Padres vs Los Angeles Dodgers [03/21/2012] Spring Training Tickets at StubHub!|Spring Training - San Diego Padres at Los Angeles Dodgers
+738976|Oakland Athletics at Chicago White Sox Spring Training|Oakland Athletics vs Chicago White Sox [03/12/2012] Spring Training Tickets at StubHub!|Spring Training - Oakland Athletics at Chicago White Sox
+738977|Arizona Diamondbacks at Chicago White Sox Spring Training|Arizona Diamondbacks vs Chicago White Sox [03/23/2012] Spring Training Tickets at StubHub!|Spring Training - Arizona Diamondbacks at Chicago White Sox
+738978|Los Angeles Angels at Chicago White Sox Spring Training|Los Angeles Angels vs Chicago White Sox [03/14/2012] Spring Training Tickets at StubHub!|Spring Training - Los Angeles Angels of Anaheim at Chicago White Sox
+738979|San Francisco Giants at Los Angeles Dodgers Spring Training|San Francisco Giants vs Los Angeles Dodgers [03/17/2012] Spring Training Tickets at StubHub!|Spring Training - San Francisco Giants at Los Angeles Dodgers
+738980|Seattle Mariners at Chicago White Sox Spring Training|Seattle Mariners vs Chicago White Sox [03/17/2012] Spring Training Tickets at StubHub!|Spring Training - Seattle Mariners at Chicago White Sox
+738981|Oakland Athletics at Los Angeles Dodgers Spring Training|Oakland Athletics vs Los Angeles Dodgers [03/08/2012] Spring Training Tickets at StubHub!|Spring Training - Oakland Athletics at Los Angeles Dodgers
+738982|Cincinnati Reds at Chicago White Sox Spring Training|Cincinnati Reds vs Chicago White Sox [03/19/2012] Spring Training Tickets at StubHub!|Spring Training - Cincinnati Reds at Chicago White Sox
+738984|Chicago White Sox at Los Angeles Dodgers Spring Training|Chicago White Sox vs Los Angeles Dodgers [03/29/2012] Spring Training Tickets at StubHub!|Spring Training - Chicago White Sox at Los Angeles Dodgers
+738985|Colorado Rockies at Chicago White Sox Spring Training|Colorado Rockies vs Chicago White Sox [03/31/2012] Spring Training Tickets at StubHub!|Spring Training - Colorado Rockies at Chicago White Sox
+739029|San Diego Padres at Los Angeles Dodgers (Sunday April 15, 2012)|Los Angeles Dodgers vs San Diego Padres [4/15/2012] Tickets at StubHub!|San Diego Padres at Los Angeles Dodgers
+739030|Pittsburgh Pirates at Los Angeles Dodgers (Tuesday April 10, 2012)|Los Angeles Dodgers vs Pittsburgh Pirates [4/10/2012] Tickets at StubHub!|Pittsburgh Pirates at Los Angeles Dodgers
+739031|Pittsburgh Pirates at Los Angeles Dodgers (Thursday April 12, 2012)|Los Angeles Dodgers vs Pittsburgh Pirates [4/12/2012] Tickets at StubHub!|Pittsburgh Pirates at Los Angeles Dodgers
+739032|San Diego Padres at Los Angeles Dodgers (Saturday April 14, 2012)|Los Angeles Dodgers vs San Diego Padres [4/14/2012] Tickets at StubHub!|San Diego Padres at Los Angeles Dodgers
+739033|Pittsburgh Pirates at Los Angeles Dodgers (Wednesday April 11, 2012)|Los Angeles Dodgers vs Pittsburgh Pirates [4/11/2012] Tickets at StubHub!|Pittsburgh Pirates at Los Angeles Dodgers
+739034|San Diego Padres at Los Angeles Dodgers (Friday April 13, 2012)|Los Angeles Dodgers vs San Diego Padres [4/13/2012] Tickets at StubHub!|San Diego Padres at Los Angeles Dodgers
+739045|Cincinnati Reds at Houston Astros (Friday August 31, 2012)|Houston Astros vs Cincinnati Reds [8/31/2012] Tickets at StubHub!|Cincinnati Reds at Houston Astros
+739046|Colorado Rockies at Houston Astros (Sunday April 8, 2012)|Houston Astros vs Colorado Rockies [4/8/2012] Tickets at StubHub!|Colorado Rockies at Houston Astros
+739047|Atlanta Braves at Houston Astros (Tuesday April 10, 2012)|Houston Astros vs Atlanta Braves [4/10/2012] Tickets at StubHub!|Atlanta Braves at Houston Astros
+739048|Colorado Rockies at Houston Astros (Saturday April 7, 2012)|Houston Astros vs Colorado Rockies [4/7/2012] Tickets at StubHub!|Colorado Rockies at Houston Astros
+739049|Atlanta Braves at Houston Astros (Monday April 9, 2012)|Houston Astros vs Atlanta Braves [4/9/2012] Tickets at StubHub!|Atlanta Braves at Houston Astros
+739050|Atlanta Braves at Houston Astros (Wednesday April 11, 2012)|Houston Astros vs Atlanta Braves [4/11/2012] Tickets at StubHub!|Atlanta Braves at Houston Astros
+739054|Arizona Diamondbacks at Colorado Rockies (Sunday September 23, 2012)|Colorado Rockies vs Arizona Diamondbacks [9/23/2012] Tickets at StubHub!|Arizona Diamondbacks at Colorado Rockies
+739055|San Francisco Giants at Colorado Rockies (Thursday April 12, 2012)|Colorado Rockies vs San Francisco Giants [4/12/2012] Tickets at StubHub!|San Francisco Giants at Colorado Rockies
+739056|San Francisco Giants at Colorado Rockies (Monday April 9, 2012)|Colorado Rockies vs San Francisco Giants [4/9/2012] Tickets at StubHub!|San Francisco Giants at Colorado Rockies
+739057|San Francisco Giants at Colorado Rockies (Wednesday April 11, 2012)|Colorado Rockies vs San Francisco Giants [4/11/2012] Tickets at StubHub!|San Francisco Giants at Colorado Rockies
+739958|Los Angeles Dodgers at Chicago White Sox Spring Training|Los Angeles Dodgers vs Chicago White Sox [03/10/2012] Spring Training Tickets at StubHub!|
+740586|Washington Nationals at Houston Astros Spring Training|Washington Nationals vs Houston Astros 3/3/2012 Spring Training Tickets at StubHub!|Spring Training - Washington Nationals at Houston Astros
+740587|Pittsburgh Pirates at Houston Astros Spring Training|Pittsburgh Pirates vs Houston Astros 25/3/2012 Spring Training Tickets at StubHub!|Spring Training - Pittsburgh Pirates at Houston Astros
+740588|Washington Nationals at Houston Astros Spring Training|Washington Nationals vs Houston Astros 23/3/2012 Spring Training Tickets at StubHub!|Spring Training - Washington Nationals at Houston Astros
+740589|Philadelphia Phillies at Houston Astros Spring Training|Philadelphia Phillies vs Houston Astros 13/3/2012 Spring Training Tickets at StubHub!|Spring Training - Philadelphia Phillies at Houston Astros
+740590|Detroit Tigers at Houston Astros Spring Training|Detroit Tigers vs Houston Astros 27/3/2012 Spring Training Tickets at StubHub!|Spring Training - Detroit Tigers at Houston Astros
+740591|New York Mets at Houston Astros Spring Training|New York Mets vs Houston Astros 18/3/2012 Spring Training Tickets at StubHub!|Spring Training - New York Mets at Houston Astros
+740592|Atlanta Braves at Houston Astros Spring Training|Atlanta Braves vs Houston Astros 5/3/2012 Spring Training Tickets at StubHub!|Spring Training - Atlanta Braves at Houston Astros
+740593|New York Mets at Houston Astros Spring Training|New York Mets vs Houston Astros 6/3/2012 Spring Training Tickets at StubHub!|Spring Training - New York Mets at Houston Astros
+740594|Toronto Blue Jays at Houston Astros Spring Training|Toronto Blue Jays vs Houston Astros 9/3/2012 Spring Training Tickets at StubHub!|Spring Training - Toronto Blue Jays at Houston Astros
+740595|Detroit Tigers at Houston Astros Spring Training|Detroit Tigers vs Houston Astros 11/3/2012 Spring Training Tickets at StubHub!|Spring Training - Detroit Tigers at Houston Astros
+740596|Atlanta Braves at Houston Astros Spring Training|Atlanta Braves vs Houston Astros 30/3/2012 Spring Training Tickets at StubHub!|Spring Training - Atlanta Braves at Houston Astros
+740597|St. Louis Cardinals at Houston Astros Spring Training|St. Louis Cardinals vs Houston Astros 20/3/2012 Spring Training Tickets at StubHub!|Spring Training - St. Louis Cardinals at Houston Astros
+740598|New York Yankees at Houston Astros Spring Training|New York Yankees vs Houston Astros 31/3/2012 Spring Training Tickets at StubHub!|Spring Training - New York Yankees at Houston Astros
+740817|Chicago Cubs Convention - Weekend Pass|Chicago Cubs Convention Weekend Pass [01/13/2012] Tickets at StubHub!|2012 Chicago Cubs Convention - 3 Day Pass
+741766|Toronto Blue Jays at Houston Astros Spring Training|Toronto Blue Jays vs Houston Astros 15/3/2012 Spring Training Tickets at StubHub!|Spring Training - Toronto Blue Jays at Houston Astros
+743145|Seattle Mariners at Arizona Diamondbacks|Arizona Diamondbacks vs Seattle Mariners [6/20/2012] Tickets at StubHub!|Seattle Mariners at Arizona Diamondbacks
+743146|Seattle Mariners at Arizona Diamondbacks|Arizona Diamondbacks vs Seattle Mariners [6/19/2012] Tickets at StubHub!|Seattle Mariners at Arizona Diamondbacks
+743147|Seattle Mariners at Arizona Diamondbacks|Arizona Diamondbacks vs Seattle Mariners [6/18/2012] Tickets at StubHub!|Seattle Mariners at Arizona Diamondbacks
+743158|Los Angeles Dodgers at Colorado Rockies (Monday April 30, 2012)|Colorado Rockies vs Los Angeles Dodgers [4/30/2012] Tickets at StubHub!|Los Angeles Dodgers at Colorado Rockies
+743200|Colorado Rockies at San Francisco Giants Spring Training|Colorado Rockies vs San Francisco Giants [03/03/2012] Spring Training Tickets at StubHub!|
+743201|Texas Rangers at San Francisco Giants Spring Training|Texas Rangers vs San Francisco Giants [03/23/2012] Spring Training Tickets at StubHub!|
+743202|Kansas City Royals at San Francisco Giants Spring Training|Kansas City Royals vs San Francisco Giants [03/26/2012] Spring Training Tickets at StubHub!|
+743203|Chicago Cubs at San Francisco Giants Spring Training|Chicago Cubs vs San Francisco Giants [03/13/2012] Spring Training Tickets at StubHub!|
+743204|Los Angeles Angels at San Francisco Giants Spring Training|Los Angeles Angels vs San Francisco Giants [03/27/2012] Spring Training Tickets at StubHub!|
+743205|Cleveland Indians at San Francisco Giants Spring Training|Cleveland Indians vs San Francisco Giants [03/14/2012] Spring Training Tickets at StubHub!|
+743206|Oakland Athletics at San Francisco Giants Spring Training|Oakland Athletics vs San Francisco Giants [03/17/2012] Spring Training Tickets at StubHub!|
+743207|San Diego Padres at San Francisco Giants Spring Training|San Diego Padres vs San Francisco Giants [03/18/2012] Spring Training Tickets at StubHub!|
+743208|Milwaukee Brewers at San Francisco Giants Spring Training|Milwaukee Brewers vs San Francisco Giants [03/05/2012] Spring Training Tickets at StubHub!|
+743209|Cincinnati Reds at San Francisco Giants Spring Training|Cincinnati Reds vs San Francisco Giants [03/09/2012] Spring Training Tickets at StubHub!|
+743210|Los Angeles Dodgers at San Francisco Giants Spring Training|Los Angeles Dodgers vs San Francisco Giants [03/28/2012] Spring Training Tickets at StubHub!|
+743211|Colorado Rockies at San Francisco Giants Spring Training|Colorado Rockies vs San Francisco Giants [03/07/2012] Spring Training Tickets at StubHub!|
+743212|Milwaukee Brewers at San Francisco Giants Spring Training|Milwaukee Brewers vs San Francisco Giants [03/10/2012] Spring Training Tickets at StubHub!|
+743213|Seattle Mariners at San Francisco Giants Spring Training|Seattle Mariners vs San Francisco Giants [03/11/2012] Spring Training Tickets at StubHub!|
+743214|Cincinnati Reds at San Francisco Giants Spring Training|Cincinnati Reds vs San Francisco Giants [03/31/2012] Spring Training Tickets at StubHub!|
+743215|Colorado Rockies at San Francisco Giants Spring Training|Colorado Rockies vs San Francisco Giants [03/24/2012] Spring Training Tickets at StubHub!|
+743322|Kansas City Royals at Los Angeles Dodgers Spring Training|Kansas City Royals vs Los Angeles Dodgers [03/15/2012] Spring Training Tickets at StubHub!|Spring Training - TBD at Los Angeles Dodgers
+743408|Detroit Tigers at Atlanta Braves Spring Training|Detroit Tigers vs Atlanta Braves [03/03/2012] Spring Training Tickets at StubHub!|Spring Training - Detroit Tigers at Atlanta Braves
+743409|Houston Astros at Atlanta Braves Spring Training|Houston Astros vs Atlanta Braves [03/25/2012] Spring Training Tickets at StubHub!|Spring Training - Houston Astros at Atlanta Braves
+743410|New York Mets at Atlanta Braves Spring Training|New York Mets vs Atlanta Braves [03/23/2012] Spring Training Tickets at StubHub!|Spring Training - New York Mets at Atlanta Braves
+743411|Houston Astros at Atlanta Braves Spring Training|Houston Astros vs Atlanta Braves [03/16/2012] Spring Training Tickets at StubHub!|Spring Training - Houston Astros at Atlanta Braves
+743412|Washington Nationals at Atlanta Braves Spring Training|Washington Nationals vs Atlanta Braves [03/14/2012] Spring Training Tickets at StubHub!|Spring Training - Washington Nationals at Atlanta Braves
+743413|Baltimore Orioles at Atlanta Braves Spring Training|Baltimore Orioles vs Atlanta Braves [03/18/2012] Spring Training Tickets at StubHub!|Spring Training - Baltimore Orioles at Atlanta Braves
+743414|St. Louis Cardinals at Atlanta Braves Spring Training|St. Louis Cardinals vs Atlanta Braves [03/19/2012] Spring Training Tickets at StubHub!|Spring Training - St. Louis Cardinals at Atlanta Braves
+743415|Washington Nationals at Atlanta Braves Spring Training|Washington Nationals vs Atlanta Braves [03/06/2012] Spring Training Tickets at StubHub!|Spring Training - Washington Nationals at Atlanta Braves
+743416|New York Yankees at Atlanta Braves Spring Training|New York Yankees vs Atlanta Braves [03/28/2012] Spring Training Tickets at StubHub!|Spring Training - New York Yankees at Atlanta Braves
+743417|New York Yankees at Atlanta Braves Spring Training|New York Yankees vs Atlanta Braves [03/10/2012] Spring Training Tickets at StubHub!|Spring Training - New York Yankees at Atlanta Braves
+743418|Houston Astros at Atlanta Braves Spring Training|Houston Astros vs Atlanta Braves [03/30/2012] Spring Training Tickets at StubHub!|Spring Training - Houston Astros at Atlanta Braves
+743419|Philadelphia Phillies at Atlanta Braves Spring Training|Philadelphia Phillies vs Atlanta Braves [04/01/2012] Spring Training Tickets at StubHub!|Spring Training - Philadelphia Phillies at Atlanta Braves
+743420|Detroit Tigers at Atlanta Braves Spring Training|Detroit Tigers vs Atlanta Braves [03/31/2012] Spring Training Tickets at StubHub!|Spring Training - Detroit Tigers at Atlanta Braves
+743421|Houston Astros at Atlanta Braves Spring Training|Houston Astros vs Atlanta Braves [04/02/2012] Spring Training Tickets at StubHub!|Spring Training - Houston Astros at Atlanta Braves
+746591|Arizona Diamondbacks at Colorado Rockies Spring Training|Arizona Diamondbacks vs Colorado Rockies [03/03/2012] Spring Training Tickets at StubHub!|Spring Training - Arizona Diamondbacks at Colorado Rockies
+746592|San Francisco Giants at Colorado Rockies Spring Training|San Francisco Giants vs Colorado Rockies [03/22/2012] Spring Training Tickets at StubHub!|Spring Training - San Francisco Giants at Colorado Rockies
+746593|Cincinnati Reds at Colorado Rockies Spring Training|Cincinnati Reds vs Colorado Rockies [03/25/2012] Spring Training Tickets at StubHub!|Spring Training - Cincinnati Reds at Colorado Rockies
+746594|San Diego Padres at Colorado Rockies Spring Training|San Diego Padres vs Colorado Rockies [03/12/2012] Spring Training Tickets at StubHub!|Spring Training - San Diego Padres at Colorado Rockies
+746595|Chicago Cubs at Colorado Rockies Spring Training|Chicago Cubs vs Colorado Rockies [03/23/2012] Spring Training Tickets at StubHub!|Spring Training - Chicago Cubs at Colorado Rockies
+746596|Seattle Mariners at Colorado Rockies Spring Training|Seattle Mariners vs Colorado Rockies [04/03/2012] Spring Training Tickets at StubHub!|Spring Training - Seattle Mariners at Colorado Rockies
+746597|Arizona Diamondbacks at Colorado Rockies Spring Training|Arizona Diamondbacks vs Colorado Rockies [03/14/2012] Spring Training Tickets at StubHub!|Spring Training - Arizona Diamondbacks at Colorado Rockies (Split Squad)
+746598|Los Angeles Dodgers at Colorado Rockies Spring Training|Los Angeles Dodgers vs Colorado Rockies [03/17/2012] Spring Training Tickets at StubHub!|Spring Training - Los Angeles Dodgers at Colorado Rockies
+746599|Chicago Cubs at Colorado Rockies Spring Training|Chicago Cubs vs Colorado Rockies [03/15/2012] Spring Training Tickets at StubHub!|Spring Training - Chicago Cubs at Colorado Rockies
+746600|Arizona Diamondbacks at Colorado Rockies Spring Training|Arizona Diamondbacks vs Colorado Rockies [03/05/2012] Spring Training Tickets at StubHub!|Spring Training - Arizona Diamondbacks at Colorado Rockies
+746601|Kansas City Royals at Colorado Rockies Spring Training|Kansas City Royals vs Colorado Rockies [03/08/2012] Spring Training Tickets at StubHub!|Spring Training - Kansas City Royals at Colorado Rockies
+746602|Los Angeles Angels at Colorado Rockies Spring Training|Los Angeles Angels vs Colorado Rockies [03/19/2012] Spring Training Tickets at StubHub!|Spring Training - Los Angeles Angels of Anaheim at Colorado Rockies
+746603|Oakland Athletics at Colorado Rockies Spring Training|Oakland Athletics vs Colorado Rockies [03/09/2012] Spring Training Tickets at StubHub!|Spring Training - Oakland Athletics at Colorado Rockies
+746604|Chicago White Sox at Colorado Rockies Spring Training|Chicago White Sox vs Colorado Rockies [03/28/2012] Spring Training Tickets at StubHub!|Spring Training - Chicago White Sox at Colorado Rockies
+746605|Chicago White Sox at Colorado Rockies Spring Training|Chicago White Sox vs Colorado Rockies [03/11/2012] Spring Training Tickets at StubHub!|Spring Training - Chicago White Sox at Colorado Rockies
+746606|Texas Rangers at Colorado Rockies Spring Training|Texas Rangers vs Colorado Rockies [03/30/2012] Spring Training Tickets at StubHub!|Spring Training - Texas Rangers at Colorado Rockies
+746607|Cleveland Indians at Colorado Rockies Spring Training|Cleveland Indians vs Colorado Rockies [04/01/2012] Spring Training Tickets at StubHub!|Spring Training - Cleveland Indians at Colorado Rockies
+747568|Pittsburgh Pirates at Toronto Blue Jays Spring Training|Pittsburgh Pirates vs Toronto Blue Jays 3/3/2012 Spring Training Tickets at StubHub!|Spring Training - Pittsburgh Pirates at Toronto Blue Jays
+747569|Philadelphia Phillies at Toronto Blue Jays Spring Training|Philadelphia Phillies vs Toronto Blue Jays 22/3/2012 Spring Training Tickets at StubHub!|Spring Training - Philadelphia Phillies at Toronto Blue Jays
+747570|Boston Red Sox at Toronto Blue Jays Spring Training|Boston Red Sox vs Toronto Blue Jays 25/3/2012 Spring Training Tickets at StubHub!|Spring Training - Boston Red Sox at Toronto Blue Jays
+747571|Baltimore Orioles at Toronto Blue Jays Spring Training|Baltimore Orioles vs Toronto Blue Jays 12/3/2012 Spring Training Tickets at StubHub!|Spring Training - Baltimore Orioles at Toronto Blue Jays
+747572|Tampa Bay Rays at Toronto Blue Jays Spring Training|Tampa Bay Rays vs Toronto Blue Jays 16/3/2012 Spring Training Tickets at StubHub!|Spring Training - Tampa Bay Rays at Toronto Blue Jays
+747573|New York Yankees at Toronto Blue Jays Spring Training|New York Yankees vs Toronto Blue Jays 14/3/2012 Spring Training Tickets at StubHub!|Spring Training - New York Yankees at Toronto Blue Jays
+747574|Philadelphia Phillies at Toronto Blue Jays Spring Training|Philadelphia Phillies vs Toronto Blue Jays 18/3/2012 Spring Training Tickets at StubHub!|Spring Training - Philadelphia Phillies at Toronto Blue Jays
+747575|New York Yankees at Toronto Blue Jays Spring Training|New York Yankees vs Toronto Blue Jays 8/3/2012 Spring Training Tickets at StubHub!|Spring Training - New York Yankees at Toronto Blue Jays
+747576|Philadelphia Phillies at Toronto Blue Jays Spring Training|Philadelphia Phillies vs Toronto Blue Jays 6/3/2012 Spring Training Tickets at StubHub!|Spring Training - Philadelphia Phillies at Toronto Blue Jays
+747577|Detroit Tigers at Toronto Blue Jays Spring Training|Detroit Tigers vs Toronto Blue Jays 3/4/2012 Spring Training Tickets at StubHub!|Spring Training - Detroit Tigers at Toronto Blue Jays
+747578|Boston Red Sox at Toronto Blue Jays Spring Training|Boston Red Sox vs Toronto Blue Jays 7/3/2012 Spring Training Tickets at StubHub!|Spring Training - Boston Red Sox at Toronto Blue Jays
+747579|Houston Astros at Toronto Blue Jays Spring Training|Houston Astros vs Toronto Blue Jays 10/3/2012 Spring Training Tickets at StubHub!|Spring Training - Houston Astros at Toronto Blue Jays
+747580|Atlanta Braves at Toronto Blue Jays Spring Training|Atlanta Braves vs Toronto Blue Jays 11/3/2012 Spring Training Tickets at StubHub!|Spring Training - Atlanta Braves at Toronto Blue Jays
+747581|Minnesota Twins at Toronto Blue Jays Spring Training|Minnesota Twins vs Toronto Blue Jays 30/3/2012 Spring Training Tickets at StubHub!|Spring Training - Minnesota Twins at Toronto Blue Jays
+747582|Pittsburgh Pirates at Toronto Blue Jays Spring Training|Pittsburgh Pirates vs Toronto Blue Jays 1/4/2012 Spring Training Tickets at StubHub!|Spring Training - Pittsburgh Pirates at Toronto Blue Jays
+747583|Baltimore Orioles at Toronto Blue Jays Spring Training|Baltimore Orioles vs Toronto Blue Jays 28/3/2012 Spring Training Tickets at StubHub!|Spring Training - Baltimore Orioles at Toronto Blue Jays
+747584|Atlanta Braves at Toronto Blue Jays Spring Training|Atlanta Braves vs Toronto Blue Jays 24/3/2012 Spring Training Tickets at StubHub!|Spring Training - Atlanta Braves at Toronto Blue Jays
+748015|Detroit Tigers at New York Yankees Spring Training|Detroit Tigers vs New York Yankees 25/3/2012 Spring Training Tickets at StubHub!|Spring Training - Detroit Tigers at New York Yankees
+748016|Houston Astros at New York Yankees Spring Training|Houston Astros vs New York Yankees 12/3/2012 Spring Training Tickets at StubHub!|Spring Training - Houston Astros at New York Yankees
+748017|Minnesota Twins at New York Yankees Spring Training|Minnesota Twins vs New York Yankees 23/3/2012 Spring Training Tickets at StubHub!|Spring Training - Minnesota Twins at New York Yankees
+748018|Boston Red Sox at New York Yankees Spring Training|Boston Red Sox vs New York Yankees 13/3/2012 Spring Training Tickets at StubHub!|Spring Training - Boston Red Sox at New York Yankees
+748019|Washington Nationals at New York Yankees Spring Training|Washington Nationals vs New York Yankees 16/3/2012 Spring Training Tickets at StubHub!|Spring Training - Washington Nationals at New York Yankees
+748020|Toronto Blue Jays at New York Yankees Spring Training|Toronto Blue Jays vs New York Yankees 27/3/2012 Spring Training Tickets at StubHub!|Spring Training - Toronto Blue Jays at New York Yankees
+748021|Houston Astros at New York Yankees Spring Training|Houston Astros vs New York Yankees 17/3/2012 Spring Training Tickets at StubHub!|Spring Training - Houston Astros at New York Yankees
+748022|New York Mets at New York Yankees Spring Training|New York Mets vs New York Yankees 4/4/2012 Spring Training Tickets at StubHub!|Spring Training - New York Mets at New York Yankees
+748023|Philadelphia Phillies at New York Yankees Spring Training|Philadelphia Phillies vs New York Yankees 4/3/2012 Spring Training Tickets at StubHub!|Spring Training - Philadelphia Phillies at New York Yankees
+748024|Atlanta Braves at New York Yankees Spring Training|Atlanta Braves vs New York Yankees 9/3/2012 Spring Training Tickets at StubHub!|Spring Training - Atlanta Braves at New York Yankees
+748025|Tampa Bay Rays at New York Yankees Spring Training|Tampa Bay Rays vs New York Yankees 7/3/2012 Spring Training Tickets at StubHub!|Spring Training - Tampa Bay Rays at New York Yankees
+748026|Baltimore Orioles at New York Yankees Spring Training|Baltimore Orioles vs New York Yankees 29/3/2012 Spring Training Tickets at StubHub!|Spring Training - Baltimore Orioles at New York Yankees
+748027|Philadelphia Phillies at New York Yankees Spring Training|Philadelphia Phillies vs New York Yankees 11/3/2012 Spring Training Tickets at StubHub!|Spring Training - Philadelphia Phillies at New York Yankees
+748028|Philadelphia Phillies at New York Yankees Spring Training|Philadelphia Phillies vs New York Yankees 30/3/2012 Spring Training Tickets at StubHub!|Spring Training - Philadelphia Phillies at New York Yankees
+748029|Pittsburgh Pirates at New York Yankees Spring Training|Pittsburgh Pirates vs New York Yankees 20/3/2012 Spring Training Tickets at StubHub!|Spring Training - Pittsburgh Pirates at New York Yankees
+748518|Miami Marlins at Atlanta Braves Spring Training|Miami Marlins vs Atlanta Braves [03/22/2012] Spring Training Tickets at StubHub!|Spring Training - Miami Marlins at Atlanta Braves
+748519|Toronto Blue Jays at Atlanta Braves Spring Training|Toronto Blue Jays vs Atlanta Braves [03/17/2012] Spring Training Tickets at StubHub!|Spring Training - Toronto Blue Jays at Atlanta Braves
+748520|New York Mets at Atlanta Braves Spring Training|New York Mets vs Atlanta Braves [03/09/2012] Spring Training Tickets at StubHub!|Spring Training - New York Mets at Atlanta Braves
+748521|Toronto Blue Jays at Atlanta Braves Spring Training|Toronto Blue Jays vs Atlanta Braves [03/11/2012] Spring Training Tickets at StubHub!|Spring Training - Toronto Blue Jays at Atlanta Braves
+749303|Miami Marlins at Cincinnati Reds (Thursday April 5, 2012)|Cincinnati Reds vs Miami Marlins [4/5/2012] Tickets at StubHub!|Miami Marlins at Cincinnati Reds
+749569|Milwaukee Brewers at Arizona Diamondbacks Spring Training|Milwaukee Brewers vs Arizona Diamondbacks [04/03/2012] Spring Training Tickets at StubHub!|MLB Exhibition - Milwaukee Brewers at Arizona Diamondbacks
+749570|Milwaukee Brewers at Arizona Diamondbacks Spring Training|Milwaukee Brewers vs Arizona Diamondbacks [04/04/2012] Spring Training Tickets at StubHub!|MLB Exhibition - Milwaukee Brewers at Arizona Diamondbacks
+749580|Cleveland Indians at Cincinnati Reds Spring Training|Cleveland Indians vs Cincinnati Reds 3/3/2012 Spring Training Tickets at StubHub!|Spring Training - Cleveland Indians at Cincinnati Reds
+749582|Los Angeles Dodgers at Cincinnati Reds Spring Training|Los Angeles Dodgers vs Cincinnati Reds 14/3/2012 Spring Training Tickets at StubHub!|Spring Training - San Diego Padres at Cincinnati Reds (Split Squad)
+750560|Atlanta Braves at New York Mets Spring Training|Atlanta Braves vs New York Mets [03/27/2012] Spring Training Tickets at StubHub!|Spring Training - Atlanta Braves at New York Mets
+750561|Washington Nationals at New York Mets Spring Training|Washington Nationals vs New York Mets [03/05/2012] Spring Training Tickets at StubHub!|Spring Training - Washington Nationals at New York Mets
+750562|Washington Nationals at New York Mets Spring Training|Washington Nationals vs New York Mets [03/20/2012] Spring Training Tickets at StubHub!|Spring Training - Washington Nationals at New York Mets
+750563|Houston Astros at New York Mets Spring Training|Houston Astros vs New York Mets [03/22/2012] Spring Training Tickets at StubHub!|Spring Training - Houston Astros at New York Mets
+750564|St Louis Cardinals at New York Mets Spring Training|St Louis Cardinals vs New York Mets [03/13/2012] Spring Training Tickets at StubHub!|Spring Training - St. Louis Cardinals at New York Mets
+750565|Detroit Tigers at New York Mets Spring Training|Detroit Tigers vs New York Mets [03/16/2012] Spring Training Tickets at StubHub!|Spring Training - Detroit Tigers at New York Mets
+750566|Washington Nationals at New York Mets Spring Training|Washington Nationals vs New York Mets [03/28/2012] Spring Training Tickets at StubHub!|Spring Training - Washington Nationals at New York Mets
+750567|Miami Marlins at New York Mets Spring Training|Miami Marlins vs New York Mets [03/11/2012] Spring Training Tickets at StubHub!|Spring Training - Miami Marlins at New York Mets
+750568|St Louis Cardinals at New York Mets Spring Training|St Louis Cardinals vs New York Mets [03/24/2012] Spring Training Tickets at StubHub!|Spring Training - St. Louis Cardinals at New York Mets
+750569|St Louis Cardinals at New York Mets Spring Training|St Louis Cardinals vs New York Mets [03/06/2012] Spring Training Tickets at StubHub!|Spring Training - St. Louis Cardinals at New York Mets (Split Squad)
+750570|Detroit Tigers at New York Mets Spring Training|Detroit Tigers vs New York Mets [04/01/2012] Spring Training Tickets at StubHub!|Spring Training - Detroit Tigers at New York Mets
+750571|New York Yankees at New York Mets Spring Training|New York Yankees vs New York Mets [04/03/2012] Spring Training Tickets at StubHub!|Spring Training - New York Yankees at New York Mets
+750572|Atlanta Braves at New York Mets Spring Training|Atlanta Braves vs New York Mets [03/17/2012] Spring Training Tickets at StubHub!|Spring Training - Atlanta Braves at New York Mets
+750573|Miami Marlins at New York Mets Spring Training|Miami Marlins vs New York Mets [03/08/2012] Spring Training Tickets at StubHub!|Spring Training - Miami Marlins at New York Mets
+750574|Houston Astros at New York Mets Spring Training|Houston Astros vs New York Mets [03/29/2012] Spring Training Tickets at StubHub!|Spring Training - Houston Astros at New York Mets
+751058|Oakland Athletics at Los Angeles Angels Spring Training|Oakland Athletics vs Los Angeles Angels [03/22/2012] Spring Training Tickets at StubHub!|
+751059|Texas Rangers at Los Angeles Angels Spring Training|Texas Rangers vs Los Angeles Angels [03/25/2012] Spring Training Tickets at StubHub!|
+751060|Los Angeles Dodgers at Los Angeles Angels Spring Training|Los Angeles Dodgers vs Los Angeles Angels [03/12/2012] Spring Training Tickets at StubHub!|
+751061|Colorado Rockies at Los Angeles Angels Spring Training|Colorado Rockies vs Los Angeles Angels [03/26/2012] Spring Training Tickets at StubHub!|
+751062|Cleveland Indians at Los Angeles Angels Spring Training|Cleveland Indians vs Los Angeles Angels [03/16/2012] Spring Training Tickets at StubHub!|
+751063|Milwaukee Brewers at Los Angeles Angels Spring Training|Milwaukee Brewers vs Los Angeles Angels [03/17/2012] Spring Training Tickets at StubHub!|
+751064|Cincinnati Reds at Los Angeles Angels Spring Training|Cincinnati Reds vs Los Angeles Angels [03/15/2012] Spring Training Tickets at StubHub!|
+751065|Chicago White Sox at Los Angeles Angels Spring Training|Chicago White Sox vs Los Angeles Angels [03/06/2012] Spring Training Tickets at StubHub!|
+751066|San Diego Padres at Los Angeles Angels Spring Training|San Diego Padres vs Los Angeles Angels [03/09/2012] Spring Training Tickets at StubHub!|
+751067|Seattle Mariners at Los Angeles Angels Spring Training|Seattle Mariners vs Los Angeles Angels [03/07/2012] Spring Training Tickets at StubHub!|
+751068|San Francisco Giants at Los Angeles Angels Spring Training|San Francisco Giants vs Los Angeles Angels [03/10/2012] Spring Training Tickets at StubHub!|
+751069|Kansas City Royals at Los Angeles Angels Spring Training|Kansas City Royals vs Los Angeles Angels [03/29/2012] Spring Training Tickets at StubHub!|
+751070|Cleveland Indians at Los Angeles Angels Spring Training|Cleveland Indians vs Los Angeles Angels [03/11/2012] Spring Training Tickets at StubHub!|
+751071|Arizona Diamondbacks at Los Angeles Angels Spring Training|Arizona Diamondbacks vs Los Angeles Angels [03/30/2012] Spring Training Tickets at StubHub!|
+751072|Chicago Cubs at Los Angeles Angels Spring Training|Chicago Cubs vs Los Angeles Angels [04/01/2012] Spring Training Tickets at StubHub!|
+751074|Seattle Mariners at Oakland Athletics Spring Training|Seattle Mariners vs Oakland Athletics [03/03/2012] Spring Training Tickets at StubHub!|
+751075|Milwaukee Brewers at Oakland Athletics Spring Training|Milwaukee Brewers vs Oakland Athletics [03/13/2012] Spring Training Tickets at StubHub!|Spring Training - Milwaukee Brewers at Oakland Athletics
+751076|Seattle Mariners at Oakland Athletics Spring Training|Seattle Mariners vs Oakland Athletics [03/16/2012] Spring Training Tickets at StubHub!|Spring Training - Seattle Mariners at Oakland Athletics
+751077|Chicago Cubs at Oakland Athletics Spring Training|Chicago Cubs vs Oakland Athletics [03/17/2012] Spring Training Tickets at StubHub!|Spring Training - Chicago Cubs at Oakland Athletics (Split Squad)
+751078|Los Angeles Angels at Oakland Athletics Spring Training|Los Angeles Angels vs Oakland Athletics [03/05/2012] Spring Training Tickets at StubHub!|Spring Training - Los Angeles Angels of Anaheim at Oakland Athletics (Split Squad)
+751079|Arizona Diamondbacks at Oakland Athletics Spring Training|Arizona Diamondbacks vs Oakland Athletics [03/19/2012] Spring Training Tickets at StubHub!|Spring Training - Arizona Diamondbacks at Oakland Athletics
+751080|Los Angeles Dodgers at Oakland Athletics Spring Training|Los Angeles Dodgers vs Oakland Athletics [03/07/2012] Spring Training Tickets at StubHub!|Spring Training - Los Angeles Dodgers at Oakland Athletics
+751081|Cincinnati Reds at Oakland Athletics Spring Training|Cincinnati Reds vs Oakland Athletics [03/10/2012] Spring Training Tickets at StubHub!|Spring Training - Cincinnati Reds at Oakland Athletics
+751082|Kansas City Royals at Oakland Athletics Spring Training|Kansas City Royals vs Oakland Athletics [03/11/2012] Spring Training Tickets at StubHub!|Spring Training - Kansas City Royals at Oakland Athletics
+751083|Chicago Cubs at Oakland Athletics Spring Training|Chicago Cubs vs Oakland Athletics [03/20/2012] Spring Training Tickets at StubHub!|Spring Training - Chicago Cubs at Oakland Athletics
+751115|Miami Marlins at Houston Astros Spring Training|Miami Marlins vs Houston Astros 28/3/2012 Spring Training Tickets at StubHub!|Spring Training - Miami Marlins at Houston Astros
+751353|Chicago Cubs at Arizona Diamondbacks Spring Training|Chicago Cubs vs Arizona Diamondbacks [04/02/2012] Spring Training Tickets at StubHub!|Spring Training - Chicago Cubs at Arizona Diamondbacks
+751354|Chicago Cubs at Arizona Diamondbacks Spring Training|Chicago Cubs vs Arizona Diamondbacks [03/26/2012] Spring Training Tickets at StubHub!|Spring Training - Chicago Cubs at Arizona Diamondbacks
+751355|Los Angeles Angels at Arizona Diamondbacks Spring Training|Los Angeles Angels vs Arizona Diamondbacks [03/13/2012] Spring Training Tickets at StubHub!|Spring Training - Los Angeles Angels of Anaheim at Arizona Diamondbacks
+751356|Chicago White Sox at Arizona Diamondbacks Spring Training|Chicago White Sox vs Arizona Diamondbacks [03/16/2012] Spring Training Tickets at StubHub!|Spring Training - Chicago White Sox at Arizona Diamondbacks
+751357|Colorado Rockies at Arizona Diamondbacks Spring Training|Colorado Rockies vs Arizona Diamondbacks [03/27/2012] Spring Training Tickets at StubHub!|Spring Training - Colorado Rockies at Arizona Diamondbacks
+751358|San Francisco Giants at Arizona Diamondbacks Spring Training|San Francisco Giants vs Arizona Diamondbacks [03/04/2012] Spring Training Tickets at StubHub!|Spring Training - San Francisco Giants at Arizona Diamondbacks
+751359|Texas Rangers at Arizona Diamondbacks Spring Training|Texas Rangers vs Arizona Diamondbacks [03/06/2012] Spring Training Tickets at StubHub!|Spring Training - Texas Rangers at Arizona Diamondbacks
+751360|Cleveland Indians at Arizona Diamondbacks Spring Training|Cleveland Indians vs Arizona Diamondbacks [03/07/2012] Spring Training Tickets at StubHub!|Spring Training - Cleveland Indians at Arizona Diamondbacks
+751361|Seattle Mariners at Arizona Diamondbacks Spring Training|Seattle Mariners vs Arizona Diamondbacks [03/10/2012] Spring Training Tickets at StubHub!|Spring Training - Seattle Mariners at Arizona Diamondbacks
+751362|Cleveland Indians at Arizona Diamondbacks Spring Training|Cleveland Indians vs Arizona Diamondbacks [03/29/2012] Spring Training Tickets at StubHub!|Spring Training - Cleveland Indians at Arizona Diamondbacks
+751363|San Francisco Giants at Arizona Diamondbacks Spring Training|San Francisco Giants vs Arizona Diamondbacks [03/20/2012] Spring Training Tickets at StubHub!|Spring Training - San Francisco Giants at Arizona Diamondbacks
+751364|Milwaukee Brewers at Arizona Diamondbacks Spring Training|Milwaukee Brewers vs Arizona Diamondbacks [03/21/2012] Spring Training Tickets at StubHub!|Spring Training - Milwaukee Brewers at Arizona Diamondbacks
+751365|Kansas City Royals at Arizona Diamondbacks Spring Training|Kansas City Royals vs Arizona Diamondbacks [03/24/2012] Spring Training Tickets at StubHub!|Spring Training - Kansas City Royals at Arizona Diamondbacks
+751392|Oakland Athletics at San Francisco Giants (Exhibition - Monday April 2, 2012)|San Francisco Giants vs Oakland Athletics [04/02/2012] Tickets at StubHub!|Exhibition - Oakland Athletics at San Francisco Giants
+751393|Oakland Athletics at San Francisco Giants (Exhibition - Wednesday April 4, 2012)|San Francisco Giants vs Oakland Athletics [04/04/2012] Tickets at StubHub!|Exhibition - Oakland Athletics at San Francisco Giants
+752308|St Louis Cardinals at Miami Marlins (Monday June 25, 2012)||St. Louis Cardinals at Miami Marlins
+752309|Washington National at Miami Marlins (Wednesday May 30, 2012)|Miami Marlins vs Washington National [05/30/2012] Tickets at StubHub!|Washington Nationals at Miami Marlins
+754293|Tampa Bay Rays at Minnesota Twins Spring Training|Minnesota Twins vs Tampa Bay Rays [03/03/2012] Tickets at StubHub!|Spring Training - Tampa Bay Rays at Minnesota Twins
+754294|Tampa Bay Rays at Minnesota Twins Spring Training|Minnesota Twins vs Tampa Bay Rays [04/03/2012] Tickets at StubHub!|Spring Training - Tampa Bay Rays at Minnesota Twins
+754295|Tampa Bay Rays at Minnesota Twins Spring Training|Minnesota Twins vs Tampa Bay Rays [03/26/2012] Tickets at StubHub!|Spring Training - Tampa Bay Rays at Minnesota Twins
+754296|Toronto Blue Jays at Minnesota Twins Spring Training|Minnesota Twins vs Toronto Blue Jays [03/13/2012] Tickets at StubHub!|Spring Training - Toronto Blue Jays at Minnesota Twins
+754297|Baltimore Orioles at Minnesota Twins Spring Training|Minnesota Twins vs Baltimore Orioles [03/16/2012] Tickets at StubHub!|Spring Training - Baltimore Orioles at Minnesota Twins
+754299|Pittsburgh Pirates at Minnesota Twins Spring Training|Minnesota Twins vs Pittsburgh Pirates [03/15/2012] Tickets at StubHub!|Spring Training - Pittsburgh Pirates at Minnesota Twins
+754300|Pittsburgh Pirates at Minnesota Twins Spring Training|Minnesota Twins vs Pittsburgh Pirates [03/18/2012] Tickets at StubHub!|Spring Training - Pittsburgh Pirates at Minnesota Twins
+754301|Boston Red Sox at Minnesota Twins Spring Training|Minnesota Twins vs Boston Red Sox [03/05/2012] Tickets at StubHub!|Spring Training - Boston Red Sox at Minnesota Twins
+754302|Tampa Bay Rays at Minnesota Twins Spring Training|Minnesota Twins vs Tampa Bay Rays [03/08/2012] Tickets at StubHub!|Spring Training - Tampa Bay Rays at Minnesota Twins
+754303|St Louis Cardinals at Minnesota Twins Spring Training|Minnesota Twins vs St Louis Cardinals [03/09/2012] Tickets at StubHub!|Spring Training - St. Louis Cardinals at Minnesota Twins
+754304|Philadelphia Phillies at Minnesota Twins Spring Training|Minnesota Twins vs Philadelphia Phillies [03/28/2012] Tickets at StubHub!|Spring Training - Philadelphia Phillies at Minnesota Twins
+754305|Baltimore Orioles at Minnesota Twins Spring Training|Minnesota Twins vs Baltimore Orioles [03/22/2012] Tickets at StubHub!|Spring Training - Baltimore Orioles at Minnesota Twins
+754306|New York Yankees at Minnesota Twins Spring Training|Minnesota Twins vs New York Yankees [03/11/2012] Tickets at StubHub!|Spring Training - New York Yankees at Minnesota Twins
+754307|Boston Red Sox at Minnesota Twins Spring Training|Minnesota Twins vs Boston Red Sox [03/30/2012] Tickets at StubHub!|Spring Training - Boston Red Sox at Minnesota Twins
+754308|Pittsburgh Pirates at Minnesota Twins Spring Training|Minnesota Twins vs Pittsburgh Pirates [03/31/2012] Tickets at StubHub!|Spring Training - Pittsburgh Pirates at Minnesota Twins
+754309|Tampa Bay Rays at Minnesota Twins Spring Training|Minnesota Twins vs Tampa Bay Rays [03/24/2012] Tickets at StubHub!|Spring Training - Tampa Bay Rays at Minnesota Twins
+754592|San Francisco Giants at Oakland Athletics (Exhibition)|Oakland Athletics vs San Francisco Giants [04/03/2012] Tickets at StubHub!|San Francisco Giants at Oakland Athletics (Exhibition)
+754620|Cleveland Indians at San Diego Padres Spring Training|Cleveland Indians vs San Diego Padres [03/22/2012] Spring Training Tickets at StubHub!|
+754621|Arizona Diamondbacks at San Diego Padres Spring Training|Arizona Diamondbacks vs San Diego Padres [03/25/2012] Spring Training Tickets at StubHub!|
+754622|Cincinnati Reds at San Diego Padres Spring Training|Cincinnati Reds vs San Diego Padres [03/23/2012] Spring Training Tickets at StubHub!|
+754623|Chicago White Sox at San Diego Padres Spring Training|Chicago White Sox vs San Diego Padres [03/13/2012] Spring Training Tickets at StubHub!|
+754624|Los Angeles Angels at San Diego Padres Spring Training|Los Angeles Angels vs San Diego Padres [03/16/2012] Spring Training Tickets at StubHub!|
+754625|Los Angeles Dodgers at San Diego Padres Spring Training|Los Angeles Dodgers vs San Diego Padres [03/27/2012] Spring Training Tickets at StubHub!|
+754626|Kansas City Royals at San Diego Padres Spring Training|Kansas City Royals vs San Diego Padres [03/17/2012] Spring Training Tickets at StubHub!|
+754627|Seattle Mariners at San Diego Padres Spring Training|Seattle Mariners vs San Diego Padres [03/05/2012] Spring Training Tickets at StubHub!|
+754628|San Francisco Giants at San Diego Padres Spring Training|San Francisco Giants vs San Diego Padres [03/08/2012] Spring Training Tickets at StubHub!|
+754629|Texas Rangers at San Diego Padres Spring Training|Texas Rangers vs San Diego Padres [03/07/2012] Spring Training Tickets at StubHub!|
+754630|Chicago Cubs at San Diego Padres Spring Training|Chicago Cubs vs San Diego Padres [03/29/2012] Spring Training Tickets at StubHub!|
+754631|Arizona Diamondbacks at San Diego Padres Spring Training|Arizona Diamondbacks vs San Diego Padres [03/11/2012] Spring Training Tickets at StubHub!|
+754632|San Francisco Giants at San Diego Padres Spring Training|San Francisco Giants vs San Diego Padres [03/30/2012] Spring Training Tickets at StubHub!|
+754633|Colorado Rockies at San Diego Padres Spring Training|Colorado Rockies vs San Diego Padres [03/20/2012] Spring Training Tickets at StubHub!|
+754634|Milwaukee Brewers at San Diego Padres Spring Training|Milwaukee Brewers vs San Diego Padres [03/31/2012] Spring Training Tickets at StubHub!|
+754635|Cincinnati Reds at San Diego Padres Spring Training|Cincinnati Reds vs San Diego Padres [03/24/2012] Spring Training Tickets at StubHub!|
+754690|Kansas City Royals at San Diego Padres Spring Training|Kansas City Royals vs San Diego Padres [03/31/2012] Spring Training Tickets at StubHub!|
+754691|Milwaukee Brewers at Chicago Cubs Spring Training|Milwaukee Brewers vs Chicago Cubs [04/03/2012] Spring Training Tickets at StubHub!|Spring Training - Milwaukee Brewers at Chicago Cubs
+754692|Cincinnati Reds at Chicago Cubs Spring Training|Cincinnati Reds vs Chicago Cubs [03/12/2012] Spring Training Tickets at StubHub!|Spring Training - Cincinnati Reds at Chicago Cubs
+754693|San Diego Padres at Chicago Cubs Spring Training|San Diego Padres vs Chicago Cubs [03/26/2012] Spring Training Tickets at StubHub!|Spring Training - San Diego Padres at Chicago Cubs (Split Squad)
+754694|Oakland Athletics at Chicago Cubs Spring Training|Oakland Athletics vs Chicago Cubs [03/16/2012] Spring Training Tickets at StubHub!|Spring Training - San Francisco Giants at Chicago Cubs
+754695|Milwaukee Brewers at Chicago Cubs Spring Training|Milwaukee Brewers vs Chicago Cubs [03/14/2012] Spring Training Tickets at StubHub!|Spring Training - Milwaukee Brewers at Chicago Cubs
+754696|Oakland Athletics at Chicago Cubs Spring Training|Oakland Athletics vs Chicago Cubs [03/04/2012] Spring Training Tickets at StubHub!|Spring Training - Oakland Athletics at Chicago Cubs
+754697|Arizona Diamondbacks at Chicago Cubs Spring Training|Arizona Diamondbacks vs Chicago Cubs [03/15/2012] Spring Training Tickets at StubHub!|Spring Training - Arizona Diamondbacks at Chicago Cubs
+754698|Chicago White Sox at Chicago Cubs Spring Training|Chicago White Sox vs Chicago Cubs [03/18/2012] Spring Training Tickets at StubHub!|Spring Training - Chicago White Sox at Chicago Cubs (Split Squad)
+754699|Oakland Athletics at Chicago Cubs Spring Training|Oakland Athletics vs Chicago Cubs [03/05/2012] Spring Training Tickets at StubHub!|Spring Training - Oakland Athletics at Chicago Cubs (Split Squad)
+754700|Seattle Mariners at Chicago Cubs Spring Training|Seattle Mariners vs Chicago Cubs [03/08/2012] Spring Training Tickets at StubHub!|Spring Training - Seattle Mariners at Chicago Cubs
+754701|Colorado Rockies at Chicago Cubs Spring Training|Colorado Rockies vs Chicago Cubs [03/06/2012] Spring Training Tickets at StubHub!|Spring Training - Colorado Rockies at Chicago Cubs
+754702|Cleveland Indians at Chicago Cubs Spring Training|Cleveland Indians vs Chicago Cubs [03/28/2012] Spring Training Tickets at StubHub!|Spring Training - Cleveland Indians at Chicago Cubs
+754703|Los Angeles Dodgers at Chicago Cubs Spring Training|Los Angeles Dodgers vs Chicago Cubs [03/30/2012] Spring Training Tickets at StubHub!|Spring Training - Los Angeles Dodgers at Chicago Cubs
+754704|Texas Rangers at Chicago Cubs Spring Training|Texas Rangers vs Chicago Cubs [03/20/2012] Spring Training Tickets at StubHub!|Spring Training - Texas Rangers at Chicago Cubs (Split Squad)
+754705|Los Angeles Angels at Chicago Cubs Spring Training|Los Angeles Angels vs Chicago Cubs [03/31/2012] Spring Training Tickets at StubHub!|Spring Training - Los Angeles Angels of Anaheim at Chicago Cubs
+754706|San Diego Padres at Chicago Cubs Spring Training|San Diego Padres vs Chicago Cubs [03/24/2012] Spring Training Tickets at StubHub!|Spring Training - San Diego Padres at Chicago Cubs
+754707|Los Angeles Dodgers at Milwaukee Brewers Spring Training|Los Angeles Dodgers vs Milwaukee Brewers [03/25/2012] Spring Training Tickets at StubHub!|
+754708|Los Angeles Angles at Milwaukee Brewers Spring Training|Los Angeles Angles vs Milwaukee Brewers [03/23/2012] Spring Training Tickets at StubHub!|
+754709|Seattle Mariners at Milwaukee Brewers Spring Training|Seattle Mariners vs Milwaukee Brewers [03/13/2012] Spring Training Tickets at StubHub!|
+754710|Kansas City Royals at Milwaukee Brewers Spring Training|Kansas City Royals vs Milwaukee Brewers [03/27/2012] Spring Training Tickets at StubHub!|
+754711|San Francisco Giants at Milwaukee Brewers Spring Training|San Francisco Giants vs Milwaukee Brewers [03/04/2012] Spring Training Tickets at StubHub!|
+754712|San Diego Padres at Milwaukee Brewers Spring Training|San Diego Padres vs Milwaukee Brewers [03/15/2012] Spring Training Tickets at StubHub!|
+754713|Texas Rangers at Milwaukee Brewers Spring Training|Texas Rangers vs Milwaukee Brewers [03/18/2012] Spring Training Tickets at StubHub!|
+754714|Cincinnati Reds at Milwaukee Brewers Spring Training|Cincinnati Reds vs Milwaukee Brewers [03/08/2012] Spring Training Tickets at StubHub!|
+754715|Oakland Athletics at Milwaukee Brewers Spring Training|Oakland Athletics vs Milwaukee Brewers [03/06/2012] Spring Training Tickets at StubHub!|
+754716|Cleveland Indians at Milwaukee Brewers Spring Training|Cleveland Indians vs Milwaukee Brewers [03/09/2012] Spring Training Tickets at StubHub!|
+754717|Arizona Diamondbacks at Milwaukee Brewers Spring Training|Arizona Diamondbacks vs Milwaukee Brewers [03/28/2012] Spring Training Tickets at StubHub!|
+754718|Chicago Cubs at Milwaukee Brewers Spring Training|Chicago Cubs vs Milwaukee Brewers [03/10/2012] Spring Training Tickets at StubHub!|
+754719|Cincinnati Reds at Milwaukee Brewers Spring Training|Cincinnati Reds vs Milwaukee Brewers [03/29/2012] Spring Training Tickets at StubHub!|
+754720|Colorado Rockies at Milwaukee Brewers Spring Training|Colorado Rockies vs Milwaukee Brewers [03/11/2012] Spring Training Tickets at StubHub!|
+754721|San Francisco Giants at Milwaukee Brewers Spring Training|San Francisco Giants vs Milwaukee Brewers [04/01/2012] Spring Training Tickets at StubHub!|
+754722|Chicago White Sox at Milwaukee Brewers Spring Training|Chicago White Sox vs Milwaukee Brewers [03/24/2012] Spring Training Tickets at StubHub!|
+754781|Miami Marlins at Tampa Bay Rays Spring Training|Miami Marlins vs Tampa Bay Rays [03/25/2012] Spring Training Tickets at StubHub!|Spring Training - Miami Marlins at Tampa Bay Rays
+754782|Baltimore Orioles at Tampa Bay Rays Spring Training|Baltimore Orioles vs Tampa Bay Rays [03/05/2012] Spring Training Tickets at StubHub!|Spring Training - Baltimore Orioles at Tampa Bay Rays
+754783|Minnesota Twins at Tampa Bay Rays Spring Training|Minnesota Twins vs Tampa Bay Rays [04/02/2012] Spring Training Tickets at StubHub!|Spring Training - Minnesota Twins at Tampa Bay Rays
+754784|Philadelphia Phillies at Tampa Bay Rays Spring Training|Philadelphia Phillies vs Tampa Bay Rays [03/15/2012] Spring Training Tickets at StubHub!|Spring Training - Philadelphia Phillies at Tampa Bay Rays
+754785|Boston Red Sox at Tampa Bay Rays Spring Training|Boston Red Sox vs Tampa Bay Rays [03/18/2012] Spring Training Tickets at StubHub!|Spring Training - Boston Red Sox at Tampa Bay Rays
+754786|Baltimore Orioles at Tampa Bay Rays Spring Training|Baltimore Orioles vs Tampa Bay Rays [03/09/2012] Spring Training Tickets at StubHub!|Spring Training - Baltimore Orioles at Tampa Bay Rays
+754787|Pittsburgh Pirates at Tampa Bay Rays Spring Training|Pittsburgh Pirates vs Tampa Bay Rays [03/28/2012] Spring Training Tickets at StubHub!|Spring Training - Pittsburgh Pirates at Tampa Bay Rays
+754788|Pittsburgh Pirates at Tampa Bay Rays Spring Training|Pittsburgh Pirates vs Tampa Bay Rays [03/11/2012] Spring Training Tickets at StubHub!|Spring Training - Pittsburgh Pirates at Tampa Bay Rays
+754789|Minnesota Twins at Tampa Bay Rays Spring Training|Minnesota Twins vs Tampa Bay Rays [03/04/2012] Spring Training Tickets at StubHub!|Spring Training - Minnesota Twins at Tampa Bay Rays
+754790|Minnesota Twins at Tampa Bay Rays Spring Training|Minnesota Twins vs Tampa Bay Rays [03/06/2012] Spring Training Tickets at StubHub!|Spring Training - Minnesota Twins at Tampa Bay Rays
+754791|New York Yankees at Tampa Bay Rays Spring Training|New York Yankees vs Tampa Bay Rays [03/21/2012] Spring Training Tickets at StubHub!|Spring Training - New York Yankees at Tampa Bay Rays
+754792|Minnesota Twins at Tampa Bay Rays Spring Training|Minnesota Twins vs Tampa Bay Rays [03/12/2012] Spring Training Tickets at StubHub!|Spring Training - Minnesota Twins at Tampa Bay Rays
+754793|Toronto Blue Jays at Tampa Bay Rays Spring Training|Toronto Blue Jays vs Tampa Bay Rays [03/23/2012] Spring Training Tickets at StubHub!|Spring Training - Toronto Blue Jays at Tampa Bay Rays
+754794|Miami Marlins at Tampa Bay Rays Spring Training|Miami Marlins vs Tampa Bay Rays [03/14/2012] Spring Training Tickets at StubHub!|Spring Training - Miami Marlins at Tampa Bay Rays
+754795|Detroit Tigers at Tampa Bay Rays Spring Training|Detroit Tigers vs Tampa Bay Rays [03/08/2012] Spring Training Tickets at StubHub!|Spring Training - Detroit Tigers at Tampa Bay Rays (Split Squad)
+754796|Boston Red Sox at Tampa Bay Rays Spring Training|Boston Red Sox vs Tampa Bay Rays [03/31/2012] Spring Training Tickets at StubHub!|Spring Training - Boston Red Sox at Tampa Bay Rays
+755295|Philadelphia Phillies at Detroit Tigers Spring Training|Philadelphia Phillies vs Detroit Tigers [03/25/2012] Spring Training Tickets at StubHub!|Spring Training - Philadelphia Phillies at Detroit Tigers
+755296|New York Mets at Detroit Tigers Spring Training|New York Mets vs Detroit Tigers [03/12/2012] Spring Training Tickets at StubHub!|Spring Training - New York Mets at Detroit Tigers
+755297|Toronto Blue Jays at Detroit Tigers Spring Training|Toronto Blue Jays vs Detroit Tigers [04/02/2012] Spring Training Tickets at StubHub!|Spring Training - Toronto Blue Jays at Detroit Tigers
+755298|Miami Marlins at Detroit Tigers Spring Training|Miami Marlins vs Detroit Tigers [03/26/2012] Spring Training Tickets at StubHub!|Spring Training - Miami Marlins at Detroit Tigers
+755299|New York Mets at Detroit Tigers Spring Training|New York Mets vs Detroit Tigers [03/14/2012] Spring Training Tickets at StubHub!|Spring Training - New York Mets at Detroit Tigers
+755300|St Louis Cardinals at Detroit Tigers Spring Training|St Louis Cardinals vs Detroit Tigers [03/17/2012] Spring Training Tickets at StubHub!|Spring Training - St. Louis Cardinals at Detroit Tigers
+755301|Atlanta Braves at Detroit Tigers Spring Training|Atlanta Braves vs Detroit Tigers [03/04/2012] Spring Training Tickets at StubHub!|Spring Training - Atlanta Braves at Detroit Tigers
+755302|Baltimore Orioles at Detroit Tigers Spring Training|Baltimore Orioles vs Detroit Tigers [03/15/2012] Spring Training Tickets at StubHub!|Spring Training - Baltimore Orioles at Detroit Tigers
+755303|Toronto Blue Jays at Detroit Tigers Spring Training|Toronto Blue Jays vs Detroit Tigers [03/05/2012] Spring Training Tickets at StubHub!|Spring Training - Toronto Blue Jays at Detroit Tigers
+755304|Philadelphia Phillies at Detroit Tigers Spring Training|Philadelphia Phillies vs Detroit Tigers [03/09/2012] Spring Training Tickets at StubHub!|Spring Training - Philadelphia Phillies at Detroit Tigers
+755305|Atlanta Braves at Detroit Tigers Spring Training|Atlanta Braves vs Detroit Tigers [03/07/2012] Spring Training Tickets at StubHub!|Spring Training - Atlanta Braves at Detroit Tigers
+755306|Washington Nationals at Detroit Tigers Spring Training|Washington Nationals vs Detroit Tigers [03/10/2012] Spring Training Tickets at StubHub!|Spring Training - Washington Nationals at Detroit Tigers
+755307|Washington Nationals at Detroit Tigers Spring Training|Washington Nationals vs Detroit Tigers [03/29/2012] Spring Training Tickets at StubHub!|Spring Training - Washington Nationals at Detroit Tigers
+755308|Atlanta Braves at Detroit Tigers Spring Training|Atlanta Braves vs Detroit Tigers [03/20/2012] Spring Training Tickets at StubHub!|Spring Training - Atlanta Braves at Detroit Tigers
+755309|Houston Astros at Detroit Tigers Spring Training|Houston Astros vs Detroit Tigers [04/01/2012] Spring Training Tickets at StubHub!|Spring Training - Houston Astros at Detroit Tigers
+755311|Minnesota Twins at Detroit Tigers Spring Training|Minnesota Twins vs Detroit Tigers [03/21/2012] Spring Training Tickets at StubHub!|Spring Training - Minnesota Twins at Detroit Tigers
+755312|New York Yankees at Detroit Tigers Spring Training|New York Yankees vs Detroit Tigers [03/24/2012] Spring Training Tickets at StubHub!|Spring Training - New York Yankees at Detroit Tigers
+757474|Minnesota Twins at St Louis Cardinals Spring Training|Minnesota Twins vs St Louis Cardinals [03/25/2012] Spring Training Tickets at StubHub!|Spring Training - Minnesota Twins at St. Louis Cardinals
+757475|Miami Marlins at St Louis Cardinals Spring Training|Miami Marlins vs St Louis Cardinals [03/05/2012] Spring Training Tickets at StubHub!|Spring Training - Miami Marlins at St. Louis Cardinals
+757476|Washington Nationals at St Louis Cardinals Spring Training|Washington Nationals vs St Louis Cardinals [03/22/2012] Spring Training Tickets at StubHub!|Spring Training - Washington Nationals at St. Louis Cardinals
+757477|Miami Marlins at St Louis Cardinals Spring Training|Miami Marlins vs St Louis Cardinals [03/16/2012] Spring Training Tickets at StubHub!|Spring Training - Miami Marlins at St. Louis Cardinals
+757478|Miami Marlins at St Louis Cardinals Spring Training|Miami Marlins vs St Louis Cardinals [03/18/2012] Spring Training Tickets at StubHub!|Spring Training - Miami Marlins at St. Louis Cardinals
+757479|Detroit Tigers at St Louis Cardinals Spring Training|Detroit Tigers vs St Louis Cardinals [03/28/2012] Spring Training Tickets at StubHub!|Spring Training - Detroit Tigers at St. Louis Cardinals
+757480|New York Mets at St Louis Cardinals Spring Training|New York Mets vs St Louis Cardinals [03/30/2012] Spring Training Tickets at StubHub!|Spring Training - New York Mets at St. Louis Cardinals
+757481|New York Mets at St Louis Cardinals Spring Training|New York Mets vs St Louis Cardinals [03/26/2012] Spring Training Tickets at StubHub!|Spring Training - New York Mets at St. Louis Cardinals
+757482|Minnesota Twins at St Louis Cardinals Spring Training|Minnesota Twins vs St Louis Cardinals [04/01/2012] Spring Training Tickets at StubHub!|Spring Training - Washington Nationals at St. Louis Cardinals
+757483|New York Mets at St Louis Cardinals Spring Training|New York Mets vs St Louis Cardinals [03/21/2012] Spring Training Tickets at StubHub!|Spring Training - New York Mets at St. Louis Cardinals
+757484|Atlanta Braves at St Louis Cardinals Spring Training|Atlanta Braves vs St Louis Cardinals [03/12/2012] Spring Training Tickets at StubHub!|Spring Training - Atlanta Braves at St. Louis Cardinals
+757485|Houston Astros at St Louis Cardinals Spring Training|Houston Astros vs St Louis Cardinals [03/14/2012] Spring Training Tickets at StubHub!|Spring Training - Houston Astros at St. Louis Cardinals
+757486|Boston Red Sox at St Louis Cardinals Spring Training|Boston Red Sox vs St Louis Cardinals [03/08/2012] Spring Training Tickets at StubHub!|Spring Training - Boston Red Sox at St. Louis Cardinals
+757487|Miami Marlins at St Louis Cardinals Spring Training|Miami Marlins vs St Louis Cardinals [03/10/2012] Spring Training Tickets at StubHub!|Spring Training - St. Louis Cardinals at Miami Marlins


### PR DESCRIPTION
I was curious about how much python-Levenshtein affected fuzzywuzzy and wether pypy would be able to beat it's speed. For this I recovered some old data that  had been made available by @acslater00 for benchmarks. Wrote a test using that data and added it to the end of benchmarks.py. And then ran the benchmarks in 4 different virtualenvs.

 - python 2
 - python 2 + python-Levenshtein
 - pypy
 - pypy + python-Levenshtein

I did not run on python 3 nor pypy 3 because benchmarks.py is not ready for python 3 at the moment.

Locally the results for the last test were as follows.

 - python 2:
```Total time: 41.679526s. Average run: 416.795ms.```
 - python 2 + python-Levenshtein:
```Total time: 2.153638s. Average run: 21.536ms.```
 - pypy:
```Total time: 7.516456s. Average run: 75.165ms.```
 - pypy + python-Levenshtein:
```Total time: 3.690244s. Average run: 36.902ms.```


Here is a small ascii diagram:
```
##########################################  python 2
##                                          python 2 + python-Levenshtein
########                                    pypy
####                                        pypy + python-Levenshtein

# ~= 1s
```

I think it is pretty obvious that python-Levenshtein is very important for fuzzywuzzy's speed. I maintain that the warning should not be raised when missing. Instead I defend that python-Levenshtein should be a required dependency.