### PR TITLE
Extract function optimizations, ~20% speedup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     env: TEST_SUITE=py.test
   - python: "2.6"
     env: TEST_SUITE="py.test test_fuzzywuzzy.py test_fuzzywuzzy_pytest.py"
-  - python: "pypy3"
+  - python: "pypy3.5-5.8.0"
     env: TEST_SUITE="py.test test_fuzzywuzzy.py test_fuzzywuzzy_pytest.py"
 install:
   - pip install pytest pycodestyle

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -90,13 +90,17 @@ for s in cirque_strings:
 
 print 'Test process.exract(scorer =  fuzz.QRatio) for string: "%s"' % s
 print '-------------------------------'
-print_result_from_timeit('process.extract(u\'cirque du soleil\', [\'\'.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(30)) for s in range(5000)], scorer =  fuzz.QRatio)',
-                             common_setup + basic_setup + " from fuzzywuzzy import process; import string,random;", number=10)
+print_result_from_timeit('process.extract(u\'cirque du soleil\', choices, scorer =  fuzz.QRatio)',
+                             common_setup + basic_setup + " from fuzzywuzzy import process; import string,random;"
+                             " choices = [\'\'.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(30)) for s in range(5000)]",
+                              number=10)
 
 print 'Test process.exract(scorer =  fuzz.WRatio) for string: "%s"' % s
 print '-------------------------------'
-print_result_from_timeit('process.extract(u\'cirque du soleil\', [\'\'.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(30)) for s in range(5000)], scorer =  fuzz.WRatio)',
-                             common_setup + basic_setup + " from fuzzywuzzy import process; import string,random;", number=10)
+print_result_from_timeit('process.extract(u\'cirque du soleil\', choices, scorer =  fuzz.WRatio)',
+                             common_setup + basic_setup + " from fuzzywuzzy import process; import string,random;"
+                             " choices = [\'\'.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(30)) for s in range(5000)]",
+                              number=10)
 
 
 # let me show you something

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -86,6 +86,17 @@ for s in cirque_strings:
     print '-------------------------------'
     print_result_from_timeit('fuzz.WRatio(u\'cirque du soleil\', u\'%s\')' % s,
                              common_setup + basic_setup, number=iterations / 100)
+                             
+
+print 'Test process.exract(scorer =  fuzz.QRatio) for string: "%s"' % s
+print '-------------------------------'
+print_result_from_timeit('process.extract(u\'cirque du soleil\', [\'\'.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(30)) for s in range(5000)], scorer =  fuzz.QRatio)',
+                             common_setup + basic_setup + " from fuzzywuzzy import process; import string,random;", number=10)
+
+print 'Test process.exract(scorer =  fuzz.WRatio) for string: "%s"' % s
+print '-------------------------------'
+print_result_from_timeit('process.extract(u\'cirque du soleil\', [\'\'.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(30)) for s in range(5000)], scorer =  fuzz.WRatio)',
+                             common_setup + basic_setup + " from fuzzywuzzy import process; import string,random;", number=10)
 
 
 # let me show you something

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -91,14 +91,14 @@ for s in cirque_strings:
 print 'Test process.exract(scorer =  fuzz.QRatio) for string: "%s"' % s
 print '-------------------------------'
 print_result_from_timeit('process.extract(u\'cirque du soleil\', choices, scorer =  fuzz.QRatio)',
-                             common_setup + basic_setup + " from fuzzywuzzy import process; import string,random;"
+                             common_setup + basic_setup + " from fuzzywuzzy import process; import string,random; random.seed(18);"
                              " choices = [\'\'.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(30)) for s in range(5000)]",
                               number=10)
 
 print 'Test process.exract(scorer =  fuzz.WRatio) for string: "%s"' % s
 print '-------------------------------'
 print_result_from_timeit('process.extract(u\'cirque du soleil\', choices, scorer =  fuzz.WRatio)',
-                             common_setup + basic_setup + " from fuzzywuzzy import process; import string,random;"
+                             common_setup + basic_setup + " from fuzzywuzzy import process; import string,random; random.seed(18);"
                              " choices = [\'\'.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(30)) for s in range(5000)]",
                               number=10)
 

