### PR TITLE
Fix build - Hypothesis and Pytest issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
   - python: "pypy3.5-5.8.0"
     env: TEST_SUITE="py.test test_fuzzywuzzy.py test_fuzzywuzzy_pytest.py"
 install:
-  - pip install pytest pycodestyle
+  - pip install pytest==3.2.5 pycodestyle
   - if [ $TRAVIS_PYTHON_VERSION != 2.6 -a $TRAVIS_PYTHON_VERSION != "pypy3" ]; then pip install hypothesis; fi;
   - if [ $TRAVIS_PYTHON_VERSION = 3.3 ]; then pip install enum34; fi;
 script:

--- a/test_fuzzywuzzy_hypothesis.py
+++ b/test_fuzzywuzzy_hypothesis.py
@@ -58,7 +58,7 @@ def full_scorers_processors():
 @pytest.mark.parametrize('scorer,processor',
                          scorers_processors())
 @given(data=st.data())
-@settings(max_examples=100)
+@settings(max_examples=25, deadline=2000)
 def test_identical_strings_extracted(scorer, processor, data):
     """
     Test that identical strings will always return a perfect match.
@@ -71,7 +71,7 @@ def test_identical_strings_extracted(scorer, processor, data):
     # Draw a list of random strings
     strings = data.draw(
         st.lists(st.text(min_size=10, max_size=100),
-                 min_size=1, max_size=50))
+                 min_size=1, max_size=10))
     # Draw a random integer for the index in that list
     choiceidx = data.draw(st.integers(min_value=0, max_value=(len(strings) - 1)))
 

--- a/test_fuzzywuzzy_hypothesis.py
+++ b/test_fuzzywuzzy_hypothesis.py
@@ -1,6 +1,6 @@
 from itertools import product
 from functools import partial
-from string import ascii_letters, digits
+from string import ascii_letters, digits, punctuation
 
 from hypothesis import given, assume, settings
 import hypothesis.strategies as st
@@ -9,7 +9,7 @@ import pytest
 from fuzzywuzzy import fuzz, process, utils
 
 
-HYPOTHESIS_ALPHABET = ascii_letters + digits
+HYPOTHESIS_ALPHABET = ascii_letters + digits + punctuation
 
 
 def scorers_processors():

--- a/test_fuzzywuzzy_hypothesis.py
+++ b/test_fuzzywuzzy_hypothesis.py
@@ -58,7 +58,7 @@ def full_scorers_processors():
 @pytest.mark.parametrize('scorer,processor',
                          scorers_processors())
 @given(data=st.data())
-@settings(max_examples=25, deadline=2000)
+@settings(max_examples=50, deadline=2000)
 def test_identical_strings_extracted(scorer, processor, data):
     """
     Test that identical strings will always return a perfect match.

--- a/test_fuzzywuzzy_hypothesis.py
+++ b/test_fuzzywuzzy_hypothesis.py
@@ -1,11 +1,15 @@
 from itertools import product
 from functools import partial
+from string import ascii_letters, digits
 
 from hypothesis import given, assume, settings
 import hypothesis.strategies as st
 import pytest
 
 from fuzzywuzzy import fuzz, process, utils
+
+
+HYPOTHESIS_ALPHABET = ascii_letters + digits
 
 
 def scorers_processors():
@@ -70,8 +74,12 @@ def test_identical_strings_extracted(scorer, processor, data):
     """
     # Draw a list of random strings
     strings = data.draw(
-        st.lists(st.text(min_size=10, max_size=100),
-                 min_size=1, max_size=10))
+        st.lists(
+            st.text(min_size=10, max_size=100, alphabet=HYPOTHESIS_ALPHABET),
+            min_size=1,
+            max_size=10
+        )
+    )
     # Draw a random integer for the index in that list
     choiceidx = data.draw(st.integers(min_value=0, max_value=(len(strings) - 1)))
 
@@ -114,8 +122,11 @@ def test_only_identical_strings_extracted(scorer, processor, data):
     """
     # Draw a list of random strings
     strings = data.draw(
-        st.lists(st.text(min_size=10, max_size=100),
-                 min_size=1, max_size=20))
+        st.lists(
+            st.text(min_size=10, max_size=100, alphabet=HYPOTHESIS_ALPHABET),
+            min_size=1,
+            max_size=10)
+    )
     # Draw a random integer for the index in that list
     choiceidx = data.draw(st.integers(min_value=0, max_value=(len(strings) - 1)))
 

--- a/test_fuzzywuzzy_hypothesis.py
+++ b/test_fuzzywuzzy_hypothesis.py
@@ -58,7 +58,7 @@ def full_scorers_processors():
 @pytest.mark.parametrize('scorer,processor',
                          scorers_processors())
 @given(data=st.data())
-@settings(max_examples=50, deadline=2000)
+@settings(max_examples=20, deadline=5000)
 def test_identical_strings_extracted(scorer, processor, data):
     """
     Test that identical strings will always return a perfect match.
@@ -99,7 +99,7 @@ def test_identical_strings_extracted(scorer, processor, data):
 @pytest.mark.parametrize('scorer,processor',
                          full_scorers_processors())
 @given(data=st.data())
-@settings(max_examples=100)
+@settings(max_examples=20, deadline=5000)
 def test_only_identical_strings_extracted(scorer, processor, data):
     """
     Test that only identical (post processing) strings score 100 on the test.
@@ -115,7 +115,7 @@ def test_only_identical_strings_extracted(scorer, processor, data):
     # Draw a list of random strings
     strings = data.draw(
         st.lists(st.text(min_size=10, max_size=100),
-                 min_size=1, max_size=50))
+                 min_size=1, max_size=20))
     # Draw a random integer for the index in that list
     choiceidx = data.draw(st.integers(min_value=0, max_value=(len(strings) - 1)))
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py26, py27, py33, py34, py35, py36, pypy, pypy3
 skip_missing_interpreters = True
 
 [testenv]
-deps = pytest
+deps = pytest==3.2.5
        pycodestyle
        hypothesis
 commands = py.test


### PR DESCRIPTION
I noticed the build was failing in some versions of Python on some of the tests I added a while ago. This PR reduces the scope of the hypothesis tests to make them faster so they stop triggering health check failures. 

It also pins the pytest version as there's a bug in the latest pytest on the latest python that seems to stop the capsys fixture working and make the pytest check for a warning fail.

This should now make the build pass again.