### PR TITLE
feat: drop 2.6 and 3.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ matrix:
   include:
   - python: "2.7"
     env: TEST_SUITE=py.test
-  - python: "3.3"
-    env: TEST_SUITE=py.test
   - python: "3.4"
     env: TEST_SUITE=py.test
   - python: "3.5"
@@ -13,14 +11,11 @@ matrix:
     env: TEST_SUITE=py.test
   - python: "pypy"
     env: TEST_SUITE=py.test
-  - python: "2.6"
-    env: TEST_SUITE="py.test test_fuzzywuzzy.py test_fuzzywuzzy_pytest.py"
   - python: "pypy3.5-5.8.0"
     env: TEST_SUITE="py.test test_fuzzywuzzy.py test_fuzzywuzzy_pytest.py"
 install:
   - pip install pytest==3.2.5 pycodestyle
-  - if [ $TRAVIS_PYTHON_VERSION != 2.6 -a $TRAVIS_PYTHON_VERSION != "pypy3" ]; then pip install hypothesis; fi;
-  - if [ $TRAVIS_PYTHON_VERSION = 3.3 ]; then pip install enum34; fi;
+  - if [ $TRAVIS_PYTHON_VERSION != "pypy3" ]; then pip install hypothesis; fi;
 script:
   - $TEST_SUITE
 notifications:

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Fuzzy string matching like a boss. It uses `Levenshtein Distance <https://en.wik
 Requirements
 ============
 
--  Python 2.4 or higher
+-  Python 2.7 or higher
 -  difflib
 -  `python-Levenshtein <https://github.com/ztane/python-Levenshtein/>`_ (optional, provides a 4-10x speedup in String
    Matching, though may result in `differing results for certain cases <https://github.com/seatgeek/fuzzywuzzy/issues/128>`_)

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,8 @@ setup(
     classifiers=[
         'Intended Audience :: Developers',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/test_fuzzywuzzy.py
+++ b/test_fuzzywuzzy.py
@@ -13,12 +13,6 @@ from fuzzywuzzy.string_processing import StringProcessor
 if sys.version_info[0] == 3:
     unicode = str
 
-if sys.version_info[:2] == (2, 6):
-    # Monkeypatch to make tests work on 2.6
-    def assertLess(first, second, msg=None):
-        assert first > second
-    unittest.TestCase.assertLess = assertLess
-
 
 class StringProcessingTest(unittest.TestCase):
     def test_replace_non_letters_non_numbers_with_whitespace(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, py36, pypy, pypy3
+envlist = py27, py34, py35, py36, pypy, pypy3
 skip_missing_interpreters = True
 
 [testenv]
@@ -7,17 +7,3 @@ deps = pytest==3.2.5
        pycodestyle
        hypothesis
 commands = py.test
-
-# Hypothesis does not work in Python 2.6
-[testenv:py26]
-deps = pytest
-       pycodestyle
-commands = py.test test_fuzzywuzzy.py test_fuzzywuzzy_pytest.py
-
-# Hypothesis needs enum34 installed to work in Python 3.3 but doesn't
-# officially support 3.3, so install it here to make tests run.
-[testenv:py33]
-deps = enum34
-       hypothesis
-       pytest
-       pycodestyle


### PR DESCRIPTION
These are no longer supported. Please upgrade your python version if you are using either version.