### PR TITLE
Update README with the renamed Rust port

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,7 +131,7 @@ FuzzyWuzzy is being ported to other languages too! Here are a few ports we know 
 
 -  Java: `xpresso's fuzzywuzzy implementation <https://github.com/WantedTechnologies/xpresso/wiki/Approximate-string-comparison-and-pattern-matching-in-Java>`_
 -  Java: `fuzzywuzzy (java port) <https://github.com/xdrop/fuzzywuzzy>`_
--  Rust: `fuzzyrusty (Rust port) <https://github.com/logannc/fuzzyrusty>`_
+-  Rust: `fuzzywuzzy-rs (Rust port) <https://github.com/logannc/fuzzywuzzy-rs>`_
 -  JavaScript: `fuzzball.js (JavaScript port) <https://github.com/nol13/fuzzball.js>`_
 -  C++: `Tmplt/fuzzywuzzy <https://github.com/Tmplt/fuzzywuzzy>`_
 -  C#: `fuzzysharp (.Net port) <https://github.com/BoomTownRoi/BoomTown.FuzzySharp>`_


### PR DESCRIPTION
`fuzzyrusty` was published to crates.io by an unknown author (not the author of the crate), so it has been renamed to `fuzzywuzzy-rs` to explicitly identify itself as a port of the original `fuzzywuzzy`.

Updated URL: https://github.com/logannc/fuzzywuzzy-rs