### PR TITLE
Normalize Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
 install:
   - pip install pytest pycodestyle
   - if [ $TRAVIS_PYTHON_VERSION != 2.6 -a $TRAVIS_PYTHON_VERSION != "pypy3" ]; then pip install hypothesis; fi;
+  - if [ $TRAVIS_PYTHON_VERSION = 3.3 ]; then pip install enum34; fi;
 script:
   - $TEST_SUITE
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
     env: TEST_SUITE=py.test
   - python: "3.5"
     env: TEST_SUITE=py.test
+  - python: "3.6"
+    env: TEST_SUITE=py.test
   - python: "pypy"
     env: TEST_SUITE=py.test
   - python: "2.6"

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,10 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3'
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     description='Fuzzy string matching in python',
     long_description=open_file('README.rst').read(),

--- a/tox.ini
+++ b/tox.ini
@@ -13,3 +13,11 @@ commands = py.test
 deps = pytest
        pycodestyle
 commands = py.test test_fuzzywuzzy.py test_fuzzywuzzy_pytest.py
+
+# Hypothesis needs enum34 installed to work in Python 3.3 but doesn't
+# officially support 3.3, so install it here to make tests run.
+[testenv:py33]
+deps = enum34
+       hypothesis
+       pytest
+       pycodestyle

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,15 @@
 [tox]
-envlist = py2, py3, pypy, pypy3
+envlist = py26, py27, py33, py34, py35, py36, pypy, pypy3
 skip_missing_interpreters = True
 
 [testenv]
 deps = pytest
        pycodestyle
+       hypothesis
 commands = py.test
+
+# Hypothesis does not work in Python 2.6
+[testenv:py26]
+deps = pytest
+       pycodestyle
+commands = py.test test_fuzzywuzzy.py test_fuzzywuzzy_pytest.py


### PR DESCRIPTION
- Enable Travis-CI tests for Python 3.6
- Enable tests for all supported Python versions in tox.ini
- Add Trove classifiers for Python 3.4 - 3.6 to setup.py

---

Note: Python 2.6 and 3.3 are no longer supported by the Python core
team. Support for these can likely be dropped, but that's out of scope
for this change set.