### PR TITLE
Fuzz ratio docstrings

### DIFF
--- a/fuzzywuzzy/fuzz.py
+++ b/fuzzywuzzy/fuzz.py
@@ -198,6 +198,17 @@ def partial_token_set_ratio(s1, s2, force_ascii=True, full_process=True):
 
 # q is for quick
 def QRatio(s1, s2, force_ascii=True):
+    """
+    Quick ratio comparison between two strings.
+
+    Runs full_process from utils on both strings
+    Short circuits if either of the strings is empty after processing.
+
+    :param s1:
+    :param s2:
+    :param force_ascii: Allow only ASCII characters (Default: True)
+    :return: similarity ratio
+    """
 
     p1 = utils.full_process(s1, force_ascii=force_ascii)
     p2 = utils.full_process(s2, force_ascii=force_ascii)
@@ -211,13 +222,51 @@ def QRatio(s1, s2, force_ascii=True):
 
 
 def UQRatio(s1, s2):
+    """
+    Unicode quick ratio
+
+    Calls QRatio with force_ascii set to False
+
+    :param s1:
+    :param s2:
+    :return: similarity ratio
+    """
     return QRatio(s1, s2, force_ascii=False)
 
 
 # w is for weighted
 def WRatio(s1, s2, force_ascii=True):
-    """Return a measure of the sequences' similarity between 0 and 100,
-    using different algorithms.
+    """
+    Return a measure of the sequences' similarity between 0 and 100, using different algorithms.
+
+    **Steps in the order they occur**
+
+    #. Run full_process from utils on both strings
+    #. Short circuit if this makes either string empty
+    #. Take the ratio of the two processed strings (fuzz.ratio)
+    #. Run checks to compare the length of the strings
+        * If one of the strings is more than 1.5 times as long as the other
+          use partial_ratio comparisons - scale partial results by 0.9
+          (this makes sure only full results can return 100)
+        * If one of the strings is over 8 times as long as the other
+          instead scale by 0.6
+
+    #. Run the other ratio functions
+        * if using partial ratio functions call partial_ratio,
+          partial_token_sort_ratio and partial_token_set_ratio
+          scale all of these by the ratio based on length
+        * otherwise call token_sort_ratio and token_set_ratio
+        * all token based comparisons are scaled by 0.95
+          (on top of any partial scalars)
+
+    #. Take the highest value from these results
+       round it and return it as an integer.
+
+    :param s1:
+    :param s2:
+    :param force_ascii: Allow only ascii characters
+    :type force_ascii: bool
+    :return:
     """
 
     p1 = utils.full_process(s1, force_ascii=force_ascii)

--- a/fuzzywuzzy/utils.py
+++ b/fuzzywuzzy/utils.py
@@ -9,6 +9,12 @@ PY3 = sys.version_info[0] == 3
 
 
 def validate_string(s):
+    """
+    Check input has length and that length > 0
+
+    :param s:
+    :return: True if len(s) > 0 else False
+    """
     try:
         return len(s) > 0
     except TypeError:

--- a/test_fuzzywuzzy_hypothesis.py
+++ b/test_fuzzywuzzy_hypothesis.py
@@ -34,6 +34,27 @@ def scorers_processors():
     return splist
 
 
+def full_scorers_processors():
+    """
+    Generate a list of (scorer, processor) pairs for testing for scorers that use the full string only
+
+    :return: [(scorer, processor), ...]
+    """
+    scorers = [fuzz.ratio]
+    processors = [lambda x: x,
+                  partial(utils.full_process, force_ascii=False),
+                  partial(utils.full_process, force_ascii=True)]
+    splist = list(product(scorers, processors))
+    splist.extend(
+        [(fuzz.WRatio, partial(utils.full_process, force_ascii=True)),
+         (fuzz.QRatio, partial(utils.full_process, force_ascii=True)),
+         (fuzz.UWRatio, partial(utils.full_process, force_ascii=False)),
+         (fuzz.UQRatio, partial(utils.full_process, force_ascii=False))]
+    )
+
+    return splist
+
+
 @pytest.mark.parametrize('scorer,processor',
                          scorers_processors())
 @given(data=st.data())
@@ -75,3 +96,47 @@ def test_identical_strings_extracted(scorer, processor, data):
     assert (choice, 100) in result
 
 
+@pytest.mark.parametrize('scorer,processor',
+                         full_scorers_processors())
+@given(data=st.data())
+@settings(max_examples=100)
+def test_only_identical_strings_extracted(scorer, processor, data):
+    """
+    Test that only identical (post processing) strings score 100 on the test.
+
+    If two strings are not identical then using full comparison methods they should
+    not be a perfect (100) match.
+
+    :param scorer:
+    :param processor:
+    :param data:
+    :return:
+    """
+    # Draw a list of random strings
+    strings = data.draw(
+        st.lists(st.text(min_size=10, max_size=100),
+                 min_size=1, max_size=50))
+    # Draw a random integer for the index in that list
+    choiceidx = data.draw(st.integers(min_value=0, max_value=(len(strings) - 1)))
+
+    # Extract our choice from the list
+    choice = strings[choiceidx]
+
+    # Check process doesn't make our choice the empty string
+    assume(processor(choice) != '')
+
+    # Extract all perfect matches
+    result = process.extractBests(choice,
+                                  strings,
+                                  scorer=scorer,
+                                  processor=processor,
+                                  score_cutoff=100,
+                                  limit=None)
+
+    # Check we get a result
+    assert result != []
+
+    # Check THE ONLY result(s) we get are a perfect match for the (processed) original data
+    pchoice = processor(choice)
+    for r in result:
+        assert pchoice == processor(r[0])


### PR DESCRIPTION
Adds docstrings to QRatio, WRatio scorers.

Additional test - the original test checked that exact matches were returned with perfect scores with all of the scorers, this test checks that for full string scorers exact matches are the only thing that is returned with perfect scores.

Work towards #137 (not complete)