### PR TITLE
Clarify default behaviour of extract / Add tests for matching strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 \#*
 .#*
 *#
-dist
 
 # Build files
 build
@@ -31,6 +30,9 @@ doc/aws_hostname.1
 
 # Hypothesis
 .hypothesis/
+
+# py.test
+.cache/
 
 # Pycharm
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ doc/aws_hostname.1
 
 # tox
 .tox
+
+# hypothesis
+.hypothesis/

--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,9 @@ doc/aws_hostname.1
 # tox
 .tox
 
-# Hypothesis
-.hypothesis/
+# Hypothesis - keep the examples database
+.hypothesis/tmp
+.hypothesis/unicodedata
 
 # py.test
 .cache/

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,8 @@ doc/aws_hostname.1
 # tox
 .tox
 
-# hypothesis
+# Hypothesis
 .hypothesis/
+
+# Pycharm
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,24 @@
 language: python
-python:
-  - 2.6
-  - 2.7
-  - 3.3
-  - 3.4
-  - 3.5
-  - pypy
-  - pypy3
+matrix:
+  include:
+  - python: "2.7"
+    env: TEST_SUITE=py.test
+  - python: "3.3"
+    env: TEST_SUITE=py.test
+  - python: "3.4"
+    env: TEST_SUITE=py.test
+  - python: "3.5"
+    env: TEST_SUITE=py.test
+  - python: "pypy"
+    env: TEST_SUITE=py.test
+  - python: "2.6"
+    env: TEST_SUITE="py.test test_fuzzywuzzy.py"
+  - python: "pypy3"
+    env: TEST_SUITE="py.test test_fuzzywuzzy.py"
 install:
   - pip install pytest pycodestyle
+  - if [ $TRAVIS_PYTHON_VERSION != 2.6 -a $TRAVIS_PYTHON_VERSION != "pypy3" ]; then pip install hypothesis; fi;
 script:
-  - py.test
+  - $TEST_SUITE
 notifications:
   on_success: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ matrix:
   - python: "pypy"
     env: TEST_SUITE=py.test
   - python: "2.6"
-    env: TEST_SUITE="py.test test_fuzzywuzzy.py"
+    env: TEST_SUITE="py.test test_fuzzywuzzy.py test_fuzzywuzzy_pytest.py"
   - python: "pypy3"
-    env: TEST_SUITE="py.test test_fuzzywuzzy.py"
+    env: TEST_SUITE="py.test test_fuzzywuzzy.py test_fuzzywuzzy_pytest.py"
 install:
   - pip install pytest pycodestyle
   - if [ $TRAVIS_PYTHON_VERSION != 2.6 -a $TRAVIS_PYTHON_VERSION != "pypy3" ]; then pip install hypothesis; fi;

