### PR TITLE
Quieten warnings

### DIFF
--- a/fuzzywuzzy/process.py
+++ b/fuzzywuzzy/process.py
@@ -28,7 +28,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 from . import fuzz
 from . import utils
 import heapq
-import warnings
+import logging
 
 
 default_scorer = fuzz.WRatio
@@ -100,11 +100,9 @@ def extractWithoutOrder(query, choices, processor=default_processor, scorer=defa
     processed_query = processor(query)
 
     if len(processed_query) == 0:
-        with warnings.catch_warnings():
-            warnings.simplefilter('always')
-            warnings.warn("Applied processor reduces input query to empty string, "
-                          "all comparisons will have score 0. "
-                          "[Query: \'{0}\']".format(query))
+        logging.warning("Applied processor reduces input query to empty string, "
+                        "all comparisons will have score 0. "
+                        "[Query: \'{0}\']".format(query))
 
     # If the scorer performs full_ratio with force ascii don't run full_process twice
     if scorer in [fuzz.WRatio, fuzz.QRatio,

--- a/fuzzywuzzy/process.py
+++ b/fuzzywuzzy/process.py
@@ -32,6 +32,8 @@ import logging
 
 
 default_scorer = fuzz.WRatio
+
+
 default_processor = utils.full_process
 
 

--- a/fuzzywuzzy/process.py
+++ b/fuzzywuzzy/process.py
@@ -102,7 +102,9 @@ def extractWithoutOrder(query, choices, processor=default_processor, scorer=defa
     if len(processed_query) == 0:
         with warnings.catch_warnings():
             warnings.simplefilter('always')
-            warnings.warn("Applied processor reduces input query to empty string, all comparisons will have score 0.")
+            warnings.warn("Applied processor reduces input query to empty string, "
+                          "all comparisons will have score 0. "
+                          "[Query: \'{0}\']".format(query))
 
     # If the scorer performs full_ratio with force ascii don't run full_process twice
     if scorer in [fuzz.WRatio, fuzz.QRatio,

--- a/fuzzywuzzy/process.py
+++ b/fuzzywuzzy/process.py
@@ -30,7 +30,6 @@ from . import utils
 import heapq
 import warnings
 
-warnings.simplefilter('always')
 
 default_scorer = fuzz.WRatio
 default_processor = utils.full_process
@@ -101,7 +100,9 @@ def extractWithoutOrder(query, choices, processor=default_processor, scorer=defa
     processed_query = processor(query)
 
     if len(processed_query) == 0:
-        warnings.warn("Applied processor reduces input query to empty string, all comparisons will have score 0.")
+        with warnings.catch_warnings():
+            warnings.simplefilter('always')
+            warnings.warn("Applied processor reduces input query to empty string, all comparisons will have score 0.")
 
     # If the scorer performs full_ratio with force ascii don't run full_process twice
     if scorer in [fuzz.WRatio, fuzz.QRatio,

--- a/fuzzywuzzy/utils.py
+++ b/fuzzywuzzy/utils.py
@@ -32,6 +32,7 @@ def check_empty_string(func):
         return func(*args, **kwargs)
     return decorator
 
+
 bad_chars = str("").join([chr(i) for i in range(128, 256)])  # ascii dammit!
 if PY3:
     translation_table = dict((ord(c), None) for c in bad_chars)

--- a/test_fuzzywuzzy.py
+++ b/test_fuzzywuzzy.py
@@ -511,7 +511,7 @@ class ProcessTest(unittest.TestCase):
 
 class TestCodeFormat(unittest.TestCase):
     def test_pep8_conformance(self):
-        pep8style = pycodestyle.StyleGuide(quiet=True)
+        pep8style = pycodestyle.StyleGuide(quiet=False)
         pep8style.options.ignore = pep8style.options.ignore + tuple(['E501'])
         pep8style.input_dir('fuzzywuzzy')
         result = pep8style.check_files()

--- a/test_fuzzywuzzy_pytest.py
+++ b/test_fuzzywuzzy_pytest.py
@@ -1,12 +1,15 @@
-import warnings
 from fuzzywuzzy import process
 
 
-def test_process_warning():
-    """Check that a string reduced to 0 by processor raises a warning"""
+def test_process_warning(capsys):
+    """Check that a string reduced to 0 by processor logs a warning to stderr"""
+
     query = ':::::::'
     choices = [':::::::']
-    with warnings.catch_warnings(record=True) as w:
-        result = process.extractOne(query, choices)
-        assert issubclass(w[-1].category, UserWarning)
-        assert result == (query, 0)
+
+    _ = process.extractOne(query, choices)
+
+    out, err = capsys.readouterr()
+
+    assert err == ("WARNING:root:Applied processor reduces input query to empty string, "
+                   "all comparisons will have score 0. [Query: ':::::::']\n")

--- a/test_fuzzywuzzy_pytest.py
+++ b/test_fuzzywuzzy_pytest.py
@@ -11,7 +11,9 @@ def test_process_warning(capsys):
 
     out, err = capsys.readouterr()
 
-    assert err == ("WARNING:root:Applied processor reduces "
-                   "input query to empty string, "
-                   "all comparisons will have score 0. "
-                   "[Query: ':::::::']\n")
+    outstr = ("WARNING:root:Applied processor reduces "
+              "input query to empty string, "
+              "all comparisons will have score 0. "
+              "[Query: ':::::::']\n")
+
+    assert err == outstr

--- a/test_fuzzywuzzy_pytest.py
+++ b/test_fuzzywuzzy_pytest.py
@@ -11,5 +11,7 @@ def test_process_warning(capsys):
 
     out, err = capsys.readouterr()
 
-    assert err == ("WARNING:root:Applied processor reduces input query to empty string, "
-                   "all comparisons will have score 0. [Query: ':::::::']\n")
+    assert err == ("WARNING:root:Applied processor reduces "
+                   "input query to empty string, "
+                   "all comparisons will have score 0. "
+                   "[Query: ':::::::']\n")


### PR DESCRIPTION
Quietened the warnings in #144 by replacing the warning with a logging.warning. Changed the test to match the change in code.

Corrected some apparent PEP-8 issues (extra blank lines) that were causing tests to fail (although these seem to be in bits of code that hadn't changed which is fairly odd). The PEP-8 warnings from pycodestyle will now appear in the test log which should make it easier to find the offending lines next time.

This closes #144 and replaces #145 (thanks @samkennerly)