### PR TITLE
Fix for Python 3.7

### DIFF
--- a/fuzzywuzzy/process.py
+++ b/fuzzywuzzy/process.py
@@ -65,7 +65,7 @@ def extractWithoutOrder(query, choices, processor=default_processor, scorer=defa
 
     try:
         if choices is None or len(choices) == 0:
-            raise StopIteration
+            return
     except TypeError:
         pass
 


### PR DESCRIPTION
Fixes #233 

According to [PEP 479](https://www.python.org/dev/peps/pep-0479/#examples-of-breakage), if raise StopIteration occurs directly in a generator, simply replace it with return.

This is both backwards and forwards compatible code.