### PR TITLE
Improving fuzzywuzzy performance

### DIFF
--- a/fuzzywuzzy/fuzz.py
+++ b/fuzzywuzzy/fuzz.py
@@ -94,10 +94,11 @@ def partial_ratio(s1, s2):
 # Advanced Scoring Functions #
 ##############################
 
-def _process_and_sort(s, force_ascii):
+def _process_and_sort(s, force_ascii, full_process=True):
     """Return a cleaned string with token sorted."""
     # pull tokens
-    tokens = utils.full_process(s, force_ascii=force_ascii).split()
+    ts = utils.full_process(s, force_ascii=force_ascii) if full_process else s
+    tokens = ts.split()
 
     # sort tokens and join
     sorted_string = u" ".join(sorted(tokens))
@@ -109,9 +110,9 @@ def _process_and_sort(s, force_ascii):
 #   sort those tokens and take ratio of resulting joined strings
 #   controls for unordered string elements
 @utils.check_for_none
-def _token_sort(s1, s2, partial=True, force_ascii=True):
-    sorted1 = _process_and_sort(s1, force_ascii)
-    sorted2 = _process_and_sort(s2, force_ascii)
+def _token_sort(s1, s2, partial=True, force_ascii=True, full_process=True):
+    sorted1 = _process_and_sort(s1, force_ascii, full_process=full_process)
+    sorted2 = _process_and_sort(s2, force_ascii, full_process=full_process)
 
     if partial:
         return partial_ratio(sorted1, sorted2)
@@ -119,22 +120,22 @@ def _token_sort(s1, s2, partial=True, force_ascii=True):
         return ratio(sorted1, sorted2)
 
 
-def token_sort_ratio(s1, s2, force_ascii=True):
+def token_sort_ratio(s1, s2, force_ascii=True, full_process=True):
     """Return a measure of the sequences' similarity between 0 and 100
     but sorting the token before comparing.
     """
-    return _token_sort(s1, s2, partial=False, force_ascii=force_ascii)
+    return _token_sort(s1, s2, partial=False, force_ascii=force_ascii, full_process=full_process)
 
 
-def partial_token_sort_ratio(s1, s2, force_ascii=True):
+def partial_token_sort_ratio(s1, s2, force_ascii=True, full_process=True):
     """Return the ratio of the most similar substring as a number between
     0 and 100 but sorting the token before comparing.
     """
-    return _token_sort(s1, s2, partial=True, force_ascii=force_ascii)
+    return _token_sort(s1, s2, partial=True, force_ascii=force_ascii, full_process=full_process)
 
 
 @utils.check_for_none
-def _token_set(s1, s2, partial=True, force_ascii=True):
+def _token_set(s1, s2, partial=True, force_ascii=True, full_process=True):
     """Find all alphanumeric tokens in each string...
         - treat them as a set
         - construct two strings of the form:
@@ -142,8 +143,8 @@ def _token_set(s1, s2, partial=True, force_ascii=True):
         - take ratios of those two strings
         - controls for unordered partial matches"""
 
-    p1 = utils.full_process(s1, force_ascii=force_ascii)
-    p2 = utils.full_process(s2, force_ascii=force_ascii)
+    p1 = utils.full_process(s1, force_ascii=force_ascii) if full_process else s1
+    p2 = utils.full_process(s2, force_ascii=force_ascii) if full_process else s2
 
     if not utils.validate_string(p1):
         return 0
@@ -151,8 +152,8 @@ def _token_set(s1, s2, partial=True, force_ascii=True):
         return 0
 
     # pull tokens
-    tokens1 = set(utils.full_process(p1).split())
-    tokens2 = set(utils.full_process(p2).split())
+    tokens1 = set(p1.split())
+    tokens2 = set(p2.split())
 
     intersection = tokens1.intersection(tokens2)
     diff1to2 = tokens1.difference(tokens2)
@@ -183,12 +184,12 @@ def _token_set(s1, s2, partial=True, force_ascii=True):
     return max(pairwise)
 
 
-def token_set_ratio(s1, s2, force_ascii=True):
-    return _token_set(s1, s2, partial=False, force_ascii=force_ascii)
+def token_set_ratio(s1, s2, force_ascii=True, full_process=True):
+    return _token_set(s1, s2, partial=False, force_ascii=force_ascii, full_process=full_process)
 
 
-def partial_token_set_ratio(s1, s2, force_ascii=True):
-    return _token_set(s1, s2, partial=True, force_ascii=force_ascii)
+def partial_token_set_ratio(s1, s2, force_ascii=True, full_process=True):
+    return _token_set(s1, s2, partial=True, force_ascii=force_ascii, full_process=full_process)
 
 
 ###################
@@ -245,15 +246,15 @@ def WRatio(s1, s2, force_ascii=True):
 
     if try_partial:
         partial = partial_ratio(p1, p2) * partial_scale
-        ptsor = partial_token_sort_ratio(p1, p2, force_ascii=force_ascii) \
+        ptsor = partial_token_sort_ratio(p1, p2, full_process=False) \
             * unbase_scale * partial_scale
-        ptser = partial_token_set_ratio(p1, p2, force_ascii=force_ascii) \
+        ptser = partial_token_set_ratio(p1, p2, full_process=False) \
             * unbase_scale * partial_scale
 
         return utils.intr(max(base, partial, ptsor, ptser))
     else:
-        tsor = token_sort_ratio(p1, p2, force_ascii=force_ascii) * unbase_scale
-        tser = token_set_ratio(p1, p2, force_ascii=force_ascii) * unbase_scale
+        tsor = token_sort_ratio(p1, p2, full_process=False) * unbase_scale
+        tser = token_set_ratio(p1, p2, full_process=False) * unbase_scale
 
         return utils.intr(max(base, tsor, tser))
 

--- a/fuzzywuzzy/process.py
+++ b/fuzzywuzzy/process.py
@@ -30,6 +30,83 @@ from . import fuzz
 from . import utils
 
 
+def extractWithoutOrder(query, choices, processor=None, scorer=None):
+    """Select the best match in a list or dictionary of choices.
+
+    Find best matches in a list or dictionary of choices, return a
+    generator of tuples containing the match and it's score. If a dictionary
+    is used, also returns the key for each match.
+
+    Arguments:
+        query: An object representing the thing we want to find.
+        choices: An iterable or dictionary-like object containing choices
+            to be matched against the query. Dictionary arguments of
+            {key: value} pairs will attempt to match the query against
+            each value.
+        processor: Optional function of the form f(a) -> b, where a is an
+            individual choice and b is the choice to be used in matching.
+
+            This can be used to match against, say, the first element of
+            a list:
+
+            lambda x: x[0]
+
+            Defaults to fuzzywuzzy.utils.full_process().
+        scorer: Optional function for scoring matches between the query and
+            an individual processed choice. This should be a function
+            of the form f(query, choice) -> int.
+
+            By default, fuzz.WRatio() is used and expects both query and
+            choice to be strings.
+
+    Returns:
+        Generator of tuples containing the match and its score.
+
+        If a list is used for choices, then the result will be 2-tuples.
+        If a dictionary is used, then the result will be 3-tuples containing
+        he key for each match.
+
+        For example, searching for 'bird' in the dictionary
+
+        {'bard': 'train', 'dog': 'man'}
+
+        may return
+
+        ('train', 22, 'bard'), ('man', 0, 'dog')
+    """
+
+    if choices is None:
+        raise StopIteration
+
+    # Catch generators without lengths
+    try:
+        if len(choices) == 0:
+            raise StopIteration
+    except TypeError:
+        pass
+
+    # default, turn whatever the choice is into a workable string
+    if not processor:
+        processor = utils.full_process
+
+    # default: wratio
+    if not scorer:
+        scorer = fuzz.WRatio
+
+    try:
+        # See if choices is a dictionary-like object.
+        for key, choice in choices.items():
+            processed = processor(choice)
+            score = scorer(query, processed)
+            yield (choice, score, key)
+    except AttributeError:
+        # It's a list; just iterate over it.
+        for choice in choices:
+            processed = processor(choice)
+            score = scorer(query, processed)
+            yield (choice, score)
+
+
 def extract(query, choices, processor=None, scorer=None, limit=5):
     """Select the best match in a list or dictionary of choices.
 
@@ -77,41 +154,9 @@ def extract(query, choices, processor=None, scorer=None, limit=5):
         [('train', 22, 'bard'), ('man', 0, 'dog')]
     """
 
-    if choices is None:
-        return []
-
-    # Catch generators without lengths
-    try:
-        if len(choices) == 0:
-            return []
-    except TypeError:
-        pass
-
-    # default, turn whatever the choice is into a workable string
-    if not processor:
-        processor = utils.full_process
-
-    # default: wratio
-    if not scorer:
-        scorer = fuzz.WRatio
-
-    sl = []
-
-    try:
-        # See if choices is a dictionary-like object.
-        for key, choice in choices.items():
-            processed = processor(choice)
-            score = scorer(query, processed)
-            sl.append((choice, score, key))
-    except AttributeError:
-        # It's a list; just iterate over it.
-        for choice in choices:
-            processed = processor(choice)
-            score = scorer(query, processed)
-            sl.append((choice, score))
-
-    sl.sort(key=lambda i: i[1], reverse=True)
-    return sl[:limit]
+    sl = extractWithoutOrder(query, choices, processor, scorer)
+    res = utils.partial_sort(sl, key=lambda i: i[1], limit=limit, reverse=True)
+    return [el for el in res]
 
 
 def extractBests(query, choices, processor=None, scorer=None, score_cutoff=0, limit=5):
@@ -133,8 +178,10 @@ def extractBests(query, choices, processor=None, scorer=None, score_cutoff=0, li
 
     Returns: A a list of (match, score) tuples.
     """
-    best_list = extract(query, choices, processor, scorer, limit)
-    return list(itertools.takewhile(lambda x: x[1] >= score_cutoff, best_list))
+
+    best_list = (el for el in extractWithoutOrder(query, choices, processor, scorer) if el[1] >= score_cutoff)
+    res = utils.partial_sort(best_list, limit=limit, key=lambda i: i[1], reverse=True)
+    return [el for el in res]
 
 
 def extractOne(query, choices, processor=None, scorer=None, score_cutoff=0):
@@ -158,10 +205,8 @@ def extractOne(query, choices, processor=None, scorer=None, score_cutoff=0):
         A tuple containing a single match and its score, if a match
         was found that was above score_cutoff. Otherwise, returns None.
     """
-    best_list = extract(query, choices, processor, scorer, limit=1)
-    if len(best_list) > 0 and best_list[0][1] >= score_cutoff:
-        return best_list[0]
-    return None
+    best_list = extractBests(query, choices, processor, scorer, score_cutoff=score_cutoff, limit=1)
+    return best_list[0] if len(best_list) > 0 else None
 
 
 def dedupe(contains_dupes, threshold=70, scorer=fuzz.token_set_ratio):

--- a/fuzzywuzzy/utils.py
+++ b/fuzzywuzzy/utils.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 import sys
 import functools
-import heapq
 
 from fuzzywuzzy.string_processing import StringProcessor
 
@@ -104,30 +103,3 @@ class RankedToken:
 
     def __lt__(self, other):
         return self.rank < other.rank
-
-
-def partial_sort(collection, key, limit, reverse=False):
-    """Utility to sort the first n elements of a collection.
-    Provide a better performance than sorting the entire collection
-    and choosing the first elements n.
-
-    Arguments:
-        collection: collection from where first elements should be extract.
-        key: A callable key selector .
-        limit: number of elements to return.
-        reverse: if true the last elements will be returned.
-
-    Returns:
-        Generator for the first ordered elements
-    """
-    h = []
-    for item in collection:
-        rank = key(item) if not reverse else -key(item)
-        heapq.heappush(h, RankedToken(rank, item))
-    if limit is None:
-        limit = len(h)
-    try:
-        for index in range(0, limit):
-            yield heapq.heappop(h).item
-    except IndexError:
-        pass

--- a/fuzzywuzzy/utils.py
+++ b/fuzzywuzzy/utils.py
@@ -90,16 +90,3 @@ def full_process(s, force_ascii=False):
 def intr(n):
     '''Returns a correctly rounded integer'''
     return int(round(n))
-
-
-@functools.total_ordering
-class RankedToken:
-    def __init__(self, rank, item):
-        self.rank = rank
-        self.item = item
-
-    def __eq__(self, other):
-        return self.item == other.item
-
-    def __lt__(self, other):
-        return self.rank < other.rank

--- a/fuzzywuzzy/utils.py
+++ b/fuzzywuzzy/utils.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 import sys
 import functools
+import heapq
 
 from fuzzywuzzy.string_processing import StringProcessor
 
@@ -90,3 +91,43 @@ def full_process(s, force_ascii=False):
 def intr(n):
     '''Returns a correctly rounded integer'''
     return int(round(n))
+
+
+@functools.total_ordering
+class RankedToken:
+    def __init__(self, rank, item):
+        self.rank = rank
+        self.item = item
+
+    def __eq__(self, other):
+        return self.item == other.item
+
+    def __lt__(self, other):
+        return self.rank < other.rank
+
+
+def partial_sort(collection, key, limit, reverse=False):
+    """Utility to sort the first n elements of a collection.
+    Provide a better performance than sorting the entire collection
+    and choosing the first elements n.
+
+    Arguments:
+        collection: collection from where first elements should be extract.
+        key: A callable key selector .
+        limit: number of elements to return.
+        reverse: if true the last elements will be returned.
+
+    Returns:
+        Generator for the first ordered elements
+    """
+    h = []
+    for item in collection:
+        rank = key(item) if not reverse else -key(item)
+        heapq.heappush(h, RankedToken(rank, item))
+    if limit is None:
+        limit = len(h)
+    try:
+        for index in range(0, limit):
+            yield heapq.heappop(h).item
+    except IndexError:
+        pass


### PR DESCRIPTION
This PR improves fuzzywuzzy performance by computing full_process only once by string. 
During performance analysis, I found out than fuzzywuzzy is performing many times string normalization (utils.full_process) on the same strings. As these operations are quite slow, it is generating an important overhead on  the total time of the operation.
Another optimization I made is a minor tweak on how to compute first elements of the results without computing a full sort (using heapq.nlargest).

When computing the best match on a huge list (2.5 million entries), these changes result in a performance of 110.78 secs versus 165.52 secs (33% improvements).