--- a/fuzzywuzzy/fuzz.py
+++ b/fuzzywuzzy/fuzz.py
@@ -94,10 +94,10 @@ def partial_ratio(s1, s2):
 # Advanced Scoring Functions #
 ##############################
 
-def _process_and_sort(s, force_ascii, full_process=True, process_s1=True):
+def _process_and_sort(s, force_ascii, full_process=True):
     """Return a cleaned string with token sorted."""
     # pull tokens
-    ts = utils.full_process(s, force_ascii=force_ascii) if full_process and process_s1 else s
+    ts = utils.full_process(s, force_ascii=force_ascii) if full_process else s
     tokens = ts.split()
 
     # sort tokens and join
@@ -110,8 +110,8 @@ def _process_and_sort(s, force_ascii, full_process=True, process_s1=True):
 #   sort those tokens and take ratio of resulting joined strings
 #   controls for unordered string elements
 @utils.check_for_none
-def _token_sort(s1, s2, partial=True, force_ascii=True, full_process=True, process_s1=True):
-    sorted1 = _process_and_sort(s1, force_ascii, full_process=full_process, process_s1=process_s1)
+def _token_sort(s1, s2, partial=True, force_ascii=True, full_process=True):
+    sorted1 = _process_and_sort(s1, force_ascii, full_process=full_process)
     sorted2 = _process_and_sort(s2, force_ascii, full_process=full_process)
 
     if partial:
