### PR TITLE
Fix setup.py (addresses #155)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     packages=['fuzzywuzzy'],
     extras_require={'speedup': ['python-levenshtein>=0.12']},
     url='https://github.com/seatgeek/fuzzywuzzy',
-    license=open('LICENSE.txt').read(),
+    license="GPL",
     classifiers=[
         'Intended Audience :: Developers',
         'Programming Language :: Python',


### PR DESCRIPTION
As mentioned in #155, this changes the `license` value in `setup.py` to a short string, which is required for some build options. 