### PR TITLE
Add extras require to install python-levenshtein optionally.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,13 @@ Using PIP via PyPI
 
     pip install fuzzywuzzy
 
+or the following to install `python-Levenshtein` too
+
+.. code:: bash
+
+    pip install fuzzywuzzy[speedup]
+
+
 Using PIP via Github
 
 .. code:: bash

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     author='Adam Cohen',
     author_email='adam@seatgeek.com',
     packages=['fuzzywuzzy'],
+    extras_require={'speedup': ['python-levenshtein>=0.12']},
     url='https://github.com/seatgeek/fuzzywuzzy',
     license=open('LICENSE.txt').read(),
     classifiers=[


### PR DESCRIPTION
This allows to install python-levenshtein as dependency.