### PR TITLE
don't attach to root logger, attach to scoped logger instead

### DIFF
--- a/fuzzywuzzy/process.py
+++ b/fuzzywuzzy/process.py
@@ -7,6 +7,7 @@ import logging
 from functools import partial
 
 
+logger = logging.getLogger(__name__)
 default_scorer = fuzz.WRatio
 
 
@@ -78,9 +79,9 @@ def extractWithoutOrder(query, choices, processor=default_processor, scorer=defa
     processed_query = processor(query)
 
     if len(processed_query) == 0:
-        logging.warning(u"Applied processor reduces input query to empty string, "
-                        "all comparisons will have score 0. "
-                        "[Query: \'{0}\']".format(query))
+        logger.warning(u"Applied processor reduces input query to empty string, "
+                       "all comparisons will have score 0. "
+                       "[Query: \'{0}\']".format(query))
 
     # Don't run full_process twice
     if scorer in [fuzz.WRatio, fuzz.QRatio,


### PR DESCRIPTION
Allows inheriting projects to conveniently control the log level of `fuzzywuzzy`'s logging by attaching to it's own package-spaced logger rather than the root logger - for example our project wants to set fuzzywuzzy's logging level to `ERROR` without setting the entire root logger to `ERROR`.

Evidence that this works:

before the changes (your master):
```
In [1]: from logging_tree import printout                                                                                     

In [2]: printout()                                                                                                            
<--""
   Level WARNING
   |
   o   "TerminalIPythonApp"
   |   Level WARNING
   |   Propagate OFF
   |   Handler Stream <_io.TextIOWrapper name='<stderr>' mode='w' encoding='UTF-8'>
   |     Formatter <traitlets.config.application.LevelFormatter object at 0x7fc5c9924f60>
   |
   o<--"asyncio"
   |   Level NOTSET so inherits level WARNING
   |
   o<--[concurrent]
   |   |
   |   o<--"concurrent.futures"
   |       Level NOTSET so inherits level WARNING
   |
   o<--[parso]
   |   |
   |   o<--"parso.cache"
   |   |   Level NOTSET so inherits level WARNING
   |   |
   |   o<--[parso.python]
   |       |
   |       o<--"parso.python.diff"
   |           Level NOTSET so inherits level WARNING
   |
   o<--"prompt_toolkit"
       Level NOTSET so inherits level WARNING

In [3]: from fuzzywuzzy import process                                                                                        
/home/arah/dev/libraries/fuzzywuzzy/fuzzywuzzy/fuzz.py:11: UserWarning: Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning
  warnings.warn('Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning')

In [4]: printout()                                                                                                            
<--""
   Level WARNING
   |
   o   "TerminalIPythonApp"
   |   Level WARNING
   |   Propagate OFF
   |   Handler Stream <_io.TextIOWrapper name='<stderr>' mode='w' encoding='UTF-8'>
   |     Formatter <traitlets.config.application.LevelFormatter object at 0x7fc5c9924f60>
   |
   o<--"asyncio"
   |   Level NOTSET so inherits level WARNING
   |
   o<--[concurrent]
   |   |
   |   o<--"concurrent.futures"
   |       Level NOTSET so inherits level WARNING
   |
   o<--[parso]
   |   |
   |   o<--"parso.cache"
   |   |   Level NOTSET so inherits level WARNING
   |   |
   |   o<--[parso.python]
   |       |
   |       o<--"parso.python.diff"
   |           Level NOTSET so inherits level WARNING
   |
   o<--"prompt_toolkit"
       Level NOTSET so inherits level WARNING
```

after the changes:

```
In [1]: from logging_tree import printout                                                                                     

In [2]: printout()                                                                                                            
<--""
   Level WARNING
   |
   o   "TerminalIPythonApp"
   |   Level WARNING
   |   Propagate OFF
   |   Handler Stream <_io.TextIOWrapper name='<stderr>' mode='w' encoding='UTF-8'>
   |     Formatter <traitlets.config.application.LevelFormatter object at 0x7f9461678f60>
   |
   o<--"asyncio"
   |   Level NOTSET so inherits level WARNING
   |
   o<--[concurrent]
   |   |
   |   o<--"concurrent.futures"
   |       Level NOTSET so inherits level WARNING
   |
   o<--[parso]
   |   |
   |   o<--"parso.cache"
   |   |   Level NOTSET so inherits level WARNING
   |   |
   |   o<--[parso.python]
   |       |
   |       o<--"parso.python.diff"
   |           Level NOTSET so inherits level WARNING
   |
   o<--"prompt_toolkit"
       Level NOTSET so inherits level WARNING

In [3]: from fuzzywuzzy import process                                                                                        
/home/arah/dev/libraries/fuzzywuzzy/fuzzywuzzy/fuzz.py:11: UserWarning: Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning
  warnings.warn('Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning')

In [4]: printout()                                                                                                            
<--""
   Level WARNING
   |
   o   "TerminalIPythonApp"
   |   Level WARNING
   |   Propagate OFF
   |   Handler Stream <_io.TextIOWrapper name='<stderr>' mode='w' encoding='UTF-8'>
   |     Formatter <traitlets.config.application.LevelFormatter object at 0x7f9461678f60>
   |
   o<--"asyncio"
   |   Level NOTSET so inherits level WARNING
   |
   o<--[concurrent]
   |   |
   |   o<--"concurrent.futures"
   |       Level NOTSET so inherits level WARNING
   |
   o<--[fuzzywuzzy]
   |   |
   |   o<--"fuzzywuzzy.process"
   |       Level NOTSET so inherits level WARNING
   |
   o<--[parso]
   |   |
   |   o<--"parso.cache"
   |   |   Level NOTSET so inherits level WARNING
   |   |
   |   o<--[parso.python]
   |       |
   |       o<--"parso.python.diff"
   |           Level NOTSET so inherits level WARNING
   |
   o<--"prompt_toolkit"
       Level NOTSET so inherits level WARNING
```

this means that I can now do:
`logging.getLogger("fuzzywuzzy").setLevel("ERROR")` in my own application (or any other way of configuring a level) and expect it not to spew out that `logger.warning` line in to my logs.

to my knowledge this shouldn't affect the `warnings.warn` by default