### PR TITLE
Process query with processor in extractWithoutOrder

### DIFF
--- a/fuzzywuzzy/process.py
+++ b/fuzzywuzzy/process.py
@@ -100,18 +100,21 @@ def extractWithoutOrder(query, choices, processor=None, scorer=None, score_cutof
     if not processor:
         processor = utils.full_process
 
+    # Run the processor on the input query.
+    processed_query = processor(query)
+
     try:
         # See if choices is a dictionary-like object.
         for key, choice in choices.items():
             processed = processor(choice)
-            score = scorer(query, processed)
+            score = scorer(processed_query, processed)
             if score >= score_cutoff:
                 yield (choice, score, key)
     except AttributeError:
         # It's a list; just iterate over it.
         for choice in choices:
             processed = processor(choice)
-            score = scorer(query, processed)
+            score = scorer(processed_query, processed)
             if score >= score_cutoff:
                 yield (choice, score)
 

--- a/test_fuzzywuzzy.py
+++ b/test_fuzzywuzzy.py
@@ -498,6 +498,16 @@ class ProcessTest(unittest.TestCase):
         result = process.dedupe(contains_dupes)
         self.assertEqual(result, deduped_list)
 
+    def test_simplematch(self):
+        basic_string = 'a, b'
+        match_strings = ['a, b']
+
+        result = process.extractOne(basic_string, match_strings, scorer=fuzz.ratio)
+        part_result = process.extractOne(basic_string, match_strings, scorer=fuzz.partial_ratio)
+
+        self.assertEqual(result, ('a, b', 100))
+        self.assertEqual(part_result, ('a, b', 100))
+
 
 class TestCodeFormat(unittest.TestCase):
     def test_pep8_conformance(self):


### PR DESCRIPTION
Process the query in process.extractWithoutOrder when using a scorer which does not do so.

Closes #139 