@@ -120,22 +120,22 @@ def _token_sort(s1, s2, partial=True, force_ascii=True, full_process=True, proce
         return ratio(sorted1, sorted2)
 
 
-def token_sort_ratio(s1, s2, force_ascii=True, full_process=True, process_s1=True):
+def token_sort_ratio(s1, s2, force_ascii=True, full_process=True):
     """Return a measure of the sequences' similarity between 0 and 100
     but sorting the token before comparing.
     """
-    return _token_sort(s1, s2, partial=False, force_ascii=force_ascii, full_process=full_process, process_s1=process_s1)
+    return _token_sort(s1, s2, partial=False, force_ascii=force_ascii, full_process=full_process)
 
 
-def partial_token_sort_ratio(s1, s2, force_ascii=True, full_process=True, process_s1=True):
+def partial_token_sort_ratio(s1, s2, force_ascii=True, full_process=True):
     """Return the ratio of the most similar substring as a number between
     0 and 100 but sorting the token before comparing.
     """
-    return _token_sort(s1, s2, partial=True, force_ascii=force_ascii, full_process=full_process, process_s1=process_s1)
+    return _token_sort(s1, s2, partial=True, force_ascii=force_ascii, full_process=full_process)
 
 
 @utils.check_for_none
-def _token_set(s1, s2, partial=True, force_ascii=True, full_process=True, process_s1=True):
+def _token_set(s1, s2, partial=True, force_ascii=True, full_process=True):
     """Find all alphanumeric tokens in each string...
         - treat them as a set
         - construct two strings of the form:
@@ -143,7 +143,7 @@ def _token_set(s1, s2, partial=True, force_ascii=True, full_process=True, proces
         - take ratios of those two strings
         - controls for unordered partial matches"""
 
-    p1 = utils.full_process(s1, force_ascii=force_ascii) if full_process and process_s1 else s1
+    p1 = utils.full_process(s1, force_ascii=force_ascii) if full_process else s1
     p2 = utils.full_process(s2, force_ascii=force_ascii) if full_process else s2
 
     if not utils.validate_string(p1):
@@ -184,12 +184,12 @@ def _token_set(s1, s2, partial=True, force_ascii=True, full_process=True, proces
     return max(pairwise)
 
 
-def token_set_ratio(s1, s2, force_ascii=True, full_process=True, process_s1=True):
-    return _token_set(s1, s2, partial=False, force_ascii=force_ascii, full_process=full_process, process_s1=process_s1)
+def token_set_ratio(s1, s2, force_ascii=True, full_process=True):
+    return _token_set(s1, s2, partial=False, force_ascii=force_ascii, full_process=full_process)
 
 
-def partial_token_set_ratio(s1, s2, force_ascii=True, full_process=True, process_s1=True):
-    return _token_set(s1, s2, partial=True, force_ascii=force_ascii, full_process=full_process, process_s1=process_s1)
+def partial_token_set_ratio(s1, s2, force_ascii=True, full_process=True):
+    return _token_set(s1, s2, partial=True, force_ascii=force_ascii, full_process=full_process)
 
 
 ###################
@@ -197,7 +197,7 @@ def partial_token_set_ratio(s1, s2, force_ascii=True, full_process=True, process
 ###################
 
 # q is for quick
-def QRatio(s1, s2, force_ascii=True, process_s1=True):
+def QRatio(s1, s2, force_ascii=True, full_process=True):
     """
     Quick ratio comparison between two strings.
 
@@ -207,15 +207,16 @@ def QRatio(s1, s2, force_ascii=True, process_s1=True):
     :param s1:
     :param s2:
     :param force_ascii: Allow only ASCII characters (Default: True)
-    :process_s1: Process first input, used to avoid reprocessing during multiple runs (Default: True)
+    :full_process: Process inputs, used here to avoid double processing in extract functions (Default: True)
     :return: similarity ratio
     """
 
-    if process_s1:
+    if full_process:
         p1 = utils.full_process(s1, force_ascii=force_ascii)
+        p2 = utils.full_process(s2, force_ascii=force_ascii)
     else:
         p1 = s1
-    p2 = utils.full_process(s2, force_ascii=force_ascii)
+        p2 = s2
 
     if not utils.validate_string(p1):
         return 0
@@ -225,7 +226,7 @@ def QRatio(s1, s2, force_ascii=True, process_s1=True):
     return ratio(p1, p2)
 
 
-def UQRatio(s1, s2, process_s1=True):
+def UQRatio(s1, s2, full_process=True):
     """
     Unicode quick ratio
 
@@ -235,11 +236,11 @@ def UQRatio(s1, s2, process_s1=True):
     :param s2:
     :return: similarity ratio
     """
-    return QRatio(s1, s2, force_ascii=False, process_s1=process_s1)
+    return QRatio(s1, s2, force_ascii=False, full_process=full_process)
 
 
 # w is for weighted
-def WRatio(s1, s2, force_ascii=True, process_s1=True):
+def WRatio(s1, s2, force_ascii=True, full_process=True):
     """
     Return a measure of the sequences' similarity between 0 and 100, using different algorithms.
 
@@ -270,15 +271,16 @@ def WRatio(s1, s2, force_ascii=True, process_s1=True):
     :param s2:
     :param force_ascii: Allow only ascii characters
     :type force_ascii: bool
-    :process_s1: Process first input, used to avoid reprocessing during multiple runs (Default: True)
+    :full_process: Process inputs, used here to avoid double processing in extract functions (Default: True)
     :return:
     """
 
-    if process_s1:
+    if full_process:
         p1 = utils.full_process(s1, force_ascii=force_ascii)
+        p2 = utils.full_process(s2, force_ascii=force_ascii)
     else:
         p1 = s1
-    p2 = utils.full_process(s2, force_ascii=force_ascii)
+        p2 = s2
 
     if not utils.validate_string(p1):
         return 0
@@ -316,8 +318,8 @@ def WRatio(s1, s2, force_ascii=True, process_s1=True):
         return utils.intr(max(base, tsor, tser))
 
 
-def UWRatio(s1, s2, process_s1=True):
+def UWRatio(s1, s2, full_process=True):
     """Return a measure of the sequences' similarity between 0 and 100,
     using different algorithms. Same as WRatio but preserving unicode.
     """
-    return WRatio(s1, s2, force_ascii=False, process_s1=process_s1)
+    return WRatio(s1, s2, force_ascii=False, full_process=full_process)

--- a/fuzzywuzzy/fuzz.py
+++ b/fuzzywuzzy/fuzz.py
@@ -94,10 +94,10 @@ def partial_ratio(s1, s2):
 # Advanced Scoring Functions #
 ##############################
 
-def _process_and_sort(s, force_ascii, full_process=True):
+def _process_and_sort(s, force_ascii, full_process=True, process_s1=True):
     """Return a cleaned string with token sorted."""
     # pull tokens
-    ts = utils.full_process(s, force_ascii=force_ascii) if full_process else s
+    ts = utils.full_process(s, force_ascii=force_ascii) if full_process and process_s1 else s
     tokens = ts.split()
 
     # sort tokens and join
@@ -110,8 +110,8 @@ def _process_and_sort(s, force_ascii, full_process=True):
 #   sort those tokens and take ratio of resulting joined strings
 #   controls for unordered string elements
 @utils.check_for_none
-def _token_sort(s1, s2, partial=True, force_ascii=True, full_process=True):
-    sorted1 = _process_and_sort(s1, force_ascii, full_process=full_process)
+def _token_sort(s1, s2, partial=True, force_ascii=True, full_process=True, process_s1=True):
+    sorted1 = _process_and_sort(s1, force_ascii, full_process=full_process, process_s1=process_s1)
     sorted2 = _process_and_sort(s2, force_ascii, full_process=full_process)
 
     if partial:
@@ -120,22 +120,22 @@ def _token_sort(s1, s2, partial=True, force_ascii=True, full_process=True):
         return ratio(sorted1, sorted2)
 
 
-def token_sort_ratio(s1, s2, force_ascii=True, full_process=True):
+def token_sort_ratio(s1, s2, force_ascii=True, full_process=True, process_s1=True):
     """Return a measure of the sequences' similarity between 0 and 100
     but sorting the token before comparing.
     """
-    return _token_sort(s1, s2, partial=False, force_ascii=force_ascii, full_process=full_process)
+    return _token_sort(s1, s2, partial=False, force_ascii=force_ascii, full_process=full_process, process_s1=process_s1)
 
 
-def partial_token_sort_ratio(s1, s2, force_ascii=True, full_process=True):
+def partial_token_sort_ratio(s1, s2, force_ascii=True, full_process=True, process_s1=True):
     """Return the ratio of the most similar substring as a number between
     0 and 100 but sorting the token before comparing.
     """
-    return _token_sort(s1, s2, partial=True, force_ascii=force_ascii, full_process=full_process)
+    return _token_sort(s1, s2, partial=True, force_ascii=force_ascii, full_process=full_process, process_s1=process_s1)
 
 
 @utils.check_for_none
-def _token_set(s1, s2, partial=True, force_ascii=True, full_process=True):
+def _token_set(s1, s2, partial=True, force_ascii=True, full_process=True, process_s1=True):
     """Find all alphanumeric tokens in each string...
         - treat them as a set
         - construct two strings of the form:
@@ -143,7 +143,7 @@ def _token_set(s1, s2, partial=True, force_ascii=True, full_process=True):
         - take ratios of those two strings
         - controls for unordered partial matches"""
 
-    p1 = utils.full_process(s1, force_ascii=force_ascii) if full_process else s1
+    p1 = utils.full_process(s1, force_ascii=force_ascii) if full_process and process_s1 else s1
     p2 = utils.full_process(s2, force_ascii=force_ascii) if full_process else s2
 
     if not utils.validate_string(p1):
@@ -184,12 +184,12 @@ def _token_set(s1, s2, partial=True, force_ascii=True, full_process=True):
     return max(pairwise)
 
 
-def token_set_ratio(s1, s2, force_ascii=True, full_process=True):
-    return _token_set(s1, s2, partial=False, force_ascii=force_ascii, full_process=full_process)
+def token_set_ratio(s1, s2, force_ascii=True, full_process=True, process_s1=True):
+    return _token_set(s1, s2, partial=False, force_ascii=force_ascii, full_process=full_process, process_s1=process_s1)
 
 
-def partial_token_set_ratio(s1, s2, force_ascii=True, full_process=True):
-    return _token_set(s1, s2, partial=True, force_ascii=force_ascii, full_process=full_process)
+def partial_token_set_ratio(s1, s2, force_ascii=True, full_process=True, process_s1=True):
+    return _token_set(s1, s2, partial=True, force_ascii=force_ascii, full_process=full_process, process_s1=process_s1)
 
 
 ###################
@@ -197,7 +197,7 @@ def partial_token_set_ratio(s1, s2, force_ascii=True, full_process=True):
 ###################
 
 # q is for quick
-def QRatio(s1, s2, force_ascii=True):
+def QRatio(s1, s2, force_ascii=True, process_s1=True):
     """
     Quick ratio comparison between two strings.
 
@@ -207,10 +207,14 @@ def QRatio(s1, s2, force_ascii=True):
     :param s1:
     :param s2:
     :param force_ascii: Allow only ASCII characters (Default: True)
+    :process_s1: Process first input, used to avoid reprocessing during multiple runs (Default: True)
     :return: similarity ratio
     """
 
-    p1 = utils.full_process(s1, force_ascii=force_ascii)
+    if process_s1:
+        p1 = utils.full_process(s1, force_ascii=force_ascii)
+    else:
+        p1 = s1
     p2 = utils.full_process(s2, force_ascii=force_ascii)
 
     if not utils.validate_string(p1):
@@ -221,7 +225,7 @@ def QRatio(s1, s2, force_ascii=True):
     return ratio(p1, p2)
 
 
-def UQRatio(s1, s2):
+def UQRatio(s1, s2, process_s1=True):
     """
     Unicode quick ratio
 
@@ -231,11 +235,11 @@ def UQRatio(s1, s2):
     :param s2:
     :return: similarity ratio
     """
-    return QRatio(s1, s2, force_ascii=False)
+    return QRatio(s1, s2, force_ascii=False, process_s1=process_s1)
 
 
 # w is for weighted
-def WRatio(s1, s2, force_ascii=True):
+def WRatio(s1, s2, force_ascii=True, process_s1=True):
     """
     Return a measure of the sequences' similarity between 0 and 100, using different algorithms.
 
@@ -266,10 +270,14 @@ def WRatio(s1, s2, force_ascii=True):
     :param s2:
     :param force_ascii: Allow only ascii characters
     :type force_ascii: bool
+    :process_s1: Process first input, used to avoid reprocessing during multiple runs (Default: True)
     :return:
     """
 
-    p1 = utils.full_process(s1, force_ascii=force_ascii)
+    if process_s1:
+        p1 = utils.full_process(s1, force_ascii=force_ascii)
+    else:
+        p1 = s1
     p2 = utils.full_process(s2, force_ascii=force_ascii)
 
     if not utils.validate_string(p1):
@@ -308,8 +316,8 @@ def WRatio(s1, s2, force_ascii=True):
         return utils.intr(max(base, tsor, tser))
 
 
-def UWRatio(s1, s2):
+def UWRatio(s1, s2, process_s1=True):
     """Return a measure of the sequences' similarity between 0 and 100,
     using different algorithms. Same as WRatio but preserving unicode.
     """
-    return WRatio(s1, s2, force_ascii=False)
+    return WRatio(s1, s2, force_ascii=False, process_s1=process_s1)

--- a/fuzzywuzzy/process.py
+++ b/fuzzywuzzy/process.py
@@ -29,6 +29,7 @@ from . import fuzz
 from . import utils
 import heapq
 import logging
+from functools import partial
 
 
 default_scorer = fuzz.WRatio
@@ -112,6 +113,16 @@ def extractWithoutOrder(query, choices, processor=default_processor, scorer=defa
                   fuzz.partial_token_set_ratio, fuzz.partial_token_sort_ratio] \
             and processor == utils.full_process:
         processor = no_process
+
+    # Only process the query once instead of for every choice
+    if scorer in [fuzz.UWRatio, fuzz.UQRatio]:
+        processed_query = utils.full_process(processed_query, force_ascii=False)
+        scorer = partial(scorer, process_s1=False)
+    elif scorer in [fuzz.WRatio, fuzz.QRatio,
+                    fuzz.token_set_ratio, fuzz.token_sort_ratio,
+                    fuzz.partial_token_set_ratio, fuzz.partial_token_sort_ratio]:
+        processed_query = utils.full_process(processed_query, force_ascii=True)
+        scorer = partial(scorer, process_s1=False)
 
     try:
         # See if choices is a dictionary-like object.


### PR DESCRIPTION
Did this separately from all of my other changes, though a bit of related code. Added parameter "process_s1" to most of the scorers that is used by extractWithoutOrder to tell them not to run full_process on the query again, so that it doesn't get run on it for each choice. Does add an extra parameter that probably doesn't need to be exposed publicly though, so maybe a better way to do that.

Added a couple additional benchmarks as well, was getting about ~20% improvement for me depending on the scorer used.