--- a/fuzzywuzzy/process.py
+++ b/fuzzywuzzy/process.py
@@ -92,7 +92,10 @@ def extractWithoutOrder(query, choices, processor=default_processor, scorer=defa
         pass
 
     # If the scorer performs full_ratio with force ascii don't run full_process twice
-    if scorer in [fuzz.WRatio, fuzz.QRatio] and processor == utils.full_process:
+    if scorer in [fuzz.WRatio, fuzz.QRatio,
+                  fuzz.token_set_ratio, fuzz.token_sort_ratio,
+                  fuzz.partial_token_set_ratio, fuzz.partial_token_sort_ratio] \
+            and processor == utils.full_process:
         processor = no_process
 
     # If the processor was removed by setting it to None

--- a/fuzzywuzzy/process.py
+++ b/fuzzywuzzy/process.py
@@ -28,9 +28,14 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 from . import fuzz
 from . import utils
 import heapq
+from warnings import warn
 
 
-def extractWithoutOrder(query, choices, processor=utils.full_process, scorer=fuzz.WRatio, score_cutoff=0):
+default_scorer = fuzz.WRatio
+default_processor = utils.full_process
+
+
+def extractWithoutOrder(query, choices, processor=default_processor, scorer=default_scorer, score_cutoff=0):
     """Select the best match in a list or dictionary of choices.
 
     Find best matches in a list or dictionary of choices, return a
@@ -98,6 +103,9 @@ def extractWithoutOrder(query, choices, processor=utils.full_process, scorer=fuz
     # Run the processor on the input query.
     processed_query = processor(query)
 
+    if len(processed_query) == 0:
+        warn("Applied processor reduces input query to empty string, no matches will be found.")
+
     try:
         # See if choices is a dictionary-like object.
         for key, choice in choices.items():
@@ -114,7 +122,7 @@ def extractWithoutOrder(query, choices, processor=utils.full_process, scorer=fuz
                 yield (choice, score)
 
 
-def extract(query, choices, processor=utils.full_process, scorer=fuzz.WRatio, limit=5):
+def extract(query, choices, processor=default_processor, scorer=default_scorer, limit=5):
     """Select the best match in a list or dictionary of choices.
 
     Find best matches in a list or dictionary of choices, return a
@@ -164,7 +172,7 @@ def extract(query, choices, processor=utils.full_process, scorer=fuzz.WRatio, li
         sorted(sl, key=lambda i: i[1], reverse=True)
 
 
-def extractBests(query, choices, processor=utils.full_process, scorer=fuzz.WRatio, score_cutoff=0, limit=5):
+def extractBests(query, choices, processor=default_processor, scorer=default_scorer, score_cutoff=0, limit=5):
     """Get a list of the best matches to a collection of choices.
 
     Convenience function for getting the choices with best scores.
@@ -189,7 +197,7 @@ def extractBests(query, choices, processor=utils.full_process, scorer=fuzz.WRati
         sorted(best_list, key=lambda i: i[1], reverse=True)
 
 
-def extractOne(query, choices, processor=utils.full_process, scorer=fuzz.WRatio, score_cutoff=0):
+def extractOne(query, choices, processor=default_processor, scorer=default_scorer, score_cutoff=0):
     """Find the single best match above a score in a list of choices.
 
     This is a convenience method which returns the single best choice.

--- a/fuzzywuzzy/process.py
+++ b/fuzzywuzzy/process.py
@@ -28,8 +28,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 from . import fuzz
 from . import utils
 import heapq
-from warnings import warn
+import warnings
 
+warnings.simplefilter('always')
 
 default_scorer = fuzz.WRatio
 default_processor = utils.full_process
@@ -91,13 +92,6 @@ def extractWithoutOrder(query, choices, processor=default_processor, scorer=defa
     except TypeError:
         pass
 
-    # If the scorer performs full_ratio with force ascii don't run full_process twice
-    if scorer in [fuzz.WRatio, fuzz.QRatio,
-                  fuzz.token_set_ratio, fuzz.token_sort_ratio,
-                  fuzz.partial_token_set_ratio, fuzz.partial_token_sort_ratio] \
-            and processor == utils.full_process:
-        processor = no_process
-
     # If the processor was removed by setting it to None
     # perfom a noop as it still needs to be a function
     if processor is None:
@@ -107,7 +101,14 @@ def extractWithoutOrder(query, choices, processor=default_processor, scorer=defa
     processed_query = processor(query)
 
     if len(processed_query) == 0:
-        warn("Applied processor reduces input query to empty string, no matches will be found.")
+        warnings.warn("Applied processor reduces input query to empty string, all comparisons will have score 0.")
+
+    # If the scorer performs full_ratio with force ascii don't run full_process twice
+    if scorer in [fuzz.WRatio, fuzz.QRatio,
+                  fuzz.token_set_ratio, fuzz.token_sort_ratio,
+                  fuzz.partial_token_set_ratio, fuzz.partial_token_sort_ratio] \
+            and processor == utils.full_process:
+        processor = no_process
 
     try:
         # See if choices is a dictionary-like object.

--- a/test_fuzzywuzzy_hypothesis.py
+++ b/test_fuzzywuzzy_hypothesis.py
@@ -1,8 +1,10 @@
+import warnings
+from itertools import product
+from functools import partial
+
 from hypothesis import given, assume, settings
 import hypothesis.strategies as st
 import pytest
-from itertools import product
-from functools import partial
 
 from fuzzywuzzy import fuzz, process, utils
 
@@ -72,3 +74,13 @@ def test_identical_strings_extracted(scorer, processor, data):
 
     # Check the original is in the list
     assert (choice, 100) in result
+
+
+def test_process_warning():
+    """Check that a string reduced to 0 by processor raises a warning"""
+    query = ':::::::'
+    choices = [':::::::']
+    with warnings.catch_warnings(record=True) as w:
+        result = process.extractOne(query, choices)
+        assert issubclass(w[-1].category, UserWarning)
+        assert result == (query, 0)

--- a/test_fuzzywuzzy_hypothesis.py
+++ b/test_fuzzywuzzy_hypothesis.py
@@ -1,0 +1,59 @@
+import unittest
+from hypothesis import given, assume, settings
+import hypothesis.strategies as st
+
+from fuzzywuzzy import fuzz, process, utils
+
+
+class ProcessHypothesisTests(unittest.TestCase):
+
+    @given(st.data())
+    @settings(max_examples=100)
+    def test_random_strings_processed(self, data):
+        # Draw a list of random strings
+        strings = data.draw(
+            st.lists(st.text(min_size=10, max_size=100),
+                     min_size=1, max_size=50))
+        # Draw a random integer for the index in that list
+        choiceidx = data.draw(st.integers(min_value=0, max_value=(len(strings) - 1)))
+        choice = strings[choiceidx]
+
+        # Check full process doesn't make our choice the empty string
+        assume(utils.full_process(choice) != '')
+
+        result = process.extractOne(choice, strings, scorer=fuzz.ratio, processor=utils.full_process)
+
+        # Check we get a result
+        self.assertIsNotNone(result)
+
+        # Check the result is a perfect match according to fuzz.ratio
+        self.assertEqual(result[1], 100)
+
+        # Assert the results are equal after processing
+        self.assertEqual(utils.full_process(choice),
+                         utils.full_process(result[0]))
+
+    @given(st.data())
+    @settings(max_examples=100)
+    def test_random_strings_unprocessed(self, data):
+        # Draw a list of random strings
+        strings = data.draw(
+            st.lists(st.text(min_size=10, max_size=100),
+                     min_size=1, max_size=50))
+        # Draw a random integer for the index in that list
+        choiceidx = data.draw(st.integers(min_value=0, max_value=(len(strings) - 1)))
+        choice = strings[choiceidx]
+
+        result = process.extractOne(choice, strings,
+                                    scorer=fuzz.ratio,
+                                    processor=lambda x: x)
+
+        # Check we get a result
+        self.assertIsNotNone(result)
+
+        # Check the result is a perfect match according to fuzz.ratio
+        self.assertEqual(result[1], 100)
+
+        # Assert the results are equal after processing
+        self.assertEqual(choice,
+                         result[0])

--- a/test_fuzzywuzzy_hypothesis.py
+++ b/test_fuzzywuzzy_hypothesis.py
@@ -1,4 +1,3 @@
-import warnings
 from itertools import product
 from functools import partial
 
@@ -76,11 +75,3 @@ def test_identical_strings_extracted(scorer, processor, data):
     assert (choice, 100) in result
 
 
-def test_process_warning():
-    """Check that a string reduced to 0 by processor raises a warning"""
-    query = ':::::::'
-    choices = [':::::::']
-    with warnings.catch_warnings(record=True) as w:
-        result = process.extractOne(query, choices)
-        assert issubclass(w[-1].category, UserWarning)
-        assert result == (query, 0)

--- a/test_fuzzywuzzy_hypothesis.py
+++ b/test_fuzzywuzzy_hypothesis.py
@@ -37,9 +37,9 @@ def scorers_processors():
                          scorers_processors())
 @given(data=st.data())
 @settings(max_examples=100)
-def test_random_strings_identical(scorer, processor, data):
+def test_identical_strings_extracted(scorer, processor, data):
     """
-    Test that in a random set of strings perfect matches return correctly
+    Test that identical strings will always return a perfect match.
 
     :param scorer:
     :param processor:

--- a/test_fuzzywuzzy_hypothesis.py
+++ b/test_fuzzywuzzy_hypothesis.py
@@ -23,7 +23,11 @@ def scorers_processors():
         [(fuzz.WRatio, partial(utils.full_process, force_ascii=True)),
          (fuzz.QRatio, partial(utils.full_process, force_ascii=True)),
          (fuzz.UWRatio, partial(utils.full_process, force_ascii=False)),
-         (fuzz.UQRatio, partial(utils.full_process, force_ascii=False))]
+         (fuzz.UQRatio, partial(utils.full_process, force_ascii=False)),
+         (fuzz.token_set_ratio, partial(utils.full_process, force_ascii=True)),
+         (fuzz.token_sort_ratio, partial(utils.full_process, force_ascii=True)),
+         (fuzz.partial_token_set_ratio, partial(utils.full_process, force_ascii=True)),
+         (fuzz.partial_token_sort_ratio, partial(utils.full_process, force_ascii=True))]
     )
 
     return splist

--- a/test_fuzzywuzzy_hypothesis.py
+++ b/test_fuzzywuzzy_hypothesis.py
@@ -8,6 +8,11 @@ from fuzzywuzzy import fuzz, process, utils
 
 
 def scorers_processors():
+    """
+    Generate a list of (scorer, processor) pairs for testing
+
+    :return: [(scorer, processor), ...]
+    """
     scorers = [fuzz.ratio,
                fuzz.partial_ratio]
     processors = [lambda x: x,
@@ -30,7 +35,8 @@ def scorers_processors():
 @settings(max_examples=100)
 def test_random_strings_identical(scorer, processor, data):
     """
-    Test that in a random set of identical strings, perfect matches
+    Test that in a random set of strings perfect matches return correctly
+
     :param scorer:
     :param processor:
     :param data:
@@ -42,16 +48,14 @@ def test_random_strings_identical(scorer, processor, data):
                  min_size=1, max_size=50))
     # Draw a random integer for the index in that list
     choiceidx = data.draw(st.integers(min_value=0, max_value=(len(strings) - 1)))
-    choice = strings[choiceidx]
 
-    if scorer in [fuzz.WRatio, fuzz.QRatio]:
-        processor = partial(utils.full_process, force_ascii=True)
-    elif scorer in [fuzz.UWRatio, fuzz.UQRatio]:
-        processor = partial(utils.full_process, force_ascii=False)
+    # Extract our choice from the list
+    choice = strings[choiceidx]
 
     # Check process doesn't make our choice the empty string
     assume(processor(choice) != '')
 
+    # Extract all perfect matches
     result = process.extractBests(choice,
                                   strings,
                                   scorer=scorer,
@@ -62,5 +66,5 @@ def test_random_strings_identical(scorer, processor, data):
     # Check we get a result
     assert result != []
 
-    # Check the result is in the list
+    # Check the original is in the list
     assert (choice, 100) in result

--- a/test_fuzzywuzzy_pytest.py
+++ b/test_fuzzywuzzy_pytest.py
@@ -1,0 +1,12 @@
+import warnings
+from fuzzywuzzy import process
+
+
+def test_process_warning():
+    """Check that a string reduced to 0 by processor raises a warning"""
+    query = ':::::::'
+    choices = [':::::::']
+    with warnings.catch_warnings(record=True) as w:
+        result = process.extractOne(query, choices)
+        assert issubclass(w[-1].category, UserWarning)
+        assert result == (query, 0)


### PR DESCRIPTION
I've made a number of changes aimed at fixing or clarifying some of the issues relating to how the functions in 'process' work (and testing them).

I'm not suggesting this for an immediate merge. With these changes I've attempted to maintain current behaviour other than making sure processors are applied if provided - and applied to both query and choices. I have not changed any of the tests that existed before and they all still pass.

This should close #77 and #129 (although in the latter case it merely issues a warning explaining what is going on).

There's some reorganisation of the extract functions - default behaviours are now provided as default arguments in the extract processes. I think this helps make it clear what processes are being used without having to look inside the functions.

If the processor is going to turn the query into an empty string it now issues a UserWarning as nothing will match - it might be worth turning this into an exception.

I've also added some tests to make sure that identical strings are always returned as a match. Other strings may also be returned due to processing/partial matches but the identical string should always be in the list.

These new tests use pytest and Hypothesis. I've separated them out into their own test files so they won't interfere with running the test suite without pytest or Hypothesis (also the hypothesis tests are **very** slow compared to the other tests). The Travis config has been edited to install hypothesis (skipped on python 2.6 / pypy3 as Hypothesis does not support these versions of python).
