### PR TITLE
Add allow_key decorator to accept object

### DIFF
--- a/fuzzywuzzy/utils.py
+++ b/fuzzywuzzy/utils.py
@@ -99,6 +99,18 @@ def full_process(s, force_ascii=False):
     string_out = StringProcessor.strip(string_out)
     return string_out
 
+def allow_key(func):
+    """Allow key function that extracts the text from passed object to be used.
+    similar to python's max, min functions
+    """
+    @functools.wraps(func)
+    def decorated(*args,
+                  key = lambda s: s, #type: Callable[[Any], str]
+                  **kwargs):
+        kwargs.update(zip(func.__code__.co_varnames, args))
+        return func(**{k:key(v) for k,v in kwargs.items()})
+    return decorated
+
 
 def intr(n):
     '''Returns a correctly rounded integer'''


### PR DESCRIPTION
Add `allow_key` decorator that would allow passing objects into fuzzywuzzy functions.  
This should help using fuzzywuzzy in more cleaner way like the test cases added.  
similar to how you can pass objects into `sort/max/min` functions and use a `key:Callable[[Any],number]` to get the numbers to use.  

Would be trivial to add to simple functions like `fuzz.ratio`.
Not added to any functions. That can be discussed further and then decided.
Might need more consideration for more complicated functions that don't follow `Callable[[str,...],int]` signature