### PR TITLE
Adding return_dupes functionality

### DIFF
--- a/fuzzywuzzy/process.py
+++ b/fuzzywuzzy/process.py
@@ -252,7 +252,7 @@ def dedupe(contains_dupes, threshold=70, scorer=fuzz.token_set_ratio, return_dup
             Out: ['Frodo Baggins', 'Samwise G.', 'Bilbo Baggins', 'Gandalf']
         """
 
-    extractor = set()
+    extractor = []
 
     # iterate over items in *contains_dupes*
     dupe_mapping = {}
@@ -265,7 +265,7 @@ def dedupe(contains_dupes, threshold=70, scorer=fuzz.token_set_ratio, return_dup
         # if there is only 1 item in *filtered*, no duplicates were found so
         # append to *extracted*
         if len(filtered) == 1:
-            extractor.add(filtered[0][0])
+            dupe_mapping[filtered[0][0]] = filtered[0][0]
         else:
             # alpha sort
             filtered = sorted(filtered, key=lambda x: x[0])
@@ -273,17 +273,9 @@ def dedupe(contains_dupes, threshold=70, scorer=fuzz.token_set_ratio, return_dup
             filter_sort = sorted(
                 filtered, key=lambda x: len(x[0]), reverse=True)
             # take first item as our 'canonical example'
-            example = filter_sort[0][0]
-            extractor.add(example)
-            if return_dupes:
-                if item in dupe_mapping:
-                    dupe_mapping[item].append(example)
-                else:
-                    dupe_mapping[item] = [example]
+            dupe_mapping[item] = filter_sort[0][0]
 
     if return_dupes:
-        for key in dupe_mapping.keys():
-            dupe_mapping[key] = sorted(list(set(dupe_mapping[key])))
-        return list(extractor), dupe_mapping
+        return set(dupe_mapping.values()), dupe_mapping
     else:
-        return list(extractor)
+        return set(dupe_mapping.values())

--- a/test_fuzzywuzzy.py
+++ b/test_fuzzywuzzy.py
@@ -498,6 +498,29 @@ class ProcessTest(unittest.TestCase):
         result = process.dedupe(contains_dupes)
         self.assertEqual(result, deduped_list)
 
+    def test_dedupe_returns(self):
+        """
+        Test `dedupe` with `return_dupes=True`.
+        """
+        # Test 1
+        contains_dupes = ['Frodo Baggins', 'Tom Sawyer', 'Bilbo Baggin', 'Samuel L. Jackson', 'F. Baggins', 'Frody Baggins', 'Bilbo Baggins']
+
+        result, mapping = process.dedupe(contains_dupes, return_dupes=True)
+
+        # Check result
+        self.assertTrue(len(result) < len(contains_dupes))
+
+        # Check mapping
+        correct_mapping = {'Bilbo Baggin': ['Bilbo Baggins'],
+         'Bilbo Baggins': ['Bilbo Baggins'],
+         'F. Baggins': ['Bilbo Baggins'],
+         'Frodo Baggins': ['Frodo Baggins'],
+         'Frody Baggins': ['Frodo Baggins']}
+        self.assertEqual(sorted(correct_mapping.keys()), sorted(mapping.keys()))
+        for key in mapping.keys():
+            self.assertTrue(key in correct_mapping)
+            self.assertEqual(sorted(correct_mapping[key]), sorted(mapping[key]))              
+
 
 class TestCodeFormat(unittest.TestCase):
     def test_pep8_conformance(self):

--- a/test_fuzzywuzzy.py
+++ b/test_fuzzywuzzy.py
@@ -496,7 +496,7 @@ class ProcessTest(unittest.TestCase):
         deduped_list = ['Tom', 'Dick', 'Harry']
 
         result = process.dedupe(contains_dupes)
-        self.assertEqual(result, deduped_list)
+        self.assertEqual(sorted(result), sorted(deduped_list))
 
     def test_dedupe_returns(self):
         """
@@ -511,11 +511,13 @@ class ProcessTest(unittest.TestCase):
         self.assertTrue(len(result) < len(contains_dupes))
 
         # Check mapping
-        correct_mapping = {'Bilbo Baggin': ['Bilbo Baggins'],
-         'Bilbo Baggins': ['Bilbo Baggins'],
-         'F. Baggins': ['Bilbo Baggins'],
-         'Frodo Baggins': ['Frodo Baggins'],
-         'Frody Baggins': ['Frodo Baggins']}
+        correct_mapping = {'Bilbo Baggin': 'Bilbo Baggins',
+                             'Bilbo Baggins': 'Bilbo Baggins',
+                             'F. Baggins': 'Bilbo Baggins',
+                             'Frodo Baggins': 'Frodo Baggins',
+                             'Frody Baggins': 'Frodo Baggins',
+                             'Samuel L. Jackson': 'Samuel L. Jackson',
+                             'Tom Sawyer': 'Tom Sawyer'}
         self.assertEqual(sorted(correct_mapping.keys()), sorted(mapping.keys()))
         for key in mapping.keys():
             self.assertTrue(key in correct_mapping)


### PR DESCRIPTION
Adds functionality to `process.dedupe()` to return the dupe mapping, which tracks which tokens were removed based on which match.
