### PR TITLE
prevent process.py from activating extraneous Python warnings

### DIFF
--- a/fuzzywuzzy/process.py
+++ b/fuzzywuzzy/process.py
@@ -30,7 +30,6 @@ from . import utils
 import heapq
 import warnings
 
-warnings.simplefilter('always')
 
 default_scorer = fuzz.WRatio
 default_processor = utils.full_process
@@ -101,7 +100,9 @@ def extractWithoutOrder(query, choices, processor=default_processor, scorer=defa
     processed_query = processor(query)
 
     if len(processed_query) == 0:
-        warnings.warn("Applied processor reduces input query to empty string, all comparisons will have score 0.")
+        with warnings.catch_warnings():
+            warnings.simplefilter('always')
+            warnings.warn("Applied processor reduces input query to empty string, all comparisons will have score 0.")
 
     # If the scorer performs full_ratio with force ascii don't run full_process twice
     if scorer in [fuzz.WRatio, fuzz.QRatio,


### PR DESCRIPTION
Proposed quick fix to [this issue](https://github.com/seatgeek/fuzzywuzzy/issues/144) in which `process.py` causes Python to throw warnings that would normally be suppressed.