### PR TITLE
Removed a manual file handler pitfall

### DIFF
--- a/benchmarks.py
+++ b/benchmarks.py
@@ -7,7 +7,8 @@ import csv
 iterations = 100000
 
 
-reader = csv.DictReader(open('data/titledata.csv'), delimiter='|')
+with open('data/titledata.csv') as stream:
+    reader = csv.DictReader(stream, delimiter='|')
 titles = [i['custom_title'] for i in reader]
 title_blob = '\n'.join(titles)
 


### PR DESCRIPTION
**The problem**
There was a case where the code was using a manual file handler pitfall, where a file stream was being opened and closed manually. But since Python supports automatic stream closing using the block 'with', its better to use it instead of the manual close in order to remove a bug vector.

**Solution**
Refactored the code to remove the manual file handler