### PR TITLE
Add ex_fuzzywuzzy port

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,3 +139,4 @@ FuzzyWuzzy is being ported to other languages too! Here are a few ports we know 
 -  Free Pascal: `FuzzyWuzzy.pas (Free Pascal port) <https://github.com/DavidMoraisFerreira/FuzzyWuzzy.pas>`_
 -  Kotlin multiplatform: `FuzzyWuzzy-Kotlin <https://github.com/willowtreeapps/fuzzywuzzy-kotlin>`_
 -  R: `fuzzywuzzyR (R port) <https://github.com/mlampros/fuzzywuzzyR>`_
+-  Elixir: `ex_fuzzywuzzy <https://github.com/primait/ex_fuzzywuzzy>`_


### PR DESCRIPTION
## Description
We used `fuzzywuzzy` for a string matching analysis in a company project and the results were really good, but since our core backend stack is in Elixir we wrote a porting of the library.
If you wish, please add this to the list.

## State of the art
Almost all of the interfaces are already ported and we hope to publish the package soon.
A couple of interfaces that we don't use are currently `not-implemented`, but we'd like to complete them (sooner or later).
