### PR TITLE
Add fuzzball.js JavaScript port link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,4 +118,5 @@ FuzzyWuzzy is being ported to other languages too! Here are a few ports we know 
 
 -  Java: `xpresso's fuzzywuzzy implementation <https://github.com/WantedTechnologies/xpresso/wiki/Approximate-string-comparison-and-pattern-matching-in-Java>`_
 -  Java: `fuzzywuzzy (java port) <https://github.com/xdrop/fuzzywuzzy>`_
--  Rust: `fuzzyrusty (Rust port) <https://github.com/logannc/fuzzyrusty>`
+-  Rust: `fuzzyrusty (Rust port) <https://github.com/logannc/fuzzyrusty>`_
+-  JavaScript: `fuzzball.js (JavaScript port) <https://github.com/nol13/fuzzball.js>`_


### PR DESCRIPTION
Also added the underscore after the Rust link (because the java links had it..)