### PR TITLE
Add license to trove classifiers.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     license="GPLv2",
     classifiers=[
         'Intended Audience :: Developers',
+        'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
Some tools fetch the license of a module from that modules classifiers list. This PR adds a line for that.

This is a standard classifier:
https://pypi.org/classifiers/