### PR TITLE
Tox config file and a few updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ doc/_build
 
 # Generated man page
 doc/aws_hostname.1
+
+# tox
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ python:
   - pypy
   - pypy3
 install:
-  - pip install pep8
+  - pip install pytest pycodestyle
 script:
-  - python test_fuzzywuzzy.py
+  - py.test
 notifications:
   on_success: always

--- a/test_fuzzywuzzy.py
+++ b/test_fuzzywuzzy.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import unittest
 import re
 import sys
-import pep8
+import pycodestyle
 
 from fuzzywuzzy import fuzz
 from fuzzywuzzy import process
@@ -501,7 +501,7 @@ class ProcessTest(unittest.TestCase):
 
 class TestCodeFormat(unittest.TestCase):
     def test_pep8_conformance(self):
-        pep8style = pep8.StyleGuide(quiet=True)
+        pep8style = pycodestyle.StyleGuide(quiet=True)
         pep8style.options.ignore = pep8style.options.ignore + tuple(['E501'])
         pep8style.input_dir('fuzzywuzzy')
         result = pep8style.check_files()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py2, py3, pypy, pypy3
+skip_missing_interpreters = True
+
+[testenv]
+deps = pytest
+       pycodestyle
+commands = py.test


### PR DESCRIPTION
In this pull request I added a tox.ini cofig file for the tox and detox automatic testing tools.
The config file sets environments for python2, python3, pypy, and pypy3.
Missing interpreters will be skipped.
The tests run using py.test.

I also set travis config to use py.test in order to match the tox file.

In the tests themselves I updated the use of the pep8 module to use pycodestyle.