### PR TITLE
Drop support for end-of-lifed Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ matrix:
   include:
   - python: "2.7"
     env: TEST_SUITE=py.test
-  - python: "3.3"
-    env: TEST_SUITE=py.test
   - python: "3.4"
     env: TEST_SUITE=py.test
   - python: "3.5"
@@ -13,14 +11,11 @@ matrix:
     env: TEST_SUITE=py.test
   - python: "pypy"
     env: TEST_SUITE=py.test
-  - python: "2.6"
-    env: TEST_SUITE="py.test test_fuzzywuzzy.py test_fuzzywuzzy_pytest.py"
   - python: "pypy3.5-5.8.0"
     env: TEST_SUITE="py.test test_fuzzywuzzy.py test_fuzzywuzzy_pytest.py"
 install:
   - pip install pytest pycodestyle
-  - if [ $TRAVIS_PYTHON_VERSION != 2.6 -a $TRAVIS_PYTHON_VERSION != "pypy3" ]; then pip install hypothesis; fi;
-  - if [ $TRAVIS_PYTHON_VERSION = 3.3 ]; then pip install enum34; fi;
+  - if [ $TRAVIS_PYTHON_VERSION != "pypy3" ]; then pip install hypothesis; fi;
 script:
   - $TEST_SUITE
 notifications:

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,8 @@ setup(
     classifiers=[
         'Intended Audience :: Developers',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, py36, pypy, pypy3
+envlist = py27, py34, py35, py36, pypy, pypy3
 skip_missing_interpreters = True
 
 [testenv]
@@ -7,17 +7,3 @@ deps = pytest
        pycodestyle
        hypothesis
 commands = py.test
-
-# Hypothesis does not work in Python 2.6
-[testenv:py26]
-deps = pytest
-       pycodestyle
-commands = py.test test_fuzzywuzzy.py test_fuzzywuzzy_pytest.py
-
-# Hypothesis needs enum34 installed to work in Python 3.3 but doesn't
-# officially support 3.3, so install it here to make tests run.
-[testenv:py33]
-deps = enum34
-       hypothesis
-       pytest
-       pycodestyle


### PR DESCRIPTION
The following versions of Python are no longer supported by the core
developers:

- Python 2.6 (end of life on 2013-10-29 [1])
- Python 3.3 (end of life on 2017-09-29 [2])

Developers should migrate off of these versions ASAP, as they may be
missing critical security fixes.

[1] https://www.python.org/dev/peps/pep-0361/#release-lifespan
[2] https://www.python.org/dev/peps/pep-0398/#lifespan

---

Note: the `fuzzywuzzy` maintainers may wish to keep support around for these versions for the time being, but dropping support will ultimately make the library's users' applications safer and allow the developers to use features that were not supported in old releases. Once the decision to drop support for 2.6 and 3.3, this PR will be ready and waiting.