### PR TITLE
Update process.py to not process query

### DIFF
--- a/fuzzywuzzy/process.py
+++ b/fuzzywuzzy/process.py
@@ -94,18 +94,18 @@ def extractWithoutOrder(query, choices, processor=default_processor, scorer=defa
         pass
 
     processed_query = utils.full_process(query)
-    
+
     # If the processor was removed by setting it to None
     # perfom a noop as it still needs to be a function
     if processor is None:
         processor = no_process
-        
+
     # If the scorer performs full_ratio with force ascii don't run full_process twice
-    if scorer in [fuzz.WRatio, fuzz.QRatio,
-                  fuzz.token_set_ratio, fuzz.token_sort_ratio,
-                  fuzz.partial_token_set_ratio, fuzz.partial_token_sort_ratio] \
-            and processor == utils.full_process:
-        processor = no_process
+#    if scorer in [fuzz.WRatio, fuzz.QRatio,
+#                  fuzz.token_set_ratio, fuzz.token_sort_ratio,
+#                  fuzz.partial_token_set_ratio, fuzz.partial_token_sort_ratio] \
+#            and processor == utils.full_process:
+#        processor = no_process
 
     try:
         # See if choices is a dictionary-like object.

--- a/fuzzywuzzy/process.py
+++ b/fuzzywuzzy/process.py
@@ -93,6 +93,8 @@ def extractWithoutOrder(query, choices, processor=default_processor, scorer=defa
     except TypeError:
         pass
 
+    processed_query = utils.full_process(query)
+    
     # If the processor was removed by setting it to None
     # perfom a noop as it still needs to be a function
     if processor is None:
@@ -109,14 +111,14 @@ def extractWithoutOrder(query, choices, processor=default_processor, scorer=defa
         # See if choices is a dictionary-like object.
         for key, choice in choices.items():
             processed = processor(choice)
-            score = scorer(query, processed)
+            score = scorer(processed_query, processed)
             if score >= score_cutoff:
                 yield (choice, score, key)
     except AttributeError:
         # It's a list; just iterate over it.
         for choice in choices:
             processed = processor(choice)
-            score = scorer(query, processed)
+            score = scorer(processed_query, processed)
             if score >= score_cutoff:
                 yield (choice, score)
 

--- a/fuzzywuzzy/process.py
+++ b/fuzzywuzzy/process.py
@@ -93,7 +93,7 @@ def extractWithoutOrder(query, choices, processor=default_processor, scorer=defa
     except TypeError:
         pass
 
-    processed_query = utils.full_process(query)
+    processed_query = query
 
     # If the processor was removed by setting it to None
     # perfom a noop as it still needs to be a function

--- a/fuzzywuzzy/process.py
+++ b/fuzzywuzzy/process.py
@@ -97,15 +97,7 @@ def extractWithoutOrder(query, choices, processor=default_processor, scorer=defa
     # perfom a noop as it still needs to be a function
     if processor is None:
         processor = no_process
-
-    # Run the processor on the input query.
-    processed_query = processor(query)
-
-    if len(processed_query) == 0:
-        logging.warning("Applied processor reduces input query to empty string, "
-                        "all comparisons will have score 0. "
-                        "[Query: \'{0}\']".format(query))
-
+        
     # If the scorer performs full_ratio with force ascii don't run full_process twice
     if scorer in [fuzz.WRatio, fuzz.QRatio,
                   fuzz.token_set_ratio, fuzz.token_sort_ratio,
@@ -117,14 +109,14 @@ def extractWithoutOrder(query, choices, processor=default_processor, scorer=defa
         # See if choices is a dictionary-like object.
         for key, choice in choices.items():
             processed = processor(choice)
-            score = scorer(processed_query, processed)
+            score = scorer(query, processed)
             if score >= score_cutoff:
                 yield (choice, score, key)
     except AttributeError:
         # It's a list; just iterate over it.
         for choice in choices:
             processed = processor(choice)
-            score = scorer(processed_query, processed)
+            score = scorer(query, processed)
             if score >= score_cutoff:
                 yield (choice, score)
 


### PR DESCRIPTION
Go back to only running processor on choices, and not on the query, to revert a breaking change. Seems unnecessary as  all processing of the query could/should be done beforehand, but maybe as a separate